### PR TITLE
add --fast to molecule destroy

### DIFF
--- a/molecule/cli.py
+++ b/molecule/cli.py
@@ -24,7 +24,7 @@ Usage:
   molecule idempotence [--platform=<platform>] [--provider=<provider>] [--debug]
   molecule test        [--platform=<platform>] [--provider=<provider>] [--debug]
   molecule verify      [--platform=<platform>] [--provider=<provider>] [--debug]
-  molecule destroy     [--platform=<platform>] [--provider=<provider>] [--debug]
+  molecule destroy     [--platform=<platform>] [--provider=<provider>] [--debug] [--fast]
   molecule status      [--platform=<platform>] [--provider=<provider>] [--debug]
   molecule list        [--platform=<platform>] [--provider=<provider>] [--debug]
   molecule login <host>

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -115,8 +115,13 @@ class BaseCommands(object):
         :return: None
         """
         self.molecule._create_templates()
+        if self.molecule._args['--fast']:
+            shutdown_politely = False
+        else:
+            shutdown_politely = True
         try:
-            self.molecule._vagrant.halt()
+            if shutdown_politely:
+                self.molecule._vagrant.halt()
             self.molecule._vagrant.destroy()
             self.molecule._set_default_platform(platform=False)
         except CalledProcessError as e:


### PR DESCRIPTION
Skips vagrant's halt() method, goes straight to destroy()