### PR TITLE
Added support for vagrant box versioning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,10 @@
 CHANGELOG for molecule
 ======================
+1.0.5
+----
+
+* Added support for Vagrant box versioning. This allows teams to ensure all members are using the correct version in their development environments
+
 1.0.4
 ----
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -57,8 +57,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Molecule'
-copyright = u'2015, Adam Brown, John Dewey, Rémy Greinhofer, Duncan Hutty'
-author = u'Adam Brown, John Dewey, Rémy Greinhofer, Duncan Hutty'
+copyright = u'2015, Adam Brown, John Dewey, Rémy Greinhofer, Duncan Hutty, Abel Lopez'
+author = u'Adam Brown, John Dewey, Rémy Greinhofer, Duncan Hutty, Abel Lopez'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/source/providers.rst
+++ b/docs/source/providers.rst
@@ -113,6 +113,7 @@ This example is far more extensive than you likely need and it demonstrates lots
             box: ubuntu/precise32
           - name: trusty64
             box: trusty64
+            box_version: "~> 20151130.0.0"
             box_url: https://vagrantcloud.com/ubuntu/boxes/trusty64/versions/14.04/providers/virtualbox.box
 
         providers:
@@ -160,6 +161,7 @@ Other Notes
 
 * `private_key_path`, as with several other values, can be any valid Ruby because it will appear in the Vagrantfile that molecule will generate.
 
+* `box_version`, defaults to '=', can include an constrains like '<, >, >=, <=, ~.' as listed in the `Versioning`_ docs.
 
 ..  _`configuration for vagrant-openstack-provider`: https://github.com/ggiamarchi/vagrant-openstack-provider/blob/master/README.md#configuration
 .. _`VirtualBox`: http://docs.vagrantup.com/v2/virtualbox/index.html
@@ -168,3 +170,4 @@ Other Notes
 .. _`Networks`: https://github.com/ggiamarchi/vagrant-openstack-provider/blob/master/README.md#networks
 .. _`Volumes`: https://github.com/ggiamarchi/vagrant-openstack-provider/blob/master/README.md#volumes
 .. _`Stacks`: https://github.com/ggiamarchi/vagrant-openstack-provider/blob/master/README.md#orchestration-stacks
+.. _`Versioning`: https://docs.vagrantup.com/v2/boxes/versioning.html

--- a/docs/source/providers.rst
+++ b/docs/source/providers.rst
@@ -161,7 +161,7 @@ Other Notes
 
 * `private_key_path`, as with several other values, can be any valid Ruby because it will appear in the Vagrantfile that molecule will generate.
 
-* `box_version`, defaults to '=', can include an constrains like '<, >, >=, <=, ~.' as listed in the `Versioning`_ docs.
+* `box_version`, defaults to '=', can include an constraints like '<, >, >=, <=, ~.' as listed in the `Versioning`_ docs.
 
 ..  _`configuration for vagrant-openstack-provider`: https://github.com/ggiamarchi/vagrant-openstack-provider/blob/master/README.md#configuration
 .. _`VirtualBox`: http://docs.vagrantup.com/v2/virtualbox/index.html

--- a/molecule/templates/molecule.yml.j2
+++ b/molecule/templates/molecule.yml.j2
@@ -96,6 +96,8 @@ vagrant:
     - name: {{ config.molecule.init.platform.name }}
       box: {{ config.molecule.init.platform.box }}
       box_url: {{ config.molecule.init.platform.box_url }}
+      # Optional item, box_version - support for vagrant versioning
+      # box_version: {{ config.molecule.init.platform.box_version }}
 
   providers:
     - name: virtualbox

--- a/molecule/templates/vagrantfile.j2
+++ b/molecule/templates/vagrantfile.j2
@@ -3,6 +3,9 @@ Vagrant.configure('2') do |config|
   {%- for platform in config.vagrant.platforms %}
     {%- if platform.name == current_platform %}
   config.vm.box = '{{ platform.box }}'
+      {%- if 'box_version' in platform %}
+  config.vm.box_version = "{{ platform.box_version|join }}"
+      {%- endif %}
       {%- if 'box_url' in platform %}
   config.vm.box_url = '{{ platform.box_url }}'
       {%- endif %}

--- a/molecule/templates/vagrantfile.j2
+++ b/molecule/templates/vagrantfile.j2
@@ -4,7 +4,7 @@ Vagrant.configure('2') do |config|
     {%- if platform.name == current_platform %}
   config.vm.box = '{{ platform.box }}'
       {%- if 'box_version' in platform %}
-  config.vm.box_version = "{{ platform.box_version|join }}"
+  config.vm.box_version = "{{ platform.box_version }}"
       {%- endif %}
       {%- if 'box_url' in platform %}
   config.vm.box_url = '{{ platform.box_url }}'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = molecule
-author = Adam Brown, John Dewey, Rémy Greinhofer, Duncan Hutty
-author-email = adambr2@cisco.com, john@dewey.ws, regreinh@cisco.com, dhutty@cisco.com
+author = Adam Brown, John Dewey, Rémy Greinhofer, Duncan Hutty, Abel Lopez
+author-email = adambr2@cisco.com, john@dewey.ws, regreinh@cisco.com, dhutty@cisco.com, abelopez@cisco.com
 summary = Vagrant wrapper for testing Ansible roles
 license = MIT
 description-file = README.rst


### PR DESCRIPTION
As per https://docs.vagrantup.com/v2/boxes/versioning.html,
molecule will now add a `box_version` if it's specified in the
molecule.yml file.