### PR TITLE
Updated state file logic, converge fast

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,12 @@
 CHANGELOG for molecule
 ======================
+1.1.1
+----
+
+* Cleaned up state file management logic to be more concise, functional for other purposes.
+* Removed --fast flag from converge in favor of using state file for fast converging.
+* Instance hostname is now printed during serverspec runs.
+
 1.1.0
 ----
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,12 +1,5 @@
 CHANGELOG for molecule
 ======================
-1.1.1
-----
-
-* Cleaned up state file management logic to be more concise, functional for other purposes.
-* Removed --fast flag from converge in favor of using state file for fast converging.
-* Instance hostname is now printed during serverspec runs.
-
 1.1.0
 ----
 

--- a/molecule/cli.py
+++ b/molecule/cli.py
@@ -20,7 +20,7 @@
 """
 Usage:
   molecule create      [--platform=<platform>] [--provider=<provider>] [--debug]
-  molecule converge    [--platform=<platform>] [--provider=<provider>] [--tags=<tag1,tag2>] [--debug] [--fast]
+  molecule converge    [--platform=<platform>] [--provider=<provider>] [--tags=<tag1,tag2>] [--debug]
   molecule idempotence [--platform=<platform>] [--provider=<provider>] [--debug]
   molecule test        [--platform=<platform>] [--provider=<provider>] [--debug]
   molecule verify      [--platform=<platform>] [--provider=<provider>] [--debug]

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -138,7 +138,7 @@ class BaseCommands(object):
         :return: Provisioning output if idempotent=True, otherwise return code of underlying call to ansible-playbook
         """
 
-        if self.molecule._state['created']:
+        if self.molecule._state.get('created'):
             create_instances = False
             create_inventory = False
 

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -100,7 +100,6 @@ class BaseCommands(object):
         self.molecule._create_templates()
         try:
             self.molecule._vagrant.up(no_provision=True)
-            self.molecule._created = True
             self.molecule._state['created'] = True
             self.molecule._write_state_file()
         except CalledProcessError as e:


### PR DESCRIPTION
* Cleaned up logic around dealing with state file so that it's decoupled from its previous use case and more generally available throughout molecule.

* Removed redundant logic when checking state for various keys.

* State file now tracks whether or not instances are created. 

* Leverage state file info for automatic fast converging.

* Removed superfluous --fast flag from converge.

* Provider and platform should now be properly tracked in state file. There was a bug with this previously.