### PR TITLE
Don't add box_url to Vagrantfile if box_version is set

### DIFF
--- a/molecule/templates/vagrantfile.j2
+++ b/molecule/templates/vagrantfile.j2
@@ -6,7 +6,7 @@ Vagrant.configure('2') do |config|
       {%- if 'box_version' in platform %}
   config.vm.box_version = "{{ platform.box_version }}"
       {%- endif %}
-      {%- if 'box_url' in platform %}
+      {%- if 'box_url' in platform and 'box_version' not in platform %}
   config.vm.box_url = '{{ platform.box_url }}'
       {%- endif %}
     {%- endif %}


### PR DESCRIPTION
If both options are set and vagrant box has not been already downloaded, it cause the error:

```
$ cat ./molecule.yml
vagrant:
  platforms:
    - name: centos-6
      box: bento/centos-6.7
      box_url: https://vagrantcloud.com/bento/boxes/centos-6.7/versions/2.2.3/providers/virtualbox.box
      box_version: 2.2.3
...

$ molecule create
Bringing machine 'yum-remi' up with 'virtualbox' provider...
==> owox-yum-remi: Box 'bento/centos-6.7' could not be found. Attempting to find and install...
    owox-yum-remi: Box Provider: virtualbox
    owox-yum-remi: Box Version: 2.2.3
==> owox-yum-remi: Box file was not detected as metadata. Adding it directly...
You specified a box version constraint with a direct box file
path. Box version constraints only work with boxes from Vagrant
Cloud or a custom box host. Please remove the version constraint
and try again.
ERROR: Command '['/usr/local/bin/vagrant', 'up', '--no-provision']' returned non-zero exit status 1
```