### PR TITLE
Changed classifier's license to MIT

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ classifier =
     Intended Audience :: Developers
     Intended Audience :: Information Technology
     Intended Audience :: System Administrators
-    License :: Other/Proprietary License
+    License :: OSI Approved :: MIT License
     Natural Language :: English
     Operating System :: OS Independent
     Programming Language :: Python :: 2


### PR DESCRIPTION
Not sure how this slipped through the cracks.