### PR TITLE
Path to templates can be relative to user home dir

### DIFF
--- a/molecule/utilities.py
+++ b/molecule/utilities.py
@@ -82,6 +82,7 @@ def write_template(src, dest, kwargs={}, _module='molecule', _dir='templates'):
     :param _dir: directory (to look for template files) passed to jinja2 PackageLoader
     :return: None
     """
+    src = os.path.expanduser(src)
     path = os.path.dirname(src)
     filename = os.path.basename(src)
 


### PR DESCRIPTION
To be able set path to templates in ` ~/.config/molecule/config.yml` like:

```
---
molecule:
  ansible_config_template: ~/.config/molecule/ansible.cfg.j2
```