### PR TITLE
CIA-283: Molecule init creates files with trailing whitespace

### DIFF
--- a/molecule/conf/defaults.yml
+++ b/molecule/conf/defaults.yml
@@ -58,6 +58,7 @@ molecule:
       name: trusty64
       box: trusty64
       box_url: https://vagrantcloud.com/ubuntu/boxes/trusty64/versions/14.04/providers/virtualbox.box
+      box_version: 0.1.0
     # templates to use when creating files during `molecule init`
     templates:
       molecule: molecule.yml.j2


### PR DESCRIPTION
* Addresses #84 
* Adds a default value to box_version for the `init` command so that the template isn't rendered with a trailing whitespace. Also avoids referencing an undefined variable.
* box_version is still commented out by default.
* The file meta/main.yml is still created with trailing whitespace that won't pass `molecule verify`. However, this file is created by the underlying call to `ansible-galaxy init`. At this time, we'd prefer not to overwrite that file with our own.