### PR TITLE
Genericized molecule's ansible.cfg

### DIFF
--- a/molecule/templates/ansible.cfg.j2
+++ b/molecule/templates/ansible.cfg.j2
@@ -1,6 +1,4 @@
 [defaults]
 
-roles_path     = roles:../
-library        = ../../library
-lookup_plugins = ../../plugins/lookups
-filter_plugins = ../../plugins/filters
+roles_path = ../
+library    = library


### PR DESCRIPTION
We specified `lookup_plugins` and `filter_plugins` for our own
use cases.  This project is upstreamed, and our needs should be
handled in house.  We are specifying `roles_path` and `library`,
since roles can ship a library/ directory.  If this is not good
enough, others can leverage `ansible_config_template` or `raw_env_vars`
as noted in #43.