### PR TITLE
Move commands into a separate module

### DIFF
--- a/molecule/cli.py
+++ b/molecule/cli.py
@@ -59,7 +59,7 @@ from docopt import docopt
 from docopt import DocoptExit
 
 import molecule
-from commands import Commands
+from molecule.commands import Commands
 
 
 class CLI(object):

--- a/molecule/cli.py
+++ b/molecule/cli.py
@@ -59,6 +59,7 @@ from docopt import docopt
 from docopt import DocoptExit
 
 import molecule
+from commands import Commands
 from provisioners import Ansible
 
 
@@ -69,7 +70,7 @@ class CLI(object):
             print molecule.__version__
             sys.exit(0)
 
-        m = Ansible(args)
+        m = Commands(args)
         m.main()
         commands = ['create', 'converge', 'idempotence', 'test', 'verify', 'destroy', 'status', 'list', 'login', 'init']
         for command in commands:

--- a/molecule/cli.py
+++ b/molecule/cli.py
@@ -60,7 +60,6 @@ from docopt import DocoptExit
 
 import molecule
 from commands import Commands
-from provisioners import Ansible
 
 
 class CLI(object):

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -18,10 +18,20 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
+import os
+import pexpect
+import signal
 import sys
+from subprocess import CalledProcessError
 
+import prettytable
 import sh
+from colorama import Fore
+from jinja2 import Environment
+from jinja2 import PackageLoader
 
+import molecule.utilities as utilities
+import molecule.validators as validators
 from provisioners import Ansible
 
 
@@ -46,7 +56,28 @@ class Commands(object):
         self.commands.create()
 
     def converge(self):
-        self.molecule.converge()
+        self.commands.converge()
+
+    def idempotence(self):
+        self.commands.idempotence()
+
+    def verify(self):
+        self.commands.verify()
+
+    def test(self):
+        self.commands.test()
+
+    def list(self):
+        self.commands.list()
+
+    def status(self):
+        self.commands.status()
+
+    def login(self):
+        self.commands.login()
+
+    def init(self):
+        self.commands.init()
 
 
 class BaseCommands(object):
@@ -80,26 +111,186 @@ class BaseCommands(object):
 
         self.molecule._create_inventory_file()
         playbook, args, kwargs = self.molecule._create_playbook_args()
-        print playbook
 
+        if idempotent:
+            kwargs.pop('_out', None)
+            kwargs.pop('_err', None)
+            kwargs['_env']['ANSIBLE_NOCOLOR'] = 'true'
+            kwargs['_env']['ANSIBLE_FORCE_COLOR'] = 'false'
+            try:
+                output = sh.ansible_playbook(playbook, *args, **kwargs)
+                return output
+            except sh.ErrorReturnCode as e:
+                print('ERROR: {}'.format(e))
+                sys.exit(e.exit_code)
+        try:
+            output = sh.ansible_playbook(playbook, *args, **kwargs)
+            return output.exit_code
+        except sh.ErrorReturnCode as e:
+            print('ERROR: {}'.format(e))
+            sys.exit(e.exit_code)
 
-        # if idempotent:
-        #     kwargs.pop('_out', None)
-        #     kwargs.pop('_err', None)
-        #     kwargs['_env']['ANSIBLE_NOCOLOR'] = 'true'
-        #     kwargs['_env']['ANSIBLE_FORCE_COLOR'] = 'false'
-        #     try:
-        #         output = sh.ansible_playbook(playbook, *args, **kwargs)
-        #         return output
-        #     except sh.ErrorReturnCode as e:
-        #         print('ERROR: {}'.format(e))
-        #         sys.exit(e.exit_code)
-        # try:
-        #     output = sh.ansible_playbook(playbook, *args, **kwargs)
-        #     return output.exit_code
-        # except sh.ErrorReturnCode as e:
-        #     print('ERROR: {}'.format(e))
-        #     sys.exit(e.exit_code)
+    def idempotence(self):
+        print('{}Idempotence test in progress...{}'.format(Fore.CYAN, Fore.RESET)),
+
+        output = self.converge(idempotent=True)
+        idempotent = self.molecule._parse_provisioning_output(output.stdout)
+
+        if idempotent:
+            print('{}OKAY{}'.format(Fore.GREEN, Fore.RESET))
+            return
+
+        print('{}FAILED{}'.format(Fore.RED, Fore.RESET))
+        sys.exit(1)
+
+    def verify(self):
+        validators.check_trailing_cruft(ignore_paths=self.molecule._config.config['molecule']['ignore_paths'])
+
+        # no tests found
+        if not os.path.isdir(self.molecule._config.config['molecule']['serverspec_dir']) and not os.path.isdir(
+                self.molecule._config.config['molecule'][
+                    'testinfra_dir']):
+            msg = '{}Skipping tests, could not find {}/ or {}/.{}'
+            print(msg.format(Fore.YELLOW, self.molecule._config.config['molecule']['serverspec_dir'],
+                             self.molecule._config.config[
+                                 'molecule']['testinfra_dir'], Fore.RESET))
+            return
+
+        self.molecule._write_ssh_config()
+        kwargs = {'_env': self.molecule._env, '_out': utilities.print_stdout, '_err': utilities.print_stderr}
+        args = []
+
+        # testinfra
+        if os.path.isdir(self.molecule._config.config['molecule']['testinfra_dir']):
+            try:
+                ti_args = [
+                    '--sudo', '--connection=ansible',
+                    '--ansible-inventory=' + self.molecule._config.config['ansible']['inventory_file']
+                ]
+                output = sh.testinfra(*ti_args, **kwargs)
+                return output.exit_code
+            except sh.ErrorReturnCode as e:
+                print('ERROR: {}'.format(e))
+                sys.exit(e.exit_code)
+
+        # serverspec
+        if os.path.isdir(self.molecule._config.config['molecule']['serverspec_dir']):
+            self.molecule._rubocop()
+            if 'rakefile_file' in self.molecule._config.config['molecule']:
+                kwargs['rakefile'] = self.molecule._config.config['molecule']['rakefile_file']
+            if self.molecule._args['--debug']:
+                args.append('--trace')
+            try:
+                rakecmd = sh.Command("rake")
+                output = rakecmd(*args, **kwargs)
+                return output.exit_code
+            except sh.ErrorReturnCode as e:
+                print('ERROR: {}'.format(e))
+                sys.exit(e.exit_code)
+
+    def test(self):
+        for task in self._config.config['molecule']['test']['sequence']:
+            m = getattr(self, task)
+            m()
+
+    def list(self):
+        print
+        self.molecule._print_valid_platforms()
+
+    def status(self):
+        if not os.path.isfile(self.molecule._config.config['molecule']['vagrantfile_file']):
+            errmsg = '{}ERROR: No instances created. Try `{} create` first.{}'
+            print(errmsg.format(Fore.RED, os.path.basename(sys.argv[0]), Fore.RESET))
+            sys.exit(1)
+
+        try:
+            status = self.molecule._vagrant.status()
+        except CalledProcessError as e:
+            print('ERROR: {}'.format(e))
+            return e.returncode
+
+        x = prettytable.PrettyTable(['Name', 'State', 'Provider'])
+        x.align = 'l'
+
+        for item in status:
+            if item.state != 'not_created':
+                state = Fore.GREEN + item.state + Fore.RESET
+            else:
+                state = item.state
+
+            x.add_row([item.name, state, item.provider])
+
+        print(x)
+        print
+        self.molecule._print_valid_platforms()
+
+    def login(self):
+        # make sure vagrant knows about this host
+        try:
+            conf = self.molecule._vagrant.conf(vm_name=self.molecule._args['<host>'])
+            ssh_args = [conf['HostName'], conf['User'], conf['Port'], conf['IdentityFile'],
+                        ' '.join(self.molecule._config.config['molecule']['raw_ssh_args'])]
+            ssh_cmd = 'ssh {} -l {} -p {} -i {} {}'
+        except CalledProcessError:
+            # gets appended to python-vagrant's error message
+            conf_format = [Fore.RED, self._args['<host>'], Fore.YELLOW, Fore.RESET]
+            conf_errmsg = '\n{0}Unknown host {1}. Try {2}molecule status{0} to see available hosts.{3}'
+            print(conf_errmsg.format(*conf_format))
+            sys.exit(1)
+
+        lines, columns = os.popen('stty size', 'r').read().split()
+        dimensions = (int(lines), int(columns))
+        self.molecule._pt = pexpect.spawn('/usr/bin/env ' + ssh_cmd.format(*ssh_args), dimensions=dimensions)
+        signal.signal(signal.SIGWINCH, self.molecule._sigwinch_passthrough)
+        self.molecule._pt.interact()
+
+    def init(self):
+        role = self.molecule._args['<role>']
+        role_path = './' + role + '/'
+
+        if not role:
+            msg = '{}The init command requires a role name. Try:\n\n{}{} init <role>{}'
+            print(msg.format(Fore.RED, Fore.YELLOW, os.path.basename(sys.argv[0]), Fore.RESET))
+            sys.exit(1)
+
+        if os.path.isdir(role):
+            msg = '{}The directory {} already exists. Cannot create new role.{}'
+            print(msg.format(Fore.RED, role_path, Fore.RESET))
+            sys.exit(1)
+
+        try:
+            sh.ansible_galaxy('init', role)
+        except (CalledProcessError, sh.ErrorReturnCode_1) as e:
+            print('ERROR: {}'.format(e))
+            sys.exit(e.returncode)
+
+        env = Environment(loader=PackageLoader('molecule', 'templates'), keep_trailing_newline=True)
+
+        t_molecule = env.get_template(self.molecule._config.config['molecule']['init']['templates']['molecule'])
+        t_playbook = env.get_template(self.molecule._config.config['molecule']['init']['templates']['playbook'])
+        t_default_spec = env.get_template(self.molecule._config.config['molecule']['init']['templates']['default_spec'])
+        t_spec_helper = env.get_template(self.molecule._config.config['molecule']['init']['templates']['spec_helper'])
+
+        with open(role_path + self.molecule._config.config['molecule']['molecule_file'], 'w') as f:
+            f.write(t_molecule.render(config=self.molecule._config.config))
+
+        with open(role_path + self.molecule._config.config['ansible']['playbook'], 'w') as f:
+            f.write(t_playbook.render(role=role))
+
+        serverspec_path = role_path + self.molecule._config.config['molecule']['serverspec_dir'] + '/'
+        os.makedirs(serverspec_path)
+        os.makedirs(serverspec_path + 'hosts')
+        os.makedirs(serverspec_path + 'groups')
+
+        with open(serverspec_path + 'default_spec.rb', 'w') as f:
+            f.write(t_default_spec.render())
+
+        with open(serverspec_path + 'spec_helper.rb', 'w') as f:
+            f.write(t_spec_helper.render())
+
+        msg = '{}Successfully initialized new role in {}{}'
+        print(msg.format(Fore.GREEN, role_path, Fore.RESET))
+        sys.exit(0)
 
 
 class MetalCommands(BaseCommands):

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -1,0 +1,107 @@
+#  Copyright (c) 2015 Cisco Systems
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
+import sys
+
+import sh
+
+from provisioners import Ansible
+
+
+class Commands(object):
+    def __init__(self, args):
+        self.args = args
+
+    def main(self):
+        self.molecule = Ansible(self.args)
+        self.molecule.main()
+
+        if self.molecule._provider in ['virtualbox', 'openstack']:
+            self.commands = BaseCommands(self.molecule)
+
+        if self.molecule._provider is 'metal':
+            self.commands = MetalCommands(self.molecule)
+
+    def destroy(self):
+        self.commands.destroy()
+
+    def create(self):
+        self.commands.create()
+
+    def converge(self):
+        self.molecule.converge()
+
+
+class BaseCommands(object):
+    def __init__(self, molecule):
+        self.molecule = molecule
+
+    def destroy(self):
+        self.molecule._create_templates()
+        try:
+            self.molecule._vagrant.halt()
+            self.molecule._vagrant.destroy()
+            self.molecule._set_default_platform(platform=False)
+        except CalledProcessError as e:
+            print('ERROR: {}'.format(e))
+            sys.exit(e.returncode)
+        self.molecule._remove_templates()
+
+    def create(self):
+        self.molecule._create_templates()
+        if not self.molecule._created:
+            try:
+                self.molecule._vagrant.up(no_provision=True)
+                self.molecule._created = True
+            except CalledProcessError as e:
+                print('ERROR: {}'.format(e))
+                sys.exit(e.returncode)
+
+    def converge(self, idempotent=False):
+        if not idempotent:
+            self.create()
+
+        self.molecule._create_inventory_file()
+        playbook, args, kwargs = self.molecule._create_playbook_args()
+        print playbook
+
+
+        # if idempotent:
+        #     kwargs.pop('_out', None)
+        #     kwargs.pop('_err', None)
+        #     kwargs['_env']['ANSIBLE_NOCOLOR'] = 'true'
+        #     kwargs['_env']['ANSIBLE_FORCE_COLOR'] = 'false'
+        #     try:
+        #         output = sh.ansible_playbook(playbook, *args, **kwargs)
+        #         return output
+        #     except sh.ErrorReturnCode as e:
+        #         print('ERROR: {}'.format(e))
+        #         sys.exit(e.exit_code)
+        # try:
+        #     output = sh.ansible_playbook(playbook, *args, **kwargs)
+        #     return output.exit_code
+        # except sh.ErrorReturnCode as e:
+        #     print('ERROR: {}'.format(e))
+        #     sys.exit(e.exit_code)
+
+
+class MetalCommands(BaseCommands):
+    def __init__(self, molecule):
+        super(self.__class__, self).__init__(molecule)

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -45,6 +45,7 @@ class Molecule(object):
     def __init__(self, args):
         self._created = False
         self._provisioned = False
+        self._provider = None
         self._env = os.environ.copy()
         self._args = args
         self._config = config.Config()
@@ -88,8 +89,10 @@ class Molecule(object):
                 sys.exit(1)
             self._set_default_provider(provider=self._args['--provider'])
             self._env['VAGRANT_DEFAULT_PROVIDER'] = self._args['--provider']
+            self._provider = self._env['VAGRANT_DEFAULT_PROVIDER']
         else:
             self._env['VAGRANT_DEFAULT_PROVIDER'] = self._get_default_provider()
+            self._provider = self._env['VAGRANT_DEFAULT_PROVIDER']
 
         if self._args['--platform']:
             if not [item

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -30,8 +30,6 @@ import sh
 import vagrant
 import yaml
 from colorama import Fore
-from jinja2 import Environment
-from jinja2 import PackageLoader
 
 import molecule.config as config
 import molecule.utilities as utilities
@@ -55,7 +53,7 @@ class Molecule(object):
 
         # init command doesn't need to load molecule.yml
         if self._args['init']:
-            self.init()  # exits program
+            return  # exits program
 
         # merge in molecule.yml
         self._config.merge_molecule_file()
@@ -230,51 +228,3 @@ class Molecule(object):
             return False
 
         return True
-
-    def init(self):
-        role = self._args['<role>']
-        role_path = './' + role + '/'
-
-        if not role:
-            msg = '{}The init command requires a role name. Try:\n\n{}{} init <role>{}'
-            print(msg.format(Fore.RED, Fore.YELLOW, os.path.basename(sys.argv[0]), Fore.RESET))
-            sys.exit(1)
-
-        if os.path.isdir(role):
-            msg = '{}The directory {} already exists. Cannot create new role.{}'
-            print(msg.format(Fore.RED, role_path, Fore.RESET))
-            sys.exit(1)
-
-        try:
-            sh.ansible_galaxy('init', role)
-        except (CalledProcessError, sh.ErrorReturnCode_1) as e:
-            print('ERROR: {}'.format(e))
-            sys.exit(e.returncode)
-
-        env = Environment(loader=PackageLoader('molecule', 'templates'), keep_trailing_newline=True)
-
-        t_molecule = env.get_template(self._config.config['molecule']['init']['templates']['molecule'])
-        t_playbook = env.get_template(self._config.config['molecule']['init']['templates']['playbook'])
-        t_default_spec = env.get_template(self._config.config['molecule']['init']['templates']['default_spec'])
-        t_spec_helper = env.get_template(self._config.config['molecule']['init']['templates']['spec_helper'])
-
-        with open(role_path + self._config.config['molecule']['molecule_file'], 'w') as f:
-            f.write(t_molecule.render(config=self._config.config))
-
-        with open(role_path + self._config.config['ansible']['playbook'], 'w') as f:
-            f.write(t_playbook.render(role=role))
-
-        serverspec_path = role_path + self._config.config['molecule']['serverspec_dir'] + '/'
-        os.makedirs(serverspec_path)
-        os.makedirs(serverspec_path + 'hosts')
-        os.makedirs(serverspec_path + 'groups')
-
-        with open(serverspec_path + 'default_spec.rb', 'w') as f:
-            f.write(t_default_spec.render())
-
-        with open(serverspec_path + 'spec_helper.rb', 'w') as f:
-            f.write(t_spec_helper.render())
-
-        msg = '{}Successfully initialized new role in {}{}'
-        print(msg.format(Fore.GREEN, role_path, Fore.RESET))
-        sys.exit(0)

--- a/molecule/provisioners.py
+++ b/molecule/provisioners.py
@@ -19,9 +19,7 @@
 #  THE SOFTWARE.
 
 import os
-import sys
 
-import sh
 from colorama import Fore
 
 from molecule.core import Molecule
@@ -133,44 +131,3 @@ class Ansible(Molecule):
         kwargs['_err'] = utilities.print_stderr
 
         return self._config.config['ansible']['playbook'], args, kwargs
-
-    def idempotence(self):
-        print('{}Idempotence test in progress...{}'.format(Fore.CYAN, Fore.RESET)),
-
-        output = self.converge(idempotent=True)
-        idempotent = self._parse_provisioning_output(output.stdout)
-
-        if idempotent:
-            print('{}OKAY{}'.format(Fore.GREEN, Fore.RESET))
-            return
-
-        print('{}FAILED{}'.format(Fore.RED, Fore.RESET))
-        sys.exit(1)
-
-    def converge(self, idempotent=False):
-        if not idempotent:
-            self.create()
-
-        self._create_inventory_file()
-        playbook, args, kwargs = self._create_playbook_args()
-        print playbook
-        print args
-        print kwargs
-
-        if idempotent:
-            kwargs.pop('_out', None)
-            kwargs.pop('_err', None)
-            kwargs['_env']['ANSIBLE_NOCOLOR'] = 'true'
-            kwargs['_env']['ANSIBLE_FORCE_COLOR'] = 'false'
-            try:
-                output = sh.ansible_playbook(playbook, *args, **kwargs)
-                return output
-            except sh.ErrorReturnCode as e:
-                print('ERROR: {}'.format(e))
-                sys.exit(e.exit_code)
-        try:
-            output = sh.ansible_playbook(playbook, *args, **kwargs)
-            return output.exit_code
-        except sh.ErrorReturnCode as e:
-            print('ERROR: {}'.format(e))
-            sys.exit(e.exit_code)

--- a/molecule/provisioners.py
+++ b/molecule/provisioners.py
@@ -153,6 +153,9 @@ class Ansible(Molecule):
 
         self._create_inventory_file()
         playbook, args, kwargs = self._create_playbook_args()
+        print playbook
+        print args
+        print kwargs
 
         if idempotent:
             kwargs.pop('_out', None)


### PR DESCRIPTION
This looks like a huge change, but in fact it's just moving all external commands into a separate module.

The idea here is that we will be able to subclass and change how commands are run. This will be important when implementing the 'metal' provider, which will allow use to use molecule to deploy to existing systems. In that case, we'll want to bypass the create portion of a converge.

Support for this has been stubbed out in this PR, you can see in the MetalCommands class.

Added docstrings for all moved methods.