### PR TITLE
Don't generate a __pycache__ directory

### DIFF
--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -219,6 +219,7 @@ class BaseCommands(object):
 
         self.molecule._write_ssh_config()
         kwargs = {'_env': self.molecule._env, '_out': utilities.print_stdout, '_err': utilities.print_stderr}
+        kwargs['_env']['PYTHONDONTWRITEBYTECODE'] = '1'
         args = []
 
         # testinfra


### PR DESCRIPTION
We gain no real benefit to generating python byte code, it only
causes problems with linters.  Rather than ignoring this directory
in the linter, we shouldn't generate it at all.