### PR TITLE
Remove old wrapper methods

### DIFF
--- a/molecule/core.py
+++ b/molecule/core.py
@@ -207,7 +207,8 @@ class Molecule(object):
         a = struct.unpack('HHHH', fcntl.ioctl(sys.stdout.fileno(), TIOCGWINSZ, s))
         self._pt.setwinsize(a[0], a[1])
 
-    def _destroy(self):
+    def destroy(self):
+        self._create_templates()
         try:
             self._vagrant.halt()
             self._vagrant.destroy()
@@ -215,8 +216,10 @@ class Molecule(object):
         except CalledProcessError as e:
             print('ERROR: {}'.format(e))
             sys.exit(e.returncode)
+        self._remove_templates()
 
-    def _create(self):
+    def create(self):
+        self._create_templates()
         if not self._created:
             try:
                 self._vagrant.up(no_provision=True)
@@ -244,7 +247,7 @@ class Molecule(object):
 
         return True
 
-    def _verify(self):
+    def verify(self):
         validators.check_trailing_cruft(ignore_paths=self._config.config['molecule']['ignore_paths'])
 
         # no tests found

--- a/molecule/provisioners.py
+++ b/molecule/provisioners.py
@@ -179,15 +179,3 @@ class Ansible(Molecule):
         except sh.ErrorReturnCode as e:
             print('ERROR: {}'.format(e))
             sys.exit(e.exit_code)
-
-    def verify(self):
-        self._verify()
-
-    def create(self):
-        self._create_templates()
-        self._create()
-
-    def destroy(self):
-        self._create_templates()
-        self._destroy()
-        self._remove_templates()


### PR DESCRIPTION
These can be rolled into the actual methods now that we're not trying to support multiple provisioners.