### PR TITLE
Update idempotence test

### DIFF
--- a/assets/ansible/plugins/callback/idempotence/idempotence.py
+++ b/assets/ansible/plugins/callback/idempotence/idempotence.py
@@ -1,0 +1,23 @@
+from __future__ import (absolute_import, division, print_function)
+
+
+class CallbackModule(object):
+    """
+    Callback module to use for Molecule idempotence test.
+    Only the tasks that have changed since last run are displayed.
+    """
+
+    def __init__(self):
+        self.changed_items = []
+        self.current = None
+
+    def runner_on_ok(self, host, res):
+        if res['changed']:
+            self.changed_items.append(self.current)
+
+    def playbook_on_task_start(self, name, is_conditional):
+        self.current = name
+
+    def playbook_on_stats(self, stats):
+        for item in self.changed_items:
+            print('NI: {}'.format(item))

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -216,10 +216,14 @@ class Molecule(object):
         # look for any non-zero changed lines
         changed = re.search(r'(changed=[1-9][0-9]*)', output)
 
-        if changed:
-            return False
+        # Look for the tasks that have changed.
+        p = re.compile(ur'NI: (.*$)', re.MULTILINE | re.IGNORECASE)
+        changed_tasks = re.findall(p, output)
 
-        return True
+        if changed:
+            return False, changed_tasks
+
+        return True, []
 
     def _remove_templates(self):
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,10 @@ warnerrors = True
 console_scripts =
     molecule = molecule.cli:main
 
+[files]
+data_files =
+  share/molecule/ansible/plugins/callback/idempotence = assets/ansible/plugins/callback/idempotence/*
+
 [build_sphinx]
 all_files = 1
 build-dir = docs/build

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -34,9 +34,21 @@ class TestCore(testtools.TestCase):
         vagrant-01-ubuntu              : ok=36   changed=29   unreachable=0    failed=0
         """
 
-        res = self._molecule._parse_provisioning_output(failed_output)
+        res, changed_tasks = self._molecule._parse_provisioning_output(failed_output)
 
         self.assertFalse(res)
+
+    def test_parse_provisioning_output_failure_01(self):
+        failed_output = """
+        PLAY RECAP ********************************************************************
+        NI: cisco.common | Non idempotent task for testing
+        common-01-rhel-7           : ok=18   changed=14   unreachable=0    failed=0
+        """
+
+        res, changed_tasks = self._molecule._parse_provisioning_output(failed_output)
+
+        self.assertFalse(res)
+        self.assertEqual(1, len(changed_tasks))
 
     def test_parse_provisioning_output_success_00(self):
         success_output = """
@@ -44,6 +56,7 @@ class TestCore(testtools.TestCase):
         vagrant-01-ubuntu              : ok=36   changed=0    unreachable=0    failed=0
         """
 
-        res = self._molecule._parse_provisioning_output(success_output)
+        res, changed_tasks = self._molecule._parse_provisioning_output(success_output)
 
         self.assertTrue(res)
+        self.assertEqual([], changed_tasks)


### PR DESCRIPTION
The idempotence test will now try to leverage the idempotence ansible
callback plugin to determine whether the role is idempotent and if not, 
display the tasks that are not.

In case the callback plugin is not found, the current behavior is not
altered and only a success or failure message is displayed to the user.

The ansible idempotence callback plugin was included into the molecule
package.

Add unit tests for the idempotence tests.

Update setup.cfg.