### PR TITLE
Sanitize the generated hostname

### DIFF
--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -20,6 +20,7 @@
 
 import os
 import pexpect
+import re
 import signal
 import sys
 from subprocess import CalledProcessError
@@ -357,8 +358,9 @@ class BaseCommands(object):
         t_default_spec = env.get_template(self.molecule._config.config['molecule']['init']['templates']['default_spec'])
         t_spec_helper = env.get_template(self.molecule._config.config['molecule']['init']['templates']['spec_helper'])
 
+        sanitized_role = re.sub('[._]', '-', role)
         with open(role_path + self.molecule._config.config['molecule']['molecule_file'], 'w') as f:
-            f.write(t_molecule.render(config=self.molecule._config.config, role=role))
+            f.write(t_molecule.render(config=self.molecule._config.config, role=sanitized_role))
 
         with open(role_path + self.molecule._config.config['ansible']['playbook'], 'w') as f:
             f.write(t_playbook.render(role=role))


### PR DESCRIPTION
Since we take the role name provided by `molecule init`, and pass that
to Vagrant, we can generate invalid hosnames[1].  I am going to assume
roles are generally named in such a way that they are valid Vagrant
hostnames[1].  However, roles tend to use underscore and dashes
interchangeably.  Also, when using roles from galaxy they contain
`namespace.rolename`.  Linux will treat these hostnames PS1 as
`namespace` which is just lame.

[1] The hostname set for the VM should only contain letters, numbers,
    hyphens or dots. It cannot start with a hyphen or dot.