### PR TITLE
Move config logic into config module

### DIFF
--- a/molecule/config.py
+++ b/molecule/config.py
@@ -99,3 +99,17 @@ class Config(object):
         for item in values_to_update:
             self.config['molecule'][item] = os.path.join(self.config['molecule']['molecule_dir'],
                                                          self.config['molecule'][item])
+
+    def update_ansible_defaults(self):
+        """
+        Copies certain default values from molecule to ansible if none are specified in molecule.yml
+
+        :return: None
+        """
+        # grab inventory_file default from molecule if it's not set in the user-supplied ansible options
+        if 'inventory_file' not in self.config['ansible']:
+            self.config['ansible']['inventory_file'] = self.config['molecule']['inventory_file']
+
+        # grab config_file default from molecule if it's not set in the user-supplied ansible options
+        if 'config_file' not in self.config['ansible']:
+            self.config['ansible']['config_file'] = self.config['molecule']['config_file']

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -66,6 +66,9 @@ class Molecule(object):
         # concatentate file names and paths within config so they're more convenient to use
         self._config.build_easy_paths()
 
+        # get defaults for inventory/ansible.cfg from molecule if none are specified
+        self._config.update_ansible_defaults()
+
         if not os.path.exists(self._config.config['molecule']['molecule_dir']):
             os.makedirs(self._config.config['molecule']['molecule_dir'])
 

--- a/molecule/provisioners.py
+++ b/molecule/provisioners.py
@@ -118,14 +118,6 @@ class Ansible(Molecule):
             for key, value in self._config.config['ansible']['raw_env_vars'].iteritems():
                 self._env[key] = value
 
-        # grab inventory_file default from molecule if it's not set in the user-supplied ansible options
-        if 'inventory_file' not in self._config.config['ansible']:
-            self._config.config['ansible']['inventory_file'] = self._config.config['molecule']['inventory_file']
-
-        # grab config_file default from molecule if it's not set in the user-supplied ansible options
-        if 'config_file' not in self._config.config['ansible']:
-            self._config.config['ansible']['config_file'] = self._config.config['molecule']['config_file']
-
         self._env['PYTHONUNBUFFERED'] = '1'
         self._env['ANSIBLE_FORCE_COLOR'] = 'true'
         self._env['ANSIBLE_HOST_KEY_CHECKING'] = str(self._config.config['ansible']['host_key_checking']).lower()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,6 +21,7 @@
 import os
 
 import testtools
+import yaml
 
 import molecule.config as config
 
@@ -30,8 +31,18 @@ class TestConfig(testtools.TestCase):
         super(TestConfig, self).setUp()
 
         self.temp = '/tmp/test_config_load_defaults_external_file.yml'
+        data = {
+            'molecule': {
+                'molecule_dir': '.test_molecule'
+            },
+            'ansible': {
+                'config_file': 'test_config',
+                'inventory_file': 'test_inventory'
+            }
+        }
+
         with open(self.temp, 'w') as f:
-            f.write('molecule:\n  molecule_dir: .test_molecule')
+            f.write(yaml.dump(data, default_flow_style=True))
 
     def test_load_defaults_file(self):
         c = config.Config()
@@ -69,6 +80,14 @@ class TestConfig(testtools.TestCase):
         self.assertEqual(c.config['molecule']['rakefile_file'], os.path.join('.molecule', 'rakefile'))
         self.assertEqual(c.config['molecule']['config_file'], os.path.join('.molecule', 'ansible.cfg'))
         self.assertEqual(c.config['molecule']['inventory_file'], os.path.join('.molecule', 'ansible_inventory'))
+
+    def test_update_ansible_defaults(self):
+        c = config.Config()
+        c.load_defaults_file()
+        c.merge_molecule_file(molecule_file=self.temp)
+
+        self.assertEqual(c.config['ansible']['inventory_file'], 'test_inventory')
+        self.assertEqual(c.config['ansible']['config_file'], 'test_config')
 
     def tearDown(self):
         super(TestConfig, self).tearDown()


### PR DESCRIPTION
The previous change put this logic into provisioners, however, that doesn't work in all cases. It needs to be in the config object so the changes are updated when molecule files are merged in. That way, the values are available throughout the script.

This opens the door for updating testinfra to use the inventory file we specify.