### PR TITLE
Improved Debug Output

### DIFF
--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -157,13 +157,14 @@ class BaseCommands(object):
             kwargs['_env']['ANSIBLE_FORCE_COLOR'] = 'false'
 
         try:
-            output = sh.ansible_playbook(playbook, *args, **kwargs)
+            ansible = sh.ansible_playbook.bake(playbook, *args, **kwargs)
             if self.molecule._args['--debug']:
                 ansible_env = {k: v for (k, v) in kwargs['_env'].items() if 'ANSIBLE' in k}
                 other_env = {k: v for (k, v) in kwargs['_env'].items() if 'ANSIBLE' not in k}
                 utilities.debug('OTHER ENVIRONMENT', yaml.dump(other_env, default_flow_style=False, indent=2))
                 utilities.debug('ANSIBLE ENVIRONMENT', yaml.dump(ansible_env, default_flow_style=False, indent=2))
-                utilities.debug('ANSIBLE PLAYBOOK', output.ran)
+                utilities.debug('ANSIBLE PLAYBOOK', str(ansible.bake.im_self))
+            output = ansible()
             return output
         except sh.ErrorReturnCode as e:
             print('ERROR: {}'.format(e))

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -163,7 +163,7 @@ class BaseCommands(object):
                 other_env = {k: v for (k, v) in kwargs['_env'].items() if 'ANSIBLE' not in k}
                 utilities.debug('OTHER ENVIRONMENT', yaml.dump(other_env, default_flow_style=False, indent=2))
                 utilities.debug('ANSIBLE ENVIRONMENT', yaml.dump(ansible_env, default_flow_style=False, indent=2))
-                utilities.debug('ANSIBLE PLAYBOOK', str(ansible.bake.im_self))
+                utilities.debug('ANSIBLE PLAYBOOK', str(ansible))
             output = ansible()
             return output
         except sh.ErrorReturnCode as e:

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -26,6 +26,7 @@ from subprocess import CalledProcessError
 
 import prettytable
 import sh
+import yaml
 from colorama import Fore
 from jinja2 import Environment
 from jinja2 import PackageLoader
@@ -134,7 +135,7 @@ class BaseCommands(object):
         :param idempotent: Optionally provision servers quietly so output can be parsed for idempotence
         :param create_inventory: Toggle inventory creation
         :param create_instances: Toggle instance creation
-        :return: Provisioning output if idempotent=True, otherwise return code of underlying call to ansible-playbook
+        :return: Provisioning output
         """
 
         if self.molecule._state.get('created'):
@@ -154,15 +155,13 @@ class BaseCommands(object):
             kwargs.pop('_err', None)
             kwargs['_env']['ANSIBLE_NOCOLOR'] = 'true'
             kwargs['_env']['ANSIBLE_FORCE_COLOR'] = 'false'
-            try:
-                output = sh.ansible_playbook(playbook, *args, **kwargs)
-                return output
-            except sh.ErrorReturnCode as e:
-                print('ERROR: {}'.format(e))
-                sys.exit(e.exit_code)
+
         try:
             output = sh.ansible_playbook(playbook, *args, **kwargs)
-            return output.exit_code
+            if self.molecule._args['--debug']:
+                utilities.debug('ENVIRONMENT', yaml.dump(kwargs['_env'], default_flow_style=False, indent=2))
+                utilities.debug('ANSIBLE PLAYBOOK', output.ran)
+            return output
         except sh.ErrorReturnCode as e:
             print('ERROR: {}'.format(e))
             sys.exit(e.exit_code)

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -159,7 +159,10 @@ class BaseCommands(object):
         try:
             output = sh.ansible_playbook(playbook, *args, **kwargs)
             if self.molecule._args['--debug']:
-                utilities.debug('ENVIRONMENT', yaml.dump(kwargs['_env'], default_flow_style=False, indent=2))
+                ansible_env = {k: v for (k, v) in kwargs['_env'].items() if 'ANSIBLE' in k}
+                other_env = {k: v for (k, v) in kwargs['_env'].items() if 'ANSIBLE' not in k}
+                utilities.debug('OTHER ENVIRONMENT', yaml.dump(other_env, default_flow_style=False, indent=2))
+                utilities.debug('ANSIBLE ENVIRONMENT', yaml.dump(ansible_env, default_flow_style=False, indent=2))
                 utilities.debug('ANSIBLE PLAYBOOK', output.ran)
             return output
         except sh.ErrorReturnCode as e:

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -103,7 +103,7 @@ class Molecule(object):
         # updates instances config with full machine names
         self._config.populate_instance_names(self._env['MOLECULE_PLATFORM'])
         if self._args['--debug']:
-            print yaml.dump(self._config.config, indent=4)
+            utilities.debug('RUNNING CONFIG', yaml.dump(self._config.config, default_flow_style=False, indent=2))
 
         self._write_state_file()
 

--- a/molecule/utilities.py
+++ b/molecule/utilities.py
@@ -25,6 +25,8 @@ import os
 import sys
 
 from colorama import Fore
+from colorama import Back
+from colorama import Style
 from jinja2 import Environment
 from jinja2 import ChoiceLoader
 from jinja2 import FileSystemLoader
@@ -159,3 +161,14 @@ def print_stderr(line):
     """
     print(line, file=sys.stderr, end='')
     sys.stderr.flush()
+
+
+def debug(title, data):
+    """
+    Prints colorized output for use when debugging portions of molecule
+    :param title: title of debug output
+    :param data: data of debug output
+    :return: None
+    """
+    print(''.join([Back.WHITE, Style.BRIGHT, Fore.BLACK, 'DEBUG: ' + title, Fore.RESET, Back.RESET, Style.RESET_ALL]))
+    print(''.join([Fore.BLACK, Style.BRIGHT, data, Style.RESET_ALL, Fore.RESET]))

--- a/molecule/utilities.py
+++ b/molecule/utilities.py
@@ -24,8 +24,8 @@ import copy
 import os
 import sys
 
-from colorama import Fore
 from colorama import Back
+from colorama import Fore
 from colorama import Style
 from jinja2 import Environment
 from jinja2 import ChoiceLoader


### PR DESCRIPTION
* Passing --debug to molecule now displays config, environment (separated into ansible and other groups) and ansible-playbook command.

* Refactored converge code slightly to remove duplication. Multiple return values weren't being used and were unnecessary.