### PR TITLE
Vagrant 1.8: add linked_clone option

### DIFF
--- a/molecule/templates/vagrantfile.j2
+++ b/molecule/templates/vagrantfile.j2
@@ -31,9 +31,13 @@ Vagrant.configure('2') do |config|
       {%- if not provider.options.cpus %}
     vb.cpus = 2
       {%- endif %}
+      {%- if not provider.options.linked_clone %}
+    vb.linked_clone = true if Vagrant::VERSION =~ /^1.8/
+      {%- endif %}
     {%- else %}
     vb.memory = 512
     vb.cpus = 2
+    vb.linked_clone = true if Vagrant::VERSION =~ /^1.8/
     {%- endif %}
   end
     {%- endif %}


### PR DESCRIPTION
By default new Virtualbox machines are created using linked clones. 