### PR TITLE
Added .cache to ignore_paths

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -95,6 +95,7 @@ Here is a commented example:
         - .git
         - .vagrant
         - .molecule
+        - .cache
 
       # directory to look for serverspec tests
       serverspec_dir: spec

--- a/molecule/conf/defaults.yml
+++ b/molecule/conf/defaults.yml
@@ -8,6 +8,7 @@ molecule:
     - .git
     - .vagrant
     - .molecule
+    - .cache
 
   # directory to look for serverspec tests
   serverspec_dir: spec

--- a/molecule/templates/molecule.yml.j2
+++ b/molecule/templates/molecule.yml.j2
@@ -16,6 +16,7 @@
 #     - .git
 #     - .vagrant
 #     - .molecule
+#     - .cache
 
 #   # directory to look for serverspec tests
 #   serverspec_dir: spec


### PR DESCRIPTION
When using testinfra this directory is created, and will fail
validators.