### PR TITLE
Add a quiet option to the list command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.egg-info/
 *.py[cod]
 .eggs/
+.idea/
 .tox/
 build/
 dist/

--- a/molecule/cli.py
+++ b/molecule/cli.py
@@ -26,7 +26,7 @@ Usage:
   molecule verify      [--platform=<platform>] [--provider=<provider>] [--debug]
   molecule destroy     [--platform=<platform>] [--provider=<provider>] [--debug]
   molecule status      [--platform=<platform>] [--provider=<provider>] [--debug]
-  molecule list        [--platform=<platform>] [--provider=<provider>] [--debug] [-q]
+  molecule list        [--debug] [-q]
   molecule login <host>
   molecule init  <role>
   molecule -v | --version

--- a/molecule/cli.py
+++ b/molecule/cli.py
@@ -26,7 +26,7 @@ Usage:
   molecule verify      [--platform=<platform>] [--provider=<provider>] [--debug]
   molecule destroy     [--platform=<platform>] [--provider=<provider>] [--debug]
   molecule status      [--platform=<platform>] [--provider=<provider>] [--debug]
-  molecule list        [--debug] [-q]
+  molecule list        [--debug] [-m]
   molecule login <host>
   molecule init  <role>
   molecule -v | --version
@@ -51,7 +51,7 @@ Options:
    --provider <provider>  specify a provider
    --tags <tag1,tag2>     comma separated list of ansible tags to target
    --debug                get more detail
-   -q                     quiet output
+   -m                     machine readable output
 """
 
 import sys

--- a/molecule/cli.py
+++ b/molecule/cli.py
@@ -26,7 +26,7 @@ Usage:
   molecule verify      [--platform=<platform>] [--provider=<provider>] [--debug]
   molecule destroy     [--platform=<platform>] [--provider=<provider>] [--debug]
   molecule status      [--platform=<platform>] [--provider=<provider>] [--debug]
-  molecule list        [--platform=<platform>] [--provider=<provider>] [--debug]
+  molecule list        [--platform=<platform>] [--provider=<provider>] [--debug] [-q]
   molecule login <host>
   molecule init  <role>
   molecule -v | --version
@@ -51,6 +51,7 @@ Options:
    --provider <provider>  specify a provider
    --tags <tag1,tag2>     comma separated list of ansible tags to target
    --debug                get more detail
+   -q                     quiet output
 """
 
 import sys

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -289,8 +289,8 @@ class BaseCommands(object):
 
         :return: None
         """
-        is_quiet = self.molecule._args['-q']
-        self.molecule._print_valid_platforms(quiet=is_quiet)
+        is_machine_readable = self.molecule._args['-m']
+        self.molecule._print_valid_platforms(machine_readable=is_machine_readable)
 
     def status(self):
         """

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -290,8 +290,6 @@ class BaseCommands(object):
         :return: None
         """
         is_quiet = self.molecule._args['-q']
-        if not is_quiet:
-            print
         self.molecule._print_valid_platforms(quiet=is_quiet)
 
     def status(self):

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -289,8 +289,10 @@ class BaseCommands(object):
 
         :return: None
         """
-        print
-        self.molecule._print_valid_platforms()
+        is_quiet = self.molecule._args['-q']
+        if not is_quiet:
+            print
+        self.molecule._print_valid_platforms(quiet=is_quiet)
 
     def status(self):
         """

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -163,12 +163,12 @@ class Molecule(object):
 
         return self._state['default_platform']
 
-    def _print_valid_platforms(self, quiet=False):
-        if not quiet:
+    def _print_valid_platforms(self, machine_readable=False):
+        if not machine_readable:
             print(Fore.CYAN + "AVAILABLE PLATFORMS" + Fore.RESET)
         default_platform = self._get_default_platform()
         for platform in self._config.config['vagrant']['platforms']:
-            default = ' (default)' if platform['name'] == default_platform and not quiet else ''
+            default = ' (default)' if platform['name'] == default_platform and not machine_readable else ''
             print(platform['name'] + default)
 
     def _get_default_provider(self):

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -163,11 +163,12 @@ class Molecule(object):
 
         return self._state['default_platform']
 
-    def _print_valid_platforms(self):
-        print(Fore.CYAN + "AVAILABLE PLATFORMS" + Fore.RESET)
+    def _print_valid_platforms(self, quiet=False):
+        if not quiet:
+            print(Fore.CYAN + "AVAILABLE PLATFORMS" + Fore.RESET)
         default_platform = self._get_default_platform()
         for platform in self._config.config['vagrant']['platforms']:
-            default = ' (default)' if platform['name'] == default_platform else ''
+            default = ' (default)' if platform['name'] == default_platform and not quiet else ''
             print(platform['name'] + default)
 
     def _get_default_provider(self):


### PR DESCRIPTION
The use case behind it is to be able to run the tests over all the available
platforms in one line:
```
molecule list -q | xargs -n1 molecule test --platform
```

This PR also raised 2 questions:
1. Why does the list command print an empty line first?
2. Why does the list command have the ``[--platform=<platform>] [--provider=<provider>]`` options?