### PR TITLE
Fix idempotence plugin

### DIFF
--- a/assets/ansible/plugins/callback/idempotence/idempotence.py
+++ b/assets/ansible/plugins/callback/idempotence/idempotence.py
@@ -8,12 +8,15 @@ class CallbackModule(object):
     """
 
     def __init__(self):
-        self.changed_items = []
+        self.changed_items = set()
         self.current = None
 
     def runner_on_ok(self, host, res):
-        if res['changed']:
-            self.changed_items.append(self.current)
+        if not res:
+            return
+
+        if res.get('changed'):
+            self.changed_items.add(self.current)
 
     def playbook_on_task_start(self, name, is_conditional):
         self.current = name


### PR DESCRIPTION
The idempotence plugin was crashing in some cases when the 'changed'
value could not be read from the 'res' dictionary.

Also, the changed task list contained duplicates in some cases. When a task
was executed several time because of a loop (using with_items for
instance), the task was being displayed once per item. Replacing the
list by a set solved this issue.