### PR TITLE
Destroy not resetting converged state

### DIFF
--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -123,6 +123,7 @@ class BaseCommands(object):
             self.molecule._state['default_platform'] = False
             self.molecule._state['default_provider'] = False
             self.molecule._state['created'] = False
+            self.molecule._state['converged'] = False
             self.molecule._write_state_file()
         except CalledProcessError as e:
             print('ERROR: {}'.format(e))


### PR DESCRIPTION
When destroying instances, the state file wasn't updating to show the converge state as false.  This would lead to a scenario where the generated inventory file wasn't being re-created during a new converge. This is especially problematic if you change what groups your instances are in.