### PR TITLE
CIA-282: Remove hardcoded serverspec dir from rakefile template

### DIFF
--- a/molecule/core.py
+++ b/molecule/core.py
@@ -259,7 +259,8 @@ class Molecule(object):
         # rakefile
         kwargs = {
             'molecule_file': self._config.config['molecule']['molecule_file'],
-            'current_platform': self._env['MOLECULE_PLATFORM']
+            'current_platform': self._env['MOLECULE_PLATFORM'],
+            'serverspec_dir': self._config.config['molecule']['serverspec_dir']
         }
         utilities.write_template(self._config.config['molecule']['rakefile_template'],
                                  self._config.config['molecule']['rakefile_file'],

--- a/molecule/templates/rakefile.j2
+++ b/molecule/templates/rakefile.j2
@@ -28,12 +28,12 @@ namespace :serverspec do
   task all: instances_to_test.keys.map { |h| h }
   instances_to_test.each do |vm_name, instance|
     desc "Run serverspec on #{vm_name}"
-    pattern = ['spec/*_spec.rb', "spec/#{instance['name']}/*_spec.rb", "spec/hosts/#{instance['name']}/*_spec.rb"]
+    pattern = ['{{ serverspec_dir }}/*_spec.rb', "{{ serverspec_dir }}/#{instance['name']}/*_spec.rb", "{{ serverspec_dir }}/hosts/#{instance['name']}/*_spec.rb"]
 
     if instance.key?('ansible_groups') && instance['ansible_groups'].nil? == false
       instance['ansible_groups'].each do |group|
-        pattern << "spec/#{group}/*_spec.rb"
-        pattern << "spec/groups/#{group}/*_spec.rb"
+        pattern << "{{ serverspec_dir }}/#{group}/*_spec.rb"
+        pattern << "{{ serverspec_dir }}/groups/#{group}/*_spec.rb"
     end
 
     end


### PR DESCRIPTION
* Fixes #85.
* Passes serverspec_dir through to rakefile template and uses that config value.