### PR TITLE
CIA-270: Refactor Commands

### DIFF
--- a/molecule/cli.py
+++ b/molecule/cli.py
@@ -65,7 +65,11 @@ import molecule.commands
 
 class CLI(object):
     def main(self):
-        args = docopt(__doc__, version=molecule.__version__)
+        args = docopt(__doc__)
+        if args['--version']:
+            print(molecule.__version__)
+            sys.exit(0)
+
         commands = ['create', 'converge', 'idempotence', 'test', 'verify', 'destroy', 'status', 'list', 'login', 'init']
         for command in commands:
             if args[command]:
@@ -74,8 +78,7 @@ class CLI(object):
                 except AttributeError:
                     raise DocoptExit()
 
-        c = command_class(args)
-        sys.exit(c.execute())
+        sys.exit(command_class(args).execute())
 
 
 def main():

--- a/molecule/cli.py
+++ b/molecule/cli.py
@@ -19,52 +19,51 @@
 #  THE SOFTWARE.
 """
 Usage:
-  molecule [-hvm] [--platform=<platform>] [--provider=<provider>] [--tags=<tag1,tag2>] [--debug] <command> [<args>]
+    molecule [-hvm] <command> [<args>]
 
 Commands:
-   create      create instances
-   converge    create and provision instances
-   idempotence converge and check the output for changes
-   test        run a full test cycle: destroy, create, converge, idempotency-check, verify and destroy instances
-   verify      create, provision and test instances
-   destroy     destroy instances
-   status      show status of instances
-   list        show available platforms, providers
-   login       connects to instance via SSH
-   init        creates the directory structure and files for a new Ansible role compatible with molecule
+    create      create instances
+    converge    create and provision instances
+    idempotence converge and check the output for changes
+    test        run a full test cycle: destroy, create, converge, idempotency-check, verify and destroy instances
+    verify      create, provision and test instances
+    destroy     destroy instances
+    status      show status of instances
+    list        show available platforms, providers
+    login       connects to instance via SSH
+    init        creates the directory structure and files for a new Ansible role compatible with molecule
 
 Options:
    -h, --help             shows this screen
    -v, --version          shows the version
-   --platform <platform>  specify a platform
-   --provider <provider>  specify a provider
-   --tags <tag1,tag2>     comma separated list of ansible tags to target
-   --debug                get more detail
    -m                     machine readable output
 """
-
+# molecule [-hvm] [--platform=<platform>] [--provider=<provider>] [--tags=<tag1,tag2>] [--debug] <command> [<args>]
 import sys
 
 from docopt import docopt
 from docopt import DocoptExit
 
 import molecule
-from molecule.commands import Commands
+import molecule.commands as commands
 
 
 class CLI(object):
     def main(self):
         args = docopt(__doc__, version=molecule.__version__, options_first=True)
-        m = Commands(args)
-        m.main()
+
+        command_name = args.pop('<command>').capitalize()
+        command_args = args.pop('<args>')
+        if command_args is None:
+            command_args = {}
 
         try:
-            method = getattr(m, args['<command>'])
+            command_class = getattr(commands, command_name)
         except AttributeError:
             raise DocoptExit()
 
-        if callable(method):
-            sys.exit(method())
+        command = command_class(command_args, args)
+        sys.exit(command.execute())
 
 
 def main():

--- a/molecule/cli.py
+++ b/molecule/cli.py
@@ -19,51 +19,63 @@
 #  THE SOFTWARE.
 """
 Usage:
-    molecule [-hvm] <command> [<args>]
+    molecule create      [--platform=<platform>] [--provider=<provider>] [--debug]
+    molecule converge    [--platform=<platform>] [--provider=<provider>] [--tags=<tag1,tag2>] [--debug]
+    molecule idempotence [--platform=<platform>] [--provider=<provider>] [--debug]
+    molecule test        [--platform=<platform>] [--provider=<provider>] [--debug]
+    molecule verify      [--platform=<platform>] [--provider=<provider>] [--debug]
+    molecule destroy     [--platform=<platform>] [--provider=<provider>] [--debug]
+    molecule status      [--platform=<platform>] [--provider=<provider>] [--debug]
+    molecule list        [--debug] [-m]
+    molecule login <host>
+    molecule init <role>
+    molecule -v | --version
+    molecule -h | --help
 
 Commands:
-    create      create instances
-    converge    create and provision instances
-    idempotence converge and check the output for changes
-    test        run a full test cycle: destroy, create, converge, idempotency-check, verify and destroy instances
-    verify      create, provision and test instances
-    destroy     destroy instances
-    status      show status of instances
-    list        show available platforms, providers
-    login       connects to instance via SSH
-    init        creates the directory structure and files for a new Ansible role compatible with molecule
+    create       create instances
+    converge     create and provision instances
+    idempotence  converge and check the output for changes
+    test         run a full test cycle: destroy, create, converge, idempotency-check, verify and destroy instances
+    verify       create, provision and test instances
+    destroy      destroy instances
+    status       show status of instances
+    list         show available platforms, providers
+    login        connects to instance via SSH
+    init         creates the directory structure and files for a new Ansible role compatible with molecule
 
 Options:
-   -h, --help             shows this screen
-   -v, --version          shows the version
-   -m                     machine readable output
+    -h --help              shows this screen
+    -v --version           shows the version
+    --platform=<platform>  specify a platform
+    --provider=<provider>  specify a provider
+    --tags=<tag1,tag2>     comma separated list of ansible tags to target
+    --debug                get more detail
+    -m                     machine readable output
 """
-# molecule [-hvm] [--platform=<platform>] [--provider=<provider>] [--tags=<tag1,tag2>] [--debug] <command> [<args>]
+
 import sys
 
 from docopt import docopt
 from docopt import DocoptExit
 
 import molecule
-import molecule.commands as commands
+import molecule.commands
 
 
 class CLI(object):
     def main(self):
-        args = docopt(__doc__, version=molecule.__version__, options_first=True)
+        args = docopt(__doc__, version=molecule.__version__)
+        commands = ['create', 'converge', 'idempotence', 'test', 'verify', 'destroy', 'status', 'list', 'login', 'init']
+        for command in commands:
+            if args[command]:
+                try:
+                    command_class = getattr(molecule.commands, command.capitalize())
+                except AttributeError:
+                    raise DocoptExit()
 
-        command_name = args.pop('<command>').capitalize()
-        command_args = args.pop('<args>')
-        if command_args is None:
-            command_args = {}
-
-        try:
-            command_class = getattr(commands, command_name)
-        except AttributeError:
-            raise DocoptExit()
-
-        command = command_class(command_args, args)
-        sys.exit(command.execute())
+        c = command_class(args)
+        sys.exit(c.execute())
 
 
 def main():

--- a/molecule/cli.py
+++ b/molecule/cli.py
@@ -19,18 +19,7 @@
 #  THE SOFTWARE.
 """
 Usage:
-  molecule create      [--platform=<platform>] [--provider=<provider>] [--debug]
-  molecule converge    [--platform=<platform>] [--provider=<provider>] [--tags=<tag1,tag2>] [--debug]
-  molecule idempotence [--platform=<platform>] [--provider=<provider>] [--debug]
-  molecule test        [--platform=<platform>] [--provider=<provider>] [--debug]
-  molecule verify      [--platform=<platform>] [--provider=<provider>] [--debug]
-  molecule destroy     [--platform=<platform>] [--provider=<provider>] [--debug]
-  molecule status      [--platform=<platform>] [--provider=<provider>] [--debug]
-  molecule list        [--debug] [-m]
-  molecule login <host>
-  molecule init  <role>
-  molecule -v | --version
-  molecule -h | --help
+  molecule [-hvm] [--platform=<platform>] [--provider=<provider>] [--tags=<tag1,tag2>] [--debug] <command> [<args>]
 
 Commands:
    create      create instances
@@ -65,23 +54,17 @@ from molecule.commands import Commands
 
 class CLI(object):
     def main(self):
-        args = docopt(__doc__)
-        if args['--version']:
-            print(molecule.__version__)
-            sys.exit(0)
-
+        args = docopt(__doc__, version=molecule.__version__, options_first=True)
         m = Commands(args)
         m.main()
-        commands = ['create', 'converge', 'idempotence', 'test', 'verify', 'destroy', 'status', 'list', 'login', 'init']
-        for command in commands:
-            if args[command]:
-                try:
-                    method = getattr(m, command)
-                except AttributeError:
-                    raise DocoptExit()
 
-                if callable(method):
-                    sys.exit(method())
+        try:
+            method = getattr(m, args['<command>'])
+        except AttributeError:
+            raise DocoptExit()
+
+        if callable(method):
+            sys.exit(method())
 
 
 def main():

--- a/molecule/cli.py
+++ b/molecule/cli.py
@@ -78,7 +78,8 @@ class CLI(object):
                 except AttributeError:
                     raise DocoptExit()
 
-        sys.exit(command_class(args).execute())
+        c = command_class(args)
+        sys.exit(c.execute())
 
 
 def main():

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -149,7 +149,8 @@ class Converge(AbstractCommand):
             create_inventory = False
 
         if create_instances and not idempotent:
-            Create(self.args, self.molecule).execute()
+            c = Create(self.args, self.molecule)
+            c.execute()
 
         if create_inventory:
             self.molecule._create_inventory_file()
@@ -206,7 +207,8 @@ class Idempotence(AbstractCommand):
 
         print('{}Idempotence test in progress (can take a few minutes)...{}'.format(Fore.CYAN, Fore.RESET))
 
-        output = Converge(self.args, self.molecule).execute(idempotent=True)
+        c = Converge(self.args, self.molecule)
+        output = c.execute(idempotent=True)
         idempotent, changed_tasks = self.molecule._parse_provisioning_output(output.stdout)
 
         if idempotent:
@@ -297,8 +299,9 @@ class Test(AbstractCommand):
             self.disabled('test')
 
         for task in self.molecule._config.config['molecule']['test']['sequence']:
-            m = getattr(sys.modules[__name__], task.capitalize())
-            m(self.args, self.molecule).execute()
+            command = getattr(sys.modules[__name__], task.capitalize())
+            c = command(self.args, self.molecule)
+            c.execute()
 
 
 class List(AbstractCommand):

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -29,6 +29,7 @@ import prettytable
 import sh
 import yaml
 from colorama import Fore
+from docopt import docopt
 from jinja2 import Environment
 from jinja2 import PackageLoader
 
@@ -37,62 +38,38 @@ import molecule.validators as validators
 from molecule.core import Molecule
 
 
-class Commands(object):
-    def __init__(self, args):
-        self.args = args
+class AbstractCommand:
+    def __init__(self, command_args, global_args):
+        """
+        Initialize commands
 
-    def main(self):
+        :param command_args: arguments of the command
+        :param global_args: arguments of the program
+        """
+        self.args = docopt(self.__doc__, argv=command_args)
+        self.global_args = global_args
         self.molecule = Molecule(self.args)
+        self.molecule._command = self.__class__.__name__.lower()
         self.molecule.main()
 
-        # assume static inventory if no vagrant config block is defined
-        if self.molecule._config.config.get('vagrant') is None:
-            self.commands = StaticCommands(self.molecule)
-            return
-
-        # assume static inventory if no instances are defined in vagrant config block
-        if self.molecule._config.config['vagrant'].get('instances') is None:
-            self.commands = StaticCommands(self.molecule)
-            return
-
-        self.commands = BaseCommands(self.molecule)
-
-    def destroy(self):
-        self.commands.destroy()
-
-    def create(self):
-        self.commands.create()
-
-    def converge(self):
-        self.commands.converge()
-
-    def idempotence(self):
-        self.commands.idempotence()
-
-    def verify(self):
-        self.commands.verify()
-
-    def test(self):
-        self.commands.test()
-
-    def list(self):
-        self.commands.list()
-
-    def status(self):
-        self.commands.status()
-
-    def login(self):
-        self.commands.login()
-
-    def init(self):
-        self.commands.init()
+    def execute(self):
+        raise NotImplementedError
 
 
-class BaseCommands(object):
-    def __init__(self, molecule):
-        self.molecule = molecule
+class Create(AbstractCommand):
+    """
+    Create instances
 
-    def create(self):
+    Usage:
+        create [--platform=<platform>] [--provider=<provider>] [--debug]
+
+    Options:
+        --platform <platform>  specify a platform
+        --provider <provider>  specify a provider
+        --debug                get more detail
+    """
+
+    def execute(self):
         """
         Creates all instances defined in molecule.yml.
         Creates all template files used by molecule, vagrant, ansible-playbook.
@@ -108,7 +85,19 @@ class BaseCommands(object):
             print('ERROR: {}'.format(e))
             sys.exit(e.returncode)
 
-    def destroy(self):
+
+class Destroy(AbstractCommand):
+    """
+    Destroy instances
+
+    Usage:
+        destroy [--debug]
+
+    Options:
+        --debug                get more detail
+    """
+
+    def execute(self):
         """
         Halts and destroys all instances created by molecule.
         Removes template files.
@@ -130,364 +119,381 @@ class BaseCommands(object):
             sys.exit(e.returncode)
         self.molecule._remove_templates()
 
-    def converge(self, idempotent=False, create_instances=True, create_inventory=True):
-        """
-        Provisions all instances using ansible-playbook.
-
-        :param idempotent: Optionally provision servers quietly so output can be parsed for idempotence
-        :param create_inventory: Toggle inventory creation
-        :param create_instances: Toggle instance creation
-        :return: Provisioning output
-        """
-
-        if self.molecule._state.get('created'):
-            create_instances = False
-
-        if self.molecule._state.get('converged'):
-            create_inventory = False
-
-        if create_instances and not idempotent:
-            self.create()
-
-        if create_inventory:
-            self.molecule._create_inventory_file()
-
-        playbook, args, kwargs = self.molecule._create_playbook_args()
-
-        if idempotent:
-            kwargs.pop('_out', None)
-            kwargs.pop('_err', None)
-            kwargs['_env']['ANSIBLE_NOCOLOR'] = 'true'
-            kwargs['_env']['ANSIBLE_FORCE_COLOR'] = 'false'
-
-            # Save the previous callback plugin if any.
-            callback_plugin = kwargs.get('_env', {}).get('ANSIBLE_CALLBACK_PLUGINS', '')
-
-            # Set the idempotence plugin.
-            kwargs['_env']['ANSIBLE_CALLBACK_PLUGINS'] = callback_plugin + os.path.join(
-                sys.prefix, 'share/molecule/ansible/plugins/callback/idempotence')
-
-        try:
-            ansible = sh.ansible_playbook.bake(playbook, *args, **kwargs)
-            if self.molecule._args['--debug']:
-                ansible_env = {k: v for (k, v) in kwargs['_env'].items() if 'ANSIBLE' in k}
-                other_env = {k: v for (k, v) in kwargs['_env'].items() if 'ANSIBLE' not in k}
-                utilities.debug('OTHER ENVIRONMENT', yaml.dump(other_env, default_flow_style=False, indent=2))
-                utilities.debug('ANSIBLE ENVIRONMENT', yaml.dump(ansible_env, default_flow_style=False, indent=2))
-                utilities.debug('ANSIBLE PLAYBOOK', str(ansible))
-
-            output = ansible()
-
-            if not self.molecule._state.get('converged'):
-                self.molecule._state['converged'] = True
-                self.molecule._write_state_file()
-
-            if idempotent:
-                # Reset the callback plugin to the previous value.
-                kwargs['_env']['ANSIBLE_CALLBACK_PLUGINS'] = callback_plugin
-
-            return output
-        except sh.ErrorReturnCode as e:
-            print('ERROR: {}'.format(e))
-            sys.exit(e.exit_code)
-
-    def idempotence(self):
-        """
-        Provisions instances and parses output to determine idempotence
-
-        :return: None
-        """
-        print('{}Idempotence test in progress (can take a few minutes)...{}'.format(Fore.CYAN, Fore.RESET))
-
-        output = self.converge(idempotent=True)
-        idempotent, changed_tasks = self.molecule._parse_provisioning_output(output.stdout)
-
-        if idempotent:
-            print('{}Idempotence test passed.{}'.format(Fore.GREEN, Fore.RESET))
-            return
-
-        # Display the details of the idempotence test.
-        if changed_tasks:
-            print('{}Idempotence test failed because of the following tasks:{}'.format(Fore.RED, Fore.RESET))
-            print('{}{}{}'.format(Fore.RED, '\n'.join(changed_tasks), Fore.RESET))
-        else:
-            # But in case the idempotence callback plugin was not found, we just display an error message.
-            print('{}Idempotence test failed.{}'.format(Fore.RED, Fore.RESET))
-            warning_msg = "The idempotence plugin was not found or did not provide the required information. " \
-                "Therefore the failure details cannot be displayed."
-
-            print('{}{}{}'.format(Fore.YELLOW, warning_msg, Fore.RESET))
-        sys.exit(1)
-
-    def verify(self):
-        """
-        Performs verification steps on running instances.
-        Checks files for trailing whitespace and newlines.
-        Runs testinfra against instances.
-        Runs serverspec against instances (also calls rubocop on spec files).
-
-        :return: None if no tests are found, otherwise return code of underlying command
-        """
-        validators.check_trailing_cruft(ignore_paths=self.molecule._config.config['molecule']['ignore_paths'])
-
-        # no tests found
-        if not os.path.isdir(self.molecule._config.config['molecule']['serverspec_dir']) and not os.path.isdir(
-                self.molecule._config.config['molecule'][
-                    'testinfra_dir']):
-            msg = '{}Skipping tests, could not find {}/ or {}/.{}'
-            print(msg.format(Fore.YELLOW, self.molecule._config.config['molecule']['serverspec_dir'],
-                             self.molecule._config.config[
-                                 'molecule']['testinfra_dir'], Fore.RESET))
-            return
-
-        self.molecule._write_ssh_config()
-        kwargs = {'_env': self.molecule._env, '_out': utilities.print_stdout, '_err': utilities.print_stderr}
-        kwargs['_env']['PYTHONDONTWRITEBYTECODE'] = '1'
-        args = []
-
-        # testinfra
-        if os.path.isdir(self.molecule._config.config['molecule']['testinfra_dir']):
-            try:
-                ti_args = [
-                    '--sudo', '--connection=ansible',
-                    '--ansible-inventory=' + self.molecule._config.config['ansible']['inventory_file']
-                ]
-                output = sh.testinfra(*ti_args, **kwargs)
-                return output.exit_code
-            except sh.ErrorReturnCode as e:
-                print('ERROR: {}'.format(e))
-                sys.exit(e.exit_code)
-
-        # serverspec
-        if os.path.isdir(self.molecule._config.config['molecule']['serverspec_dir']):
-            self.molecule._rubocop()
-            if 'rakefile_file' in self.molecule._config.config['molecule']:
-                kwargs['rakefile'] = self.molecule._config.config['molecule']['rakefile_file']
-            if self.molecule._args['--debug']:
-                args.append('--trace')
-            try:
-                rakecmd = sh.Command("rake")
-                output = rakecmd(*args, **kwargs)
-                return output.exit_code
-            except sh.ErrorReturnCode as e:
-                print('ERROR: {}'.format(e))
-                sys.exit(e.exit_code)
-
-    def test(self):
-        """
-        Runs a series of commands (defined in config) against instances for a full test/verify run
-
-        :return: None
-        """
-        for task in self.molecule._config.config['molecule']['test']['sequence']:
-            m = getattr(self, task)
-            m()
-
-    def list(self):
-        """
-        Prints a list of currently available platforms
-
-        :return: None
-        """
-        is_machine_readable = self.molecule._args['-m']
-        self.molecule._print_valid_platforms(machine_readable=is_machine_readable)
-
-    def status(self):
-        """
-        Prints status of currently converged instances, similar to `vagrant status`
-
-        :return: Return code of underlying command if there's an exception, otherwise None
-        """
-        if not os.path.isfile(self.molecule._config.config['molecule']['vagrantfile_file']):
-            errmsg = '{}ERROR: No instances created. Try `{} create` first.{}'
-            print(errmsg.format(Fore.RED, os.path.basename(sys.argv[0]), Fore.RESET))
-            sys.exit(1)
-
-        try:
-            status = self.molecule._vagrant.status()
-        except CalledProcessError as e:
-            print('ERROR: {}'.format(e))
-            return e.returncode
-
-        x = prettytable.PrettyTable(['Name', 'State', 'Provider'])
-        x.align = 'l'
-
-        for item in status:
-            if item.state != 'not_created':
-                state = Fore.GREEN + item.state + Fore.RESET
-            else:
-                state = item.state
-
-            x.add_row([item.name, state, item.provider])
-
-        print(x)
-        print
-        self.molecule._print_valid_platforms()
-
-    def login(self):
-        """
-        Initiates an interactive ssh session with a given instance name.
-
-        :return: None
-        """
-        # make sure vagrant knows about this host
-        try:
-            conf = self.molecule._vagrant.conf(vm_name=self.molecule._args['<args>'])
-            ssh_args = [conf['HostName'], conf['User'], conf['Port'], conf['IdentityFile'],
-                        ' '.join(self.molecule._config.config['molecule']['raw_ssh_args'])]
-            ssh_cmd = 'ssh {} -l {} -p {} -i {} {}'
-        except CalledProcessError:
-            # gets appended to python-vagrant's error message
-            conf_format = [Fore.RED, self.molecule._args['<args>'], Fore.YELLOW, Fore.RESET]
-            conf_errmsg = '\n{0}Unknown host {1}. Try {2}molecule status{0} to see available hosts.{3}'
-            print(conf_errmsg.format(*conf_format))
-            sys.exit(1)
-
-        lines, columns = os.popen('stty size', 'r').read().split()
-        dimensions = (int(lines), int(columns))
-        self.molecule._pt = pexpect.spawn('/usr/bin/env ' + ssh_cmd.format(*ssh_args), dimensions=dimensions)
-        signal.signal(signal.SIGWINCH, self.molecule._sigwinch_passthrough)
-        self.molecule._pt.interact()
-
-    def init(self):
-        """
-        Creates the scaffolding for a new role intended for use with molecule
-
-        :return: None
-        """
-        role = self.molecule._args['<args>']
-        role_path = './' + role + '/'
-
-        if not role:
-            msg = '{}The init command requires a role name. Try:\n\n{}{} init <role>{}'
-            print(msg.format(Fore.RED, Fore.YELLOW, os.path.basename(sys.argv[0]), Fore.RESET))
-            sys.exit(1)
-
-        if os.path.isdir(role):
-            msg = '{}The directory {} already exists. Cannot create new role.{}'
-            print(msg.format(Fore.RED, role_path, Fore.RESET))
-            sys.exit(1)
-
-        try:
-            sh.ansible_galaxy('init', role)
-        except (CalledProcessError, sh.ErrorReturnCode_1) as e:
-            print('ERROR: {}'.format(e))
-            sys.exit(e.returncode)
-
-        env = Environment(loader=PackageLoader('molecule', 'templates'), keep_trailing_newline=True)
-
-        t_molecule = env.get_template(self.molecule._config.config['molecule']['init']['templates']['molecule'])
-        t_playbook = env.get_template(self.molecule._config.config['molecule']['init']['templates']['playbook'])
-        t_default_spec = env.get_template(self.molecule._config.config['molecule']['init']['templates']['default_spec'])
-        t_spec_helper = env.get_template(self.molecule._config.config['molecule']['init']['templates']['spec_helper'])
-
-        sanitized_role = re.sub('[._]', '-', role)
-        with open(role_path + self.molecule._config.config['molecule']['molecule_file'], 'w') as f:
-            f.write(t_molecule.render(config=self.molecule._config.config, role=sanitized_role))
-
-        with open(role_path + self.molecule._config.config['ansible']['playbook'], 'w') as f:
-            f.write(t_playbook.render(role=role))
-
-        serverspec_path = role_path + self.molecule._config.config['molecule']['serverspec_dir'] + '/'
-        os.makedirs(serverspec_path)
-        os.makedirs(serverspec_path + 'hosts')
-        os.makedirs(serverspec_path + 'groups')
-
-        with open(serverspec_path + 'default_spec.rb', 'w') as f:
-            f.write(t_default_spec.render())
-
-        with open(serverspec_path + 'spec_helper.rb', 'w') as f:
-            f.write(t_spec_helper.render())
-
-        msg = '{}Successfully initialized new role in {}{}'
-        print(msg.format(Fore.GREEN, role_path, Fore.RESET))
-        sys.exit(0)
-
-
-class StaticCommands(BaseCommands):
-    def __init__(self, molecule):
-        super(self.__class__, self).__init__(molecule)
-
-    def _disabled(self, cmd):
-        """
-        Prints 'command disabled' message and exits program.
-
-        :param cmd: Name of the disabled command to print.
-        :return: None
-        """
-        fmt = [Fore.RED, cmd, Fore.RESET]
-        errmsg = "\n{}The `{}` command isn't supported with static inventory.{}"
-        print(errmsg.format(*fmt))
-        sys.exit(1)
-
-    def converge(self):
-        """
-        Calls parent converge method without instance and inventory creation.
-
-        :return: Output of parent's converge method.
-        """
-        return super(self.__class__, self).converge(create_instances=False, create_inventory=False)
-
-    def create(self):
-        """
-        Overrides parent method and prints an error message.
-
-        :return: None
-        """
-        self._disabled('create')
-
-    def destroy(self):
-        """
-        Overrides parent method and prints an error message.
-
-        :return: None
-        """
-        self._disabled('destroy')
-
-    def login(self):
-        """
-        Overrides parent method and prints an error message.
-
-        :return: None
-        """
-        self._disabled('login')
-
-    def idempotence(self):
-        """
-        Overrides parent method and prints an error message.
-
-        :return: None
-        """
-        self._disabled('idempotence')
-
-    def verify(self):
-        """
-        Overrides parent method and prints an error message.
-
-        :return: None
-        """
-        self._disabled('verify')
-
-    def test(self):
-        """
-        Overrides parent method and prints an error message.
-
-        :return: None
-        """
-        self._disabled('test')
-
-    def list(self):
-        """
-        Overrides parent method and prints an error message.
-
-        :return: None
-        """
-        self._disabled('list')
-
-    def status(self):
-        """
-        Overrides parent method and prints an error message.
-
-        :return: None
-        """
-        self._disabled('status')
+
+
+
+#         # assume static inventory if no vagrant config block is defined
+#         if self.molecule._config.config.get('vagrant') is None:
+#             self.commands = StaticCommands(self.molecule)
+#             return
+
+#         # assume static inventory if no instances are defined in vagrant config block
+#         if self.molecule._config.config['vagrant'].get('instances') is None:
+#             self.commands = StaticCommands(self.molecule)
+#             return
+
+
+
+
+
+#     def converge(self, idempotent=False, create_instances=True, create_inventory=True):
+#         """
+#         Provisions all instances using ansible-playbook.
+
+#         :param idempotent: Optionally provision servers quietly so output can be parsed for idempotence
+#         :param create_inventory: Toggle inventory creation
+#         :param create_instances: Toggle instance creation
+#         :return: Provisioning output
+#         """
+
+#         if self.molecule._state.get('created'):
+#             create_instances = False
+
+#         if self.molecule._state.get('converged'):
+#             create_inventory = False
+
+#         if create_instances and not idempotent:
+#             self.create()
+
+#         if create_inventory:
+#             self.molecule._create_inventory_file()
+
+#         playbook, args, kwargs = self.molecule._create_playbook_args()
+
+#         if idempotent:
+#             kwargs.pop('_out', None)
+#             kwargs.pop('_err', None)
+#             kwargs['_env']['ANSIBLE_NOCOLOR'] = 'true'
+#             kwargs['_env']['ANSIBLE_FORCE_COLOR'] = 'false'
+
+#             # Save the previous callback plugin if any.
+#             callback_plugin = kwargs.get('_env', {}).get('ANSIBLE_CALLBACK_PLUGINS', '')
+
+#             # Set the idempotence plugin.
+#             kwargs['_env']['ANSIBLE_CALLBACK_PLUGINS'] = callback_plugin + os.path.join(
+#                 sys.prefix, 'share/molecule/ansible/plugins/callback/idempotence')
+
+#         try:
+#             ansible = sh.ansible_playbook.bake(playbook, *args, **kwargs)
+#             if self.molecule._args['--debug']:
+#                 ansible_env = {k: v for (k, v) in kwargs['_env'].items() if 'ANSIBLE' in k}
+#                 other_env = {k: v for (k, v) in kwargs['_env'].items() if 'ANSIBLE' not in k}
+#                 utilities.debug('OTHER ENVIRONMENT', yaml.dump(other_env, default_flow_style=False, indent=2))
+#                 utilities.debug('ANSIBLE ENVIRONMENT', yaml.dump(ansible_env, default_flow_style=False, indent=2))
+#                 utilities.debug('ANSIBLE PLAYBOOK', str(ansible))
+
+#             output = ansible()
+
+#             if not self.molecule._state.get('converged'):
+#                 self.molecule._state['converged'] = True
+#                 self.molecule._write_state_file()
+
+#             if idempotent:
+#                 # Reset the callback plugin to the previous value.
+#                 kwargs['_env']['ANSIBLE_CALLBACK_PLUGINS'] = callback_plugin
+
+#             return output
+#         except sh.ErrorReturnCode as e:
+#             print('ERROR: {}'.format(e))
+#             sys.exit(e.exit_code)
+
+#     def idempotence(self):
+#         """
+#         Provisions instances and parses output to determine idempotence
+
+#         :return: None
+#         """
+#         print('{}Idempotence test in progress (can take a few minutes)...{}'.format(Fore.CYAN, Fore.RESET))
+
+#         output = self.converge(idempotent=True)
+#         idempotent, changed_tasks = self.molecule._parse_provisioning_output(output.stdout)
+
+#         if idempotent:
+#             print('{}Idempotence test passed.{}'.format(Fore.GREEN, Fore.RESET))
+#             return
+
+#         # Display the details of the idempotence test.
+#         if changed_tasks:
+#             print('{}Idempotence test failed because of the following tasks:{}'.format(Fore.RED, Fore.RESET))
+#             print('{}{}{}'.format(Fore.RED, '\n'.join(changed_tasks), Fore.RESET))
+#         else:
+#             # But in case the idempotence callback plugin was not found, we just display an error message.
+#             print('{}Idempotence test failed.{}'.format(Fore.RED, Fore.RESET))
+#             warning_msg = "The idempotence plugin was not found or did not provide the required information. " \
+#                 "Therefore the failure details cannot be displayed."
+
+#             print('{}{}{}'.format(Fore.YELLOW, warning_msg, Fore.RESET))
+#         sys.exit(1)
+
+#     def verify(self):
+#         """
+#         Performs verification steps on running instances.
+#         Checks files for trailing whitespace and newlines.
+#         Runs testinfra against instances.
+#         Runs serverspec against instances (also calls rubocop on spec files).
+
+#         :return: None if no tests are found, otherwise return code of underlying command
+#         """
+#         validators.check_trailing_cruft(ignore_paths=self.molecule._config.config['molecule']['ignore_paths'])
+
+#         # no tests found
+#         if not os.path.isdir(self.molecule._config.config['molecule']['serverspec_dir']) and not os.path.isdir(
+#                 self.molecule._config.config['molecule'][
+#                     'testinfra_dir']):
+#             msg = '{}Skipping tests, could not find {}/ or {}/.{}'
+#             print(msg.format(Fore.YELLOW, self.molecule._config.config['molecule']['serverspec_dir'],
+#                              self.molecule._config.config[
+#                                  'molecule']['testinfra_dir'], Fore.RESET))
+#             return
+
+#         self.molecule._write_ssh_config()
+#         kwargs = {'_env': self.molecule._env, '_out': utilities.print_stdout, '_err': utilities.print_stderr}
+#         kwargs['_env']['PYTHONDONTWRITEBYTECODE'] = '1'
+#         args = []
+
+#         # testinfra
+#         if os.path.isdir(self.molecule._config.config['molecule']['testinfra_dir']):
+#             try:
+#                 ti_args = [
+#                     '--sudo', '--connection=ansible',
+#                     '--ansible-inventory=' + self.molecule._config.config['ansible']['inventory_file']
+#                 ]
+#                 output = sh.testinfra(*ti_args, **kwargs)
+#                 return output.exit_code
+#             except sh.ErrorReturnCode as e:
+#                 print('ERROR: {}'.format(e))
+#                 sys.exit(e.exit_code)
+
+#         # serverspec
+#         if os.path.isdir(self.molecule._config.config['molecule']['serverspec_dir']):
+#             self.molecule._rubocop()
+#             if 'rakefile_file' in self.molecule._config.config['molecule']:
+#                 kwargs['rakefile'] = self.molecule._config.config['molecule']['rakefile_file']
+#             if self.molecule._args['--debug']:
+#                 args.append('--trace')
+#             try:
+#                 rakecmd = sh.Command("rake")
+#                 output = rakecmd(*args, **kwargs)
+#                 return output.exit_code
+#             except sh.ErrorReturnCode as e:
+#                 print('ERROR: {}'.format(e))
+#                 sys.exit(e.exit_code)
+
+#     def test(self):
+#         """
+#         Runs a series of commands (defined in config) against instances for a full test/verify run
+
+#         :return: None
+#         """
+#         for task in self.molecule._config.config['molecule']['test']['sequence']:
+#             m = getattr(self, task)
+#             m()
+
+#     def list(self):
+#         """
+#         Prints a list of currently available platforms
+
+#         :return: None
+#         """
+#         is_machine_readable = self.molecule._args['-m']
+#         self.molecule._print_valid_platforms(machine_readable=is_machine_readable)
+
+#     def status(self):
+#         """
+#         Prints status of currently converged instances, similar to `vagrant status`
+
+#         :return: Return code of underlying command if there's an exception, otherwise None
+#         """
+#         if not os.path.isfile(self.molecule._config.config['molecule']['vagrantfile_file']):
+#             errmsg = '{}ERROR: No instances created. Try `{} create` first.{}'
+#             print(errmsg.format(Fore.RED, os.path.basename(sys.argv[0]), Fore.RESET))
+#             sys.exit(1)
+
+#         try:
+#             status = self.molecule._vagrant.status()
+#         except CalledProcessError as e:
+#             print('ERROR: {}'.format(e))
+#             return e.returncode
+
+#         x = prettytable.PrettyTable(['Name', 'State', 'Provider'])
+#         x.align = 'l'
+
+#         for item in status:
+#             if item.state != 'not_created':
+#                 state = Fore.GREEN + item.state + Fore.RESET
+#             else:
+#                 state = item.state
+
+#             x.add_row([item.name, state, item.provider])
+
+#         print(x)
+#         print
+#         self.molecule._print_valid_platforms()
+
+#     def login(self):
+#         """
+#         Initiates an interactive ssh session with a given instance name.
+
+#         :return: None
+#         """
+#         # make sure vagrant knows about this host
+#         try:
+#             conf = self.molecule._vagrant.conf(vm_name=self.molecule._args['<args>'])
+#             ssh_args = [conf['HostName'], conf['User'], conf['Port'], conf['IdentityFile'],
+#                         ' '.join(self.molecule._config.config['molecule']['raw_ssh_args'])]
+#             ssh_cmd = 'ssh {} -l {} -p {} -i {} {}'
+#         except CalledProcessError:
+#             # gets appended to python-vagrant's error message
+#             conf_format = [Fore.RED, self.molecule._args['<args>'], Fore.YELLOW, Fore.RESET]
+#             conf_errmsg = '\n{0}Unknown host {1}. Try {2}molecule status{0} to see available hosts.{3}'
+#             print(conf_errmsg.format(*conf_format))
+#             sys.exit(1)
+
+#         lines, columns = os.popen('stty size', 'r').read().split()
+#         dimensions = (int(lines), int(columns))
+#         self.molecule._pt = pexpect.spawn('/usr/bin/env ' + ssh_cmd.format(*ssh_args), dimensions=dimensions)
+#         signal.signal(signal.SIGWINCH, self.molecule._sigwinch_passthrough)
+#         self.molecule._pt.interact()
+
+#     def init(self):
+#         """
+#         Creates the scaffolding for a new role intended for use with molecule
+
+#         :return: None
+#         """
+#         role = self.molecule._args['<args>']
+#         role_path = './' + role + '/'
+
+#         if not role:
+#             msg = '{}The init command requires a role name. Try:\n\n{}{} init <role>{}'
+#             print(msg.format(Fore.RED, Fore.YELLOW, os.path.basename(sys.argv[0]), Fore.RESET))
+#             sys.exit(1)
+
+#         if os.path.isdir(role):
+#             msg = '{}The directory {} already exists. Cannot create new role.{}'
+#             print(msg.format(Fore.RED, role_path, Fore.RESET))
+#             sys.exit(1)
+
+#         try:
+#             sh.ansible_galaxy('init', role)
+#         except (CalledProcessError, sh.ErrorReturnCode_1) as e:
+#             print('ERROR: {}'.format(e))
+#             sys.exit(e.returncode)
+
+#         env = Environment(loader=PackageLoader('molecule', 'templates'), keep_trailing_newline=True)
+
+#         t_molecule = env.get_template(self.molecule._config.config['molecule']['init']['templates']['molecule'])
+#         t_playbook = env.get_template(self.molecule._config.config['molecule']['init']['templates']['playbook'])
+#         t_default_spec = env.get_template(self.molecule._config.config['molecule']['init']['templates']['default_spec'])
+#         t_spec_helper = env.get_template(self.molecule._config.config['molecule']['init']['templates']['spec_helper'])
+
+#         sanitized_role = re.sub('[._]', '-', role)
+#         with open(role_path + self.molecule._config.config['molecule']['molecule_file'], 'w') as f:
+#             f.write(t_molecule.render(config=self.molecule._config.config, role=sanitized_role))
+
+#         with open(role_path + self.molecule._config.config['ansible']['playbook'], 'w') as f:
+#             f.write(t_playbook.render(role=role))
+
+#         serverspec_path = role_path + self.molecule._config.config['molecule']['serverspec_dir'] + '/'
+#         os.makedirs(serverspec_path)
+#         os.makedirs(serverspec_path + 'hosts')
+#         os.makedirs(serverspec_path + 'groups')
+
+#         with open(serverspec_path + 'default_spec.rb', 'w') as f:
+#             f.write(t_default_spec.render())
+
+#         with open(serverspec_path + 'spec_helper.rb', 'w') as f:
+#             f.write(t_spec_helper.render())
+
+#         msg = '{}Successfully initialized new role in {}{}'
+#         print(msg.format(Fore.GREEN, role_path, Fore.RESET))
+#         sys.exit(0)
+
+
+# class StaticCommands(BaseCommands):
+#     def __init__(self, molecule):
+#         super(self.__class__, self).__init__(molecule)
+
+#     def _disabled(self, cmd):
+#         """
+#         Prints 'command disabled' message and exits program.
+
+#         :param cmd: Name of the disabled command to print.
+#         :return: None
+#         """
+#         fmt = [Fore.RED, cmd, Fore.RESET]
+#         errmsg = "\n{}The `{}` command isn't supported with static inventory.{}"
+#         print(errmsg.format(*fmt))
+#         sys.exit(1)
+
+#     def converge(self):
+#         """
+#         Calls parent converge method without instance and inventory creation.
+
+#         :return: Output of parent's converge method.
+#         """
+#         return super(self.__class__, self).converge(create_instances=False, create_inventory=False)
+
+#     def create(self):
+#         """
+#         Overrides parent method and prints an error message.
+
+#         :return: None
+#         """
+#         self._disabled('create')
+
+#     def destroy(self):
+#         """
+#         Overrides parent method and prints an error message.
+
+#         :return: None
+#         """
+#         self._disabled('destroy')
+
+#     def login(self):
+#         """
+#         Overrides parent method and prints an error message.
+
+#         :return: None
+#         """
+#         self._disabled('login')
+
+#     def idempotence(self):
+#         """
+#         Overrides parent method and prints an error message.
+
+#         :return: None
+#         """
+#         self._disabled('idempotence')
+
+#     def verify(self):
+#         """
+#         Overrides parent method and prints an error message.
+
+#         :return: None
+#         """
+#         self._disabled('verify')
+
+#     def test(self):
+#         """
+#         Overrides parent method and prints an error message.
+
+#         :return: None
+#         """
+#         self._disabled('test')
+
+#     def list(self):
+#         """
+#         Overrides parent method and prints an error message.
+
+#         :return: None
+#         """
+#         self._disabled('list')
+
+#     def status(self):
+#         """
+#         Overrides parent method and prints an error message.
+
+#         :return: None
+#         """
+#         self._disabled('status')

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -332,13 +332,13 @@ class BaseCommands(object):
         """
         # make sure vagrant knows about this host
         try:
-            conf = self.molecule._vagrant.conf(vm_name=self.molecule._args['<host>'])
+            conf = self.molecule._vagrant.conf(vm_name=self.molecule._args['<args>'])
             ssh_args = [conf['HostName'], conf['User'], conf['Port'], conf['IdentityFile'],
                         ' '.join(self.molecule._config.config['molecule']['raw_ssh_args'])]
             ssh_cmd = 'ssh {} -l {} -p {} -i {} {}'
         except CalledProcessError:
             # gets appended to python-vagrant's error message
-            conf_format = [Fore.RED, self.molecule._args['<host>'], Fore.YELLOW, Fore.RESET]
+            conf_format = [Fore.RED, self.molecule._args['<args>'], Fore.YELLOW, Fore.RESET]
             conf_errmsg = '\n{0}Unknown host {1}. Try {2}molecule status{0} to see available hosts.{3}'
             print(conf_errmsg.format(*conf_format))
             sys.exit(1)
@@ -355,7 +355,7 @@ class BaseCommands(object):
 
         :return: None
         """
-        role = self.molecule._args['<role>']
+        role = self.molecule._args['<args>']
         role_path = './' + role + '/'
 
         if not role:

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -38,16 +38,43 @@ from molecule.core import Molecule
 
 
 class AbstractCommand:
-    def __init__(self, args):
+    def __init__(self, args, molecule=False):
         """
         Initialize commands
 
-        :param command_args: arguments from the CLI
+        :param args: arguments from the CLI
+        :param molecule: molecule instance
         """
         self.args = args
-        self.molecule = Molecule(self.args)
-        self.molecule._command = self.__class__.__name__.lower()
-        self.molecule.main()
+        self.static = False
+
+        # only create a molecule instance if one doesn't exist
+        if not molecule:
+            self.molecule = Molecule(self.args)
+            self.molecule.main()
+        else:
+            self.molecule = molecule
+
+        # assume static inventory if no vagrant config block is defined
+        if self.molecule._config.config.get('vagrant') is None:
+            self.static = True
+
+        # assume static inventory if no instances are defined in vagrant config block
+        if self.molecule._config.config['vagrant'].get('instances') is None:
+            self.static = True
+
+    def disabled(self, cmd):
+        """
+        Prints 'command disabled' message and exits program.
+
+        :param cmd: Name of the disabled command to print.
+        :return: None
+        """
+        fmt = [Fore.RED, cmd, Fore.RESET]
+        errmsg = "{}The `{}` command isn't supported with static inventory.{}"
+        print(errmsg.format(*fmt))
+        sys.exit(1)
+
     def execute(self):
         raise NotImplementedError
 
@@ -60,6 +87,9 @@ class Create(AbstractCommand):
 
         :return: None
         """
+        if self.static:
+            self.disabled('create')
+
         self.molecule._create_templates()
         try:
             self.molecule._vagrant.up(no_provision=True)
@@ -71,16 +101,6 @@ class Create(AbstractCommand):
 
 
 class Destroy(AbstractCommand):
-    """
-    Destroy instances
-
-    Usage:
-        destroy [--debug]
-
-    Options:
-        --debug                get more detail
-    """
-
     def execute(self):
         """
         Halts and destroys all instances created by molecule.
@@ -89,6 +109,9 @@ class Destroy(AbstractCommand):
 
         :return: None
         """
+        if self.static:
+            self.disabled('destroy')
+
         self.molecule._create_templates()
         try:
             self.molecule._vagrant.halt()
@@ -104,380 +127,312 @@ class Destroy(AbstractCommand):
         self.molecule._remove_templates()
 
 
-
-
-#         # assume static inventory if no vagrant config block is defined
-#         if self.molecule._config.config.get('vagrant') is None:
-#             self.commands = StaticCommands(self.molecule)
-#             return
-
-#         # assume static inventory if no instances are defined in vagrant config block
-#         if self.molecule._config.config['vagrant'].get('instances') is None:
-#             self.commands = StaticCommands(self.molecule)
-#             return
-
-
-
-
-
-#     def converge(self, idempotent=False, create_instances=True, create_inventory=True):
-#         """
-#         Provisions all instances using ansible-playbook.
-
-#         :param idempotent: Optionally provision servers quietly so output can be parsed for idempotence
-#         :param create_inventory: Toggle inventory creation
-#         :param create_instances: Toggle instance creation
-#         :return: Provisioning output
-#         """
-
-#         if self.molecule._state.get('created'):
-#             create_instances = False
-
-#         if self.molecule._state.get('converged'):
-#             create_inventory = False
-
-#         if create_instances and not idempotent:
-#             self.create()
-
-#         if create_inventory:
-#             self.molecule._create_inventory_file()
-
-#         playbook, args, kwargs = self.molecule._create_playbook_args()
-
-#         if idempotent:
-#             kwargs.pop('_out', None)
-#             kwargs.pop('_err', None)
-#             kwargs['_env']['ANSIBLE_NOCOLOR'] = 'true'
-#             kwargs['_env']['ANSIBLE_FORCE_COLOR'] = 'false'
-
-#             # Save the previous callback plugin if any.
-#             callback_plugin = kwargs.get('_env', {}).get('ANSIBLE_CALLBACK_PLUGINS', '')
-
-#             # Set the idempotence plugin.
-#             kwargs['_env']['ANSIBLE_CALLBACK_PLUGINS'] = callback_plugin + os.path.join(
-#                 sys.prefix, 'share/molecule/ansible/plugins/callback/idempotence')
-
-#         try:
-#             ansible = sh.ansible_playbook.bake(playbook, *args, **kwargs)
-#             if self.molecule._args['--debug']:
-#                 ansible_env = {k: v for (k, v) in kwargs['_env'].items() if 'ANSIBLE' in k}
-#                 other_env = {k: v for (k, v) in kwargs['_env'].items() if 'ANSIBLE' not in k}
-#                 utilities.debug('OTHER ENVIRONMENT', yaml.dump(other_env, default_flow_style=False, indent=2))
-#                 utilities.debug('ANSIBLE ENVIRONMENT', yaml.dump(ansible_env, default_flow_style=False, indent=2))
-#                 utilities.debug('ANSIBLE PLAYBOOK', str(ansible))
-
-#             output = ansible()
-
-#             if not self.molecule._state.get('converged'):
-#                 self.molecule._state['converged'] = True
-#                 self.molecule._write_state_file()
-
-#             if idempotent:
-#                 # Reset the callback plugin to the previous value.
-#                 kwargs['_env']['ANSIBLE_CALLBACK_PLUGINS'] = callback_plugin
-
-#             return output
-#         except sh.ErrorReturnCode as e:
-#             print('ERROR: {}'.format(e))
-#             sys.exit(e.exit_code)
-
-#     def idempotence(self):
-#         """
-#         Provisions instances and parses output to determine idempotence
-
-#         :return: None
-#         """
-#         print('{}Idempotence test in progress (can take a few minutes)...{}'.format(Fore.CYAN, Fore.RESET))
-
-#         output = self.converge(idempotent=True)
-#         idempotent, changed_tasks = self.molecule._parse_provisioning_output(output.stdout)
-
-#         if idempotent:
-#             print('{}Idempotence test passed.{}'.format(Fore.GREEN, Fore.RESET))
-#             return
-
-#         # Display the details of the idempotence test.
-#         if changed_tasks:
-#             print('{}Idempotence test failed because of the following tasks:{}'.format(Fore.RED, Fore.RESET))
-#             print('{}{}{}'.format(Fore.RED, '\n'.join(changed_tasks), Fore.RESET))
-#         else:
-#             # But in case the idempotence callback plugin was not found, we just display an error message.
-#             print('{}Idempotence test failed.{}'.format(Fore.RED, Fore.RESET))
-#             warning_msg = "The idempotence plugin was not found or did not provide the required information. " \
-#                 "Therefore the failure details cannot be displayed."
-
-#             print('{}{}{}'.format(Fore.YELLOW, warning_msg, Fore.RESET))
-#         sys.exit(1)
-
-#     def verify(self):
-#         """
-#         Performs verification steps on running instances.
-#         Checks files for trailing whitespace and newlines.
-#         Runs testinfra against instances.
-#         Runs serverspec against instances (also calls rubocop on spec files).
-
-#         :return: None if no tests are found, otherwise return code of underlying command
-#         """
-#         validators.check_trailing_cruft(ignore_paths=self.molecule._config.config['molecule']['ignore_paths'])
-
-#         # no tests found
-#         if not os.path.isdir(self.molecule._config.config['molecule']['serverspec_dir']) and not os.path.isdir(
-#                 self.molecule._config.config['molecule'][
-#                     'testinfra_dir']):
-#             msg = '{}Skipping tests, could not find {}/ or {}/.{}'
-#             print(msg.format(Fore.YELLOW, self.molecule._config.config['molecule']['serverspec_dir'],
-#                              self.molecule._config.config[
-#                                  'molecule']['testinfra_dir'], Fore.RESET))
-#             return
-
-#         self.molecule._write_ssh_config()
-#         kwargs = {'_env': self.molecule._env, '_out': utilities.print_stdout, '_err': utilities.print_stderr}
-#         kwargs['_env']['PYTHONDONTWRITEBYTECODE'] = '1'
-#         args = []
-
-#         # testinfra
-#         if os.path.isdir(self.molecule._config.config['molecule']['testinfra_dir']):
-#             try:
-#                 ti_args = [
-#                     '--sudo', '--connection=ansible',
-#                     '--ansible-inventory=' + self.molecule._config.config['ansible']['inventory_file']
-#                 ]
-#                 output = sh.testinfra(*ti_args, **kwargs)
-#                 return output.exit_code
-#             except sh.ErrorReturnCode as e:
-#                 print('ERROR: {}'.format(e))
-#                 sys.exit(e.exit_code)
-
-#         # serverspec
-#         if os.path.isdir(self.molecule._config.config['molecule']['serverspec_dir']):
-#             self.molecule._rubocop()
-#             if 'rakefile_file' in self.molecule._config.config['molecule']:
-#                 kwargs['rakefile'] = self.molecule._config.config['molecule']['rakefile_file']
-#             if self.molecule._args['--debug']:
-#                 args.append('--trace')
-#             try:
-#                 rakecmd = sh.Command("rake")
-#                 output = rakecmd(*args, **kwargs)
-#                 return output.exit_code
-#             except sh.ErrorReturnCode as e:
-#                 print('ERROR: {}'.format(e))
-#                 sys.exit(e.exit_code)
-
-#     def test(self):
-#         """
-#         Runs a series of commands (defined in config) against instances for a full test/verify run
-
-#         :return: None
-#         """
-#         for task in self.molecule._config.config['molecule']['test']['sequence']:
-#             m = getattr(self, task)
-#             m()
-
-#     def list(self):
-#         """
-#         Prints a list of currently available platforms
-
-#         :return: None
-#         """
-#         is_machine_readable = self.molecule._args['-m']
-#         self.molecule._print_valid_platforms(machine_readable=is_machine_readable)
-
-#     def status(self):
-#         """
-#         Prints status of currently converged instances, similar to `vagrant status`
-
-#         :return: Return code of underlying command if there's an exception, otherwise None
-#         """
-#         if not os.path.isfile(self.molecule._config.config['molecule']['vagrantfile_file']):
-#             errmsg = '{}ERROR: No instances created. Try `{} create` first.{}'
-#             print(errmsg.format(Fore.RED, os.path.basename(sys.argv[0]), Fore.RESET))
-#             sys.exit(1)
-
-#         try:
-#             status = self.molecule._vagrant.status()
-#         except CalledProcessError as e:
-#             print('ERROR: {}'.format(e))
-#             return e.returncode
-
-#         x = prettytable.PrettyTable(['Name', 'State', 'Provider'])
-#         x.align = 'l'
-
-#         for item in status:
-#             if item.state != 'not_created':
-#                 state = Fore.GREEN + item.state + Fore.RESET
-#             else:
-#                 state = item.state
-
-#             x.add_row([item.name, state, item.provider])
-
-#         print(x)
-#         print
-#         self.molecule._print_valid_platforms()
-
-#     def login(self):
-#         """
-#         Initiates an interactive ssh session with a given instance name.
-
-#         :return: None
-#         """
-#         # make sure vagrant knows about this host
-#         try:
-#             conf = self.molecule._vagrant.conf(vm_name=self.molecule._args['<args>'])
-#             ssh_args = [conf['HostName'], conf['User'], conf['Port'], conf['IdentityFile'],
-#                         ' '.join(self.molecule._config.config['molecule']['raw_ssh_args'])]
-#             ssh_cmd = 'ssh {} -l {} -p {} -i {} {}'
-#         except CalledProcessError:
-#             # gets appended to python-vagrant's error message
-#             conf_format = [Fore.RED, self.molecule._args['<args>'], Fore.YELLOW, Fore.RESET]
-#             conf_errmsg = '\n{0}Unknown host {1}. Try {2}molecule status{0} to see available hosts.{3}'
-#             print(conf_errmsg.format(*conf_format))
-#             sys.exit(1)
-
-#         lines, columns = os.popen('stty size', 'r').read().split()
-#         dimensions = (int(lines), int(columns))
-#         self.molecule._pt = pexpect.spawn('/usr/bin/env ' + ssh_cmd.format(*ssh_args), dimensions=dimensions)
-#         signal.signal(signal.SIGWINCH, self.molecule._sigwinch_passthrough)
-#         self.molecule._pt.interact()
-
-#     def init(self):
-#         """
-#         Creates the scaffolding for a new role intended for use with molecule
-
-#         :return: None
-#         """
-#         role = self.molecule._args['<args>']
-#         role_path = './' + role + '/'
-
-#         if not role:
-#             msg = '{}The init command requires a role name. Try:\n\n{}{} init <role>{}'
-#             print(msg.format(Fore.RED, Fore.YELLOW, os.path.basename(sys.argv[0]), Fore.RESET))
-#             sys.exit(1)
-
-#         if os.path.isdir(role):
-#             msg = '{}The directory {} already exists. Cannot create new role.{}'
-#             print(msg.format(Fore.RED, role_path, Fore.RESET))
-#             sys.exit(1)
-
-#         try:
-#             sh.ansible_galaxy('init', role)
-#         except (CalledProcessError, sh.ErrorReturnCode_1) as e:
-#             print('ERROR: {}'.format(e))
-#             sys.exit(e.returncode)
-
-#         env = Environment(loader=PackageLoader('molecule', 'templates'), keep_trailing_newline=True)
-
-#         t_molecule = env.get_template(self.molecule._config.config['molecule']['init']['templates']['molecule'])
-#         t_playbook = env.get_template(self.molecule._config.config['molecule']['init']['templates']['playbook'])
-#         t_default_spec = env.get_template(self.molecule._config.config['molecule']['init']['templates']['default_spec'])
-#         t_spec_helper = env.get_template(self.molecule._config.config['molecule']['init']['templates']['spec_helper'])
-
-#         sanitized_role = re.sub('[._]', '-', role)
-#         with open(role_path + self.molecule._config.config['molecule']['molecule_file'], 'w') as f:
-#             f.write(t_molecule.render(config=self.molecule._config.config, role=sanitized_role))
-
-#         with open(role_path + self.molecule._config.config['ansible']['playbook'], 'w') as f:
-#             f.write(t_playbook.render(role=role))
-
-#         serverspec_path = role_path + self.molecule._config.config['molecule']['serverspec_dir'] + '/'
-#         os.makedirs(serverspec_path)
-#         os.makedirs(serverspec_path + 'hosts')
-#         os.makedirs(serverspec_path + 'groups')
-
-#         with open(serverspec_path + 'default_spec.rb', 'w') as f:
-#             f.write(t_default_spec.render())
-
-#         with open(serverspec_path + 'spec_helper.rb', 'w') as f:
-#             f.write(t_spec_helper.render())
-
-#         msg = '{}Successfully initialized new role in {}{}'
-#         print(msg.format(Fore.GREEN, role_path, Fore.RESET))
-#         sys.exit(0)
-
-
-# class StaticCommands(BaseCommands):
-#     def __init__(self, molecule):
-#         super(self.__class__, self).__init__(molecule)
-
-#     def _disabled(self, cmd):
-#         """
-#         Prints 'command disabled' message and exits program.
-
-#         :param cmd: Name of the disabled command to print.
-#         :return: None
-#         """
-#         fmt = [Fore.RED, cmd, Fore.RESET]
-#         errmsg = "\n{}The `{}` command isn't supported with static inventory.{}"
-#         print(errmsg.format(*fmt))
-#         sys.exit(1)
-
-#     def converge(self):
-#         """
-#         Calls parent converge method without instance and inventory creation.
-
-#         :return: Output of parent's converge method.
-#         """
-#         return super(self.__class__, self).converge(create_instances=False, create_inventory=False)
-
-#     def create(self):
-#         """
-#         Overrides parent method and prints an error message.
-
-#         :return: None
-#         """
-#         self._disabled('create')
-
-#     def destroy(self):
-#         """
-#         Overrides parent method and prints an error message.
-
-#         :return: None
-#         """
-#         self._disabled('destroy')
-
-#     def login(self):
-#         """
-#         Overrides parent method and prints an error message.
-
-#         :return: None
-#         """
-#         self._disabled('login')
-
-#     def idempotence(self):
-#         """
-#         Overrides parent method and prints an error message.
-
-#         :return: None
-#         """
-#         self._disabled('idempotence')
-
-#     def verify(self):
-#         """
-#         Overrides parent method and prints an error message.
-
-#         :return: None
-#         """
-#         self._disabled('verify')
-
-#     def test(self):
-#         """
-#         Overrides parent method and prints an error message.
-
-#         :return: None
-#         """
-#         self._disabled('test')
-
-#     def list(self):
-#         """
-#         Overrides parent method and prints an error message.
-
-#         :return: None
-#         """
-#         self._disabled('list')
-
-#     def status(self):
-#         """
-#         Overrides parent method and prints an error message.
-
-#         :return: None
-#         """
-#         self._disabled('status')
+class Converge(AbstractCommand):
+    def execute(self, idempotent=False, create_instances=True, create_inventory=True):
+        """
+        Provisions all instances using ansible-playbook.
+
+        :param idempotent: Optionally provision servers quietly so output can be parsed for idempotence
+        :param create_inventory: Toggle inventory creation
+        :param create_instances: Toggle instance creation
+        :return: Provisioning output
+        """
+
+        if self.molecule._state.get('created'):
+            create_instances = False
+
+        if self.molecule._state.get('converged'):
+            create_inventory = False
+
+        if self.static:
+            create_instances = False
+            create_inventory = False
+
+        if create_instances and not idempotent:
+            Create(self.args, self.molecule).execute()
+
+        if create_inventory:
+            self.molecule._create_inventory_file()
+
+        playbook, args, kwargs = self.molecule._create_playbook_args()
+
+        if idempotent:
+            kwargs.pop('_out', None)
+            kwargs.pop('_err', None)
+            kwargs['_env']['ANSIBLE_NOCOLOR'] = 'true'
+            kwargs['_env']['ANSIBLE_FORCE_COLOR'] = 'false'
+
+            # Save the previous callback plugin if any.
+            callback_plugin = kwargs.get('_env', {}).get('ANSIBLE_CALLBACK_PLUGINS', '')
+
+            # Set the idempotence plugin.
+            kwargs['_env']['ANSIBLE_CALLBACK_PLUGINS'] = callback_plugin + os.path.join(
+                sys.prefix, 'share/molecule/ansible/plugins/callback/idempotence')
+
+        try:
+            ansible = sh.ansible_playbook.bake(playbook, *args, **kwargs)
+            if self.molecule._args['--debug']:
+                ansible_env = {k: v for (k, v) in kwargs['_env'].items() if 'ANSIBLE' in k}
+                other_env = {k: v for (k, v) in kwargs['_env'].items() if 'ANSIBLE' not in k}
+                utilities.debug('OTHER ENVIRONMENT', yaml.dump(other_env, default_flow_style=False, indent=2))
+                utilities.debug('ANSIBLE ENVIRONMENT', yaml.dump(ansible_env, default_flow_style=False, indent=2))
+                utilities.debug('ANSIBLE PLAYBOOK', str(ansible))
+
+            output = ansible()
+
+            if not self.molecule._state.get('converged'):
+                self.molecule._state['converged'] = True
+                self.molecule._write_state_file()
+
+            if idempotent:
+                # Reset the callback plugin to the previous value.
+                kwargs['_env']['ANSIBLE_CALLBACK_PLUGINS'] = callback_plugin
+
+            return output
+        except sh.ErrorReturnCode as e:
+            print('ERROR: {}'.format(e))
+            sys.exit(e.exit_code)
+
+
+class Idempotence(AbstractCommand):
+    def execute(self):
+        """
+        Provisions instances and parses output to determine idempotence
+
+        :return: None
+        """
+        if self.static:
+            self.disabled('idempotence')
+
+        print('{}Idempotence test in progress (can take a few minutes)...{}'.format(Fore.CYAN, Fore.RESET))
+
+        output = Converge(self.args, self.molecule).execute(idempotent=True)
+        idempotent, changed_tasks = self.molecule._parse_provisioning_output(output.stdout)
+
+        if idempotent:
+            print('{}Idempotence test passed.{}'.format(Fore.GREEN, Fore.RESET))
+            return
+
+        # Display the details of the idempotence test.
+        if changed_tasks:
+            print('{}Idempotence test failed because of the following tasks:{}'.format(Fore.RED, Fore.RESET))
+            print('{}{}{}'.format(Fore.RED, '\n'.join(changed_tasks), Fore.RESET))
+        else:
+            # But in case the idempotence callback plugin was not found, we just display an error message.
+            print('{}Idempotence test failed.{}'.format(Fore.RED, Fore.RESET))
+            warning_msg = "The idempotence plugin was not found or did not provide the required information. " \
+                "Therefore the failure details cannot be displayed."
+
+            print('{}{}{}'.format(Fore.YELLOW, warning_msg, Fore.RESET))
+        sys.exit(1)
+
+
+class Verify(AbstractCommand):
+    def execute(self):
+        """
+        Performs verification steps on running instances.
+        Checks files for trailing whitespace and newlines.
+        Runs testinfra against instances.
+        Runs serverspec against instances (also calls rubocop on spec files).
+
+        :return: None if no tests are found, otherwise return code of underlying command
+        """
+        if self.static:
+            self.disabled('verify')
+
+        validators.check_trailing_cruft(ignore_paths=self.molecule._config.config['molecule']['ignore_paths'])
+
+        # no tests found
+        if not os.path.isdir(self.molecule._config.config['molecule']['serverspec_dir']) and not os.path.isdir(
+                self.molecule._config.config['molecule'][
+                    'testinfra_dir']):
+            msg = '{}Skipping tests, could not find {}/ or {}/.{}'
+            print(msg.format(Fore.YELLOW, self.molecule._config.config['molecule']['serverspec_dir'],
+                             self.molecule._config.config[
+                                 'molecule']['testinfra_dir'], Fore.RESET))
+            return
+
+        self.molecule._write_ssh_config()
+        kwargs = {'_env': self.molecule._env, '_out': utilities.print_stdout, '_err': utilities.print_stderr}
+        kwargs['_env']['PYTHONDONTWRITEBYTECODE'] = '1'
+        args = []
+
+        # testinfra
+        if os.path.isdir(self.molecule._config.config['molecule']['testinfra_dir']):
+            try:
+                ti_args = [
+                    '--sudo', '--connection=ansible',
+                    '--ansible-inventory=' + self.molecule._config.config['ansible']['inventory_file']
+                ]
+                output = sh.testinfra(*ti_args, **kwargs)
+                return output.exit_code
+            except sh.ErrorReturnCode as e:
+                print('ERROR: {}'.format(e))
+                sys.exit(e.exit_code)
+
+        # serverspec
+        if os.path.isdir(self.molecule._config.config['molecule']['serverspec_dir']):
+            self.molecule._rubocop()
+            if 'rakefile_file' in self.molecule._config.config['molecule']:
+                kwargs['rakefile'] = self.molecule._config.config['molecule']['rakefile_file']
+            if self.molecule._args['--debug']:
+                args.append('--trace')
+            try:
+                rakecmd = sh.Command("rake")
+                output = rakecmd(*args, **kwargs)
+                return output.exit_code
+            except sh.ErrorReturnCode as e:
+                print('ERROR: {}'.format(e))
+                sys.exit(e.exit_code)
+
+
+class Test(AbstractCommand):
+    def execute(self):
+        """
+        Runs a series of commands (defined in config) against instances for a full test/verify run
+
+        :return: None
+        """
+        if self.static:
+            self.disabled('test')
+
+        for task in self.molecule._config.config['molecule']['test']['sequence']:
+            m = getattr(sys.modules[__name__], task.capitalize())
+            m(self.args, self.molecule).execute()
+
+
+class List(AbstractCommand):
+    def execute(self):
+        """
+        Prints a list of currently available platforms
+
+        :return: None
+        """
+        if self.static:
+            self.disabled('list')
+
+        is_machine_readable = self.molecule._args['-m']
+        self.molecule._print_valid_platforms(machine_readable=is_machine_readable)
+
+
+class Status(AbstractCommand):
+    def execute(self):
+        """
+        Prints status of currently converged instances, similar to `vagrant status`
+
+        :return: Return code of underlying command if there's an exception, otherwise None
+        """
+        if self.static:
+            self.disabled('status')
+
+        if not os.path.isfile(self.molecule._config.config['molecule']['vagrantfile_file']):
+            errmsg = '{}ERROR: No instances created. Try `{} create` first.{}'
+            print(errmsg.format(Fore.RED, os.path.basename(sys.argv[0]), Fore.RESET))
+            sys.exit(1)
+
+        try:
+            status = self.molecule._vagrant.status()
+        except CalledProcessError as e:
+            print('ERROR: {}'.format(e))
+            return e.returncode
+
+        x = prettytable.PrettyTable(['Name', 'State', 'Provider'])
+        x.align = 'l'
+
+        for item in status:
+            if item.state != 'not_created':
+                state = Fore.GREEN + item.state + Fore.RESET
+            else:
+                state = item.state
+
+            x.add_row([item.name, state, item.provider])
+
+        print(x)
+        print
+        self.molecule._print_valid_platforms()
+
+
+class Login(AbstractCommand):
+    def execute(self):
+        """
+        Initiates an interactive ssh session with a given instance name.
+
+        :return: None
+        """
+        if self.static:
+            self.disabled('login')
+
+        # make sure vagrant knows about this host
+        try:
+            conf = self.molecule._vagrant.conf(vm_name=self.molecule._args['<host>'])
+            ssh_args = [conf['HostName'], conf['User'], conf['Port'], conf['IdentityFile'],
+                        ' '.join(self.molecule._config.config['molecule']['raw_ssh_args'])]
+            ssh_cmd = 'ssh {} -l {} -p {} -i {} {}'
+        except CalledProcessError:
+            # gets appended to python-vagrant's error message
+            conf_format = [Fore.RED, self.molecule._args['<host>'], Fore.YELLOW, Fore.RESET]
+            conf_errmsg = '\n{0}Unknown host {1}. Try {2}molecule status{0} to see available hosts.{3}'
+            print(conf_errmsg.format(*conf_format))
+            sys.exit(1)
+
+        lines, columns = os.popen('stty size', 'r').read().split()
+        dimensions = (int(lines), int(columns))
+        self.molecule._pt = pexpect.spawn('/usr/bin/env ' + ssh_cmd.format(*ssh_args), dimensions=dimensions)
+        signal.signal(signal.SIGWINCH, self.molecule._sigwinch_passthrough)
+        self.molecule._pt.interact()
+
+
+class Init(AbstractCommand):
+    def execute(self):
+        """
+        Creates the scaffolding for a new role intended for use with molecule
+
+        :return: None
+        """
+        role = self.molecule._args['<role>']
+        role_path = './' + role + '/'
+
+        if not role:
+            msg = '{}The init command requires a role name. Try:\n\n{}{} init <role>{}'
+            print(msg.format(Fore.RED, Fore.YELLOW, os.path.basename(sys.argv[0]), Fore.RESET))
+            sys.exit(1)
+
+        if os.path.isdir(role):
+            msg = '{}The directory {} already exists. Cannot create new role.{}'
+            print(msg.format(Fore.RED, role_path, Fore.RESET))
+            sys.exit(1)
+
+        try:
+            sh.ansible_galaxy('init', role)
+        except (CalledProcessError, sh.ErrorReturnCode_1) as e:
+            print('ERROR: {}'.format(e))
+            sys.exit(e.returncode)
+
+        env = Environment(loader=PackageLoader('molecule', 'templates'), keep_trailing_newline=True)
+
+        t_molecule = env.get_template(self.molecule._config.config['molecule']['init']['templates']['molecule'])
+        t_playbook = env.get_template(self.molecule._config.config['molecule']['init']['templates']['playbook'])
+        t_default_spec = env.get_template(self.molecule._config.config['molecule']['init']['templates']['default_spec'])
+        t_spec_helper = env.get_template(self.molecule._config.config['molecule']['init']['templates']['spec_helper'])
+
+        sanitized_role = re.sub('[._]', '-', role)
+        with open(role_path + self.molecule._config.config['molecule']['molecule_file'], 'w') as f:
+            f.write(t_molecule.render(config=self.molecule._config.config, role=sanitized_role))
+
+        with open(role_path + self.molecule._config.config['ansible']['playbook'], 'w') as f:
+            f.write(t_playbook.render(role=role))
+
+        serverspec_path = role_path + self.molecule._config.config['molecule']['serverspec_dir'] + '/'
+        os.makedirs(serverspec_path)
+        os.makedirs(serverspec_path + 'hosts')
+        os.makedirs(serverspec_path + 'groups')
+
+        with open(serverspec_path + 'default_spec.rb', 'w') as f:
+            f.write(t_default_spec.render())
+
+        with open(serverspec_path + 'spec_helper.rb', 'w') as f:
+            f.write(t_spec_helper.render())
+
+        msg = '{}Successfully initialized new role in {}{}'
+        print(msg.format(Fore.GREEN, role_path, Fore.RESET))
+        sys.exit(0)

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -29,7 +29,6 @@ import prettytable
 import sh
 import yaml
 from colorama import Fore
-from docopt import docopt
 from jinja2 import Environment
 from jinja2 import PackageLoader
 
@@ -39,36 +38,21 @@ from molecule.core import Molecule
 
 
 class AbstractCommand:
-    def __init__(self, command_args, global_args):
+    def __init__(self, args):
         """
         Initialize commands
 
-        :param command_args: arguments of the command
-        :param global_args: arguments of the program
+        :param command_args: arguments from the CLI
         """
-        self.args = docopt(self.__doc__, argv=command_args)
-        self.global_args = global_args
+        self.args = args
         self.molecule = Molecule(self.args)
         self.molecule._command = self.__class__.__name__.lower()
         self.molecule.main()
-
     def execute(self):
         raise NotImplementedError
 
 
 class Create(AbstractCommand):
-    """
-    Create instances
-
-    Usage:
-        create [--platform=<platform>] [--provider=<provider>] [--debug]
-
-    Options:
-        --platform <platform>  specify a platform
-        --provider <provider>  specify a provider
-        --debug                get more detail
-    """
-
     def execute(self):
         """
         Creates all instances defined in molecule.yml.

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -41,6 +41,7 @@ class Molecule(object):
         self._env = os.environ.copy()
         self._args = args
         self._config = config.Config()
+        self._command = None
 
     def main(self):
         # load molecule defaults
@@ -50,7 +51,7 @@ class Molecule(object):
         self._config.merge_molecule_config_files()
 
         # init command doesn't need to load molecule.yml
-        if self._args['<command>'] == 'init':
+        if self._command == 'init':
             return  # exits program
 
         # merge in molecule.yml
@@ -71,10 +72,10 @@ class Molecule(object):
 
         self._env['VAGRANT_VAGRANTFILE'] = self._config.config['molecule']['vagrantfile_file']
 
-        if self._args['--tags']:
+        if '--tags' in self._args:
             self._env['MOLECULE_TAGS'] = self._args['--tags']
 
-        if self._args['--provider']:
+        if '--provider' in self._args and self._args['--provider']:
             if not [item
                     for item in self._config.config['vagrant']['providers']
                     if item['name'] == self._args['--provider']]:
@@ -86,7 +87,7 @@ class Molecule(object):
         else:
             self._env['VAGRANT_DEFAULT_PROVIDER'] = self._get_default_provider()
 
-        if self._args['--platform']:
+        if '--platform' in self._args and self._args['--platform']:
             if not [item
                     for item in self._config.config['vagrant']['platforms']
                     if item['name'] == self._args['--platform']]:
@@ -102,7 +103,7 @@ class Molecule(object):
 
         # updates instances config with full machine names
         self._config.populate_instance_names(self._env['MOLECULE_PLATFORM'])
-        if self._args['--debug']:
+        if '--debug' in self._args and self._args['--debug']:
             utilities.debug('RUNNING CONFIG', yaml.dump(self._config.config, default_flow_style=False, indent=2))
 
         self._write_state_file()
@@ -329,7 +330,7 @@ class Molecule(object):
         args = []
 
         # pull in values passed to molecule CLI
-        if self._args['--tags']:
+        if '--tags' in self._args:
             self._config.config['ansible']['tags'] = self._args['--tags']
 
         # pass supported --arg=value args

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -41,7 +41,6 @@ class Molecule(object):
         self._env = os.environ.copy()
         self._args = args
         self._config = config.Config()
-        self._command = None
 
     def main(self):
         # load molecule defaults
@@ -51,7 +50,7 @@ class Molecule(object):
         self._config.merge_molecule_config_files()
 
         # init command doesn't need to load molecule.yml
-        if self._command == 'init':
+        if self._args['init']:
             return  # exits program
 
         # merge in molecule.yml
@@ -72,10 +71,10 @@ class Molecule(object):
 
         self._env['VAGRANT_VAGRANTFILE'] = self._config.config['molecule']['vagrantfile_file']
 
-        if '--tags' in self._args:
+        if self._args['--tags']:
             self._env['MOLECULE_TAGS'] = self._args['--tags']
 
-        if '--provider' in self._args and self._args['--provider']:
+        if self._args['--provider']:
             if not [item
                     for item in self._config.config['vagrant']['providers']
                     if item['name'] == self._args['--provider']]:
@@ -87,7 +86,7 @@ class Molecule(object):
         else:
             self._env['VAGRANT_DEFAULT_PROVIDER'] = self._get_default_provider()
 
-        if '--platform' in self._args and self._args['--platform']:
+        if self._args['--platform']:
             if not [item
                     for item in self._config.config['vagrant']['platforms']
                     if item['name'] == self._args['--platform']]:
@@ -103,7 +102,7 @@ class Molecule(object):
 
         # updates instances config with full machine names
         self._config.populate_instance_names(self._env['MOLECULE_PLATFORM'])
-        if '--debug' in self._args and self._args['--debug']:
+        if self._args['--debug']:
             utilities.debug('RUNNING CONFIG', yaml.dump(self._config.config, default_flow_style=False, indent=2))
 
         self._write_state_file()

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -50,7 +50,7 @@ class Molecule(object):
         self._config.merge_molecule_config_files()
 
         # init command doesn't need to load molecule.yml
-        if self._args['init']:
+        if self._args['<command>'] == 'init':
             return  # exits program
 
         # merge in molecule.yml
@@ -329,7 +329,7 @@ class Molecule(object):
         args = []
 
         # pull in values passed to molecule CLI
-        if '--tags' in self._args:
+        if self._args['--tags']:
             self._config.config['ansible']['tags'] = self._args['--tags']
 
         # pass supported --arg=value args


### PR DESCRIPTION
This looks like a huge change, but it's mostly moving code around and removing duplication.  I was unable to use Remy's DocOpt pattern mentioned in #76 due to an unresolved DocOpt bug. However this work makes it very easy to switch to his pattern at a later time.

* Refactored commands.py to use a separate class for each command.

* No longer subclassing all commands for static inventory. Removed the redefinition of many methods.

* Cleaned up DocOpt spacing in cli.py to be consistent.