### PR TITLE
CIA-284: Dedicated class & tests for ansible-playbook

### DIFF
--- a/molecule/ansible_playbook.py
+++ b/molecule/ansible_playbook.py
@@ -28,7 +28,7 @@ from utilities import print_stdout
 
 
 class AnsiblePlaybook:
-    def __init__(self, args={}, _env=None, _out=print_stdout, _err=print_stderr):
+    def __init__(self, args, _env=None, _out=print_stdout, _err=print_stderr):
         """
         Sets up requirements for ansible-playbook
 
@@ -108,11 +108,17 @@ class AnsiblePlaybook:
         :param value: Value of argument to be added
         :return: None
         """
-        if not value:
-            self.cli.pop(name, None)
-            return
+        if value:
+            self.cli[name] = value
 
-        self.cli[name] = value
+    def remove_cli_arg(self, name):
+        """
+        Removes CLI argument
+
+        :param name: Key name of CLI argument to remove
+        :return: None
+        """
+        self.cli.pop(name, None)
 
     def add_env_arg(self, name, value):
         """
@@ -124,11 +130,21 @@ class AnsiblePlaybook:
         """
         self.env[name] = value
 
+    def remove_env_arg(self, name):
+        """
+        Removes environment argument
+
+        :param name: Key name of environment argument to remove
+        :return: None
+        """
+        self.env.pop(name, None)
+
     def execute(self):
         """
         Executes ansible-playbook
 
-        :return: sh stdout on success, else None
+        :return: sh.stdout on success, else None
+        :return: None
         """
         if self.ansible is None:
             self.bake()

--- a/molecule/ansible_playbook.py
+++ b/molecule/ansible_playbook.py
@@ -39,6 +39,7 @@ class AnsiblePlaybook:
         """
 
         self.cli = {}
+        self.cli_pos = []
         self.env = _env if _env else os.environ.copy()
         self.playbook = None
         self.ansible = None
@@ -60,7 +61,7 @@ class AnsiblePlaybook:
 
         :return: None
         """
-        self.ansible = sh.ansible_playbook.bake(self.playbook, _env=self.env, **self.cli)
+        self.ansible = sh.ansible_playbook.bake(self.playbook, *self.cli_pos, _env=self.env, **self.cli)
 
     def parse_arg(self, name, value):
         """
@@ -96,15 +97,16 @@ class AnsiblePlaybook:
         if not value:
             return
 
+        # verbose is weird, must be -vvvv not verbose=vvvv
+        if name == 'verbose':
+            self.cli_pos.append('-' + value)
+            return
+
         self.add_cli_arg(name, value)
 
-        ### make sure verbose: vvvv works as --verbose ###
-        # verbose is weird -vvvv
-        # if self._config.config['ansible']['verbose']:
-        #     args.append('-' + self._config.config['ansible']['verbose'])
-
     def add_cli_arg(self, name, value):
-        self.cli[name] = value
+        if value:
+            self.cli[name] = value
 
     def add_env_arg(self, name, value):
         self.env[name] = value

--- a/molecule/ansible_playbook.py
+++ b/molecule/ansible_playbook.py
@@ -1,0 +1,116 @@
+#  Copyright (c) 2015 Cisco Systems
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
+import os
+
+import sh
+
+import molecule.utilities as utilities
+
+
+class AnsiblePlaybook:
+    def __init__(self, args={}, _env=None, _out=utilities.print_stdout, _err=utilities.print_stderr):
+        """
+        Sets up requirements for ansible-playbook
+
+        :param args: Dictionary arguments to pass to ansible-playbook
+        :param _env: Environment dictionary to use. os.environ.copy() is used by default
+        :param _out: Function passed to sh for STDOUT
+        :param _err: Function passed to sh for STDERR
+
+        :return: None
+        """
+
+        self.cli = {}
+        self.env = _env if _env else os.environ.copy()
+        self.playbook = None
+        self.ansible = None
+
+        for k, v in args.iteritems():
+            self.parse_arg(k, v)
+
+        # these can be overridden with calls to add_env_arg()
+        self.add_env_arg('PYTHONUNBUFFERED', '1')
+        self.add_env_arg('ANSIBLE_FORCE_COLOR', 'true')
+
+        # these get passed through to sh, not ansible-playbook
+        self.add_cli_arg('_out', _out)
+        self.add_cli_arg('_err', _err)
+
+    def bake(self):
+        """
+        Bake ansible-playbook command so it's ready to execute.
+
+        :return: None
+        """
+        self.ansible = sh.ansible_playbook.bake(self.playbook, _env=self.env, **self.cli)
+
+    def parse_arg(self, name, value):
+        """
+        Sanitizes and adds CLI arguments to be passed to ansible-playbook
+
+        :param name: Name of CLI argument to be added
+        :param value: Value of CLI argument to be added
+        :return: None
+        """
+
+        if name == 'raw_env_vars':
+            for k, v in value.iteritems():
+                self.add_env_arg(k, v)
+            return
+
+        if name == 'host_key_checking':
+            self.add_env_arg('ANSIBLE_HOST_KEY_CHECKING', str(value).lower())
+            return
+
+        if name == 'raw_ssh_args':
+            self.add_env_arg('ANSIBLE_SSH_ARGS', ' '.join(value))
+            return
+
+        if name == 'config_file':
+            self.add_env_arg('ANSIBLE_CONFIG', value)
+            return
+
+        if name == 'playbook':
+            self.playbook = value
+            return
+
+        # don't pass False values to ansible-playbook
+        if not value:
+            return
+
+        self.add_cli_arg(name, value)
+
+        ### make sure verbose: vvvv works as --verbose ###
+        # verbose is weird -vvvv
+        # if self._config.config['ansible']['verbose']:
+        #     args.append('-' + self._config.config['ansible']['verbose'])
+
+    def add_cli_arg(self, name, value):
+        self.cli[name] = value
+
+    def add_env_arg(self, name, value):
+        self.env[name] = value
+
+    def execute(self):
+        if self.ansible is None:
+            self.bake()
+
+        self.ansible()

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -156,14 +156,14 @@ class Converge(AbstractCommand):
         if create_inventory:
             self.molecule._create_inventory_file()
 
-        ansible = AnsiblePlaybook(args=self.molecule._config.config['ansible'])
+        ansible = AnsiblePlaybook(self.molecule._config.config['ansible'])
 
         # target tags passed in via CLI
         ansible.add_cli_arg('tags', self.molecule._args.get('--tags'))
 
         if idempotent:
-            ansible.add_cli_arg('_out', None)
-            ansible.add_cli_arg('_err', None)
+            ansible.remove_cli_arg('_out')
+            ansible.remove_cli_arg('_err')
             ansible.add_env_arg('ANSIBLE_NOCOLOR', 'true')
             ansible.add_env_arg('ANSIBLE_FORCE_COLOR', 'false')
 

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -168,7 +168,7 @@ class Converge(AbstractCommand):
             ansible.add_env_arg('ANSIBLE_FORCE_COLOR', 'false')
 
             # Save the previous callback plugin if any.
-            callback_plugin = ansible.env.get('ANSIBLE_CALLBACK_PLUGINS', '')
+            callback_plugin = ansible.env.get('ANSIBLE_CALLBACK_PLUGINS')
 
             # Set the idempotence plugin.
             if callback_plugin:

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -34,8 +34,8 @@ from jinja2 import PackageLoader
 
 import molecule.utilities as utilities
 import molecule.validators as validators
-from molecule.core import Molecule
 from molecule.ansible_playbook import AnsiblePlaybook
+from molecule.core import Molecule
 
 
 class AbstractCommand:

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -168,7 +168,7 @@ class Converge(AbstractCommand):
             ansible.add_env_arg('ANSIBLE_FORCE_COLOR', 'false')
 
             # Save the previous callback plugin if any.
-            callback_plugin = ansible.env.get('ANSIBLE_CALLBACK_PLUGINS')
+            callback_plugin = ansible.env.get('ANSIBLE_CALLBACK_PLUGINS', '')
 
             # Set the idempotence plugin.
             if callback_plugin:

--- a/tests/test_ansible_playbook.py
+++ b/tests/test_ansible_playbook.py
@@ -1,0 +1,115 @@
+#  Copyright (c) 2015 Cisco Systems
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
+import testtools
+
+from molecule.ansible_playbook import AnsiblePlaybook
+
+
+class TestConfig(testtools.TestCase):
+    def setUp(self):
+        super(TestConfig, self).setUp()
+
+        self.data = {
+            'playbook': 'playbook.yml',
+            'config_file': 'test.cfg',
+            'limit': 'all',
+            'verbose': 'vvvv',
+            'diff': True,
+            'host_key_checking': False,
+            'raw_ssh_args': [
+                '-o UserKnownHostsFile=/dev/null', '-o IdentitiesOnly=yes', '-o ControlMaster=auto',
+                '-o ControlPersist=60s'
+            ],
+            'raw_env_vars': {
+                'TEST_1': 'test_1'
+            }
+        }
+
+        self.ansible = AnsiblePlaybook(self.data)
+
+    def test_arg_loading(self):
+        # string value set
+        self.assertEqual(self.ansible.cli['limit'], self.data['limit'])
+
+        # true value set
+        self.assertEqual(self.ansible.cli['diff'], self.data['diff'])
+
+        # false values don't exist in arg dict at all
+        self.assertIsNone(self.ansible.cli.get('sudo_user'))
+
+    def test_parse_arg_special_cases(self):
+        # raw environment variables are set
+        self.assertIsNone(self.ansible.cli.get('raw_env_vars'))
+        self.assertEqual(self.ansible.env['TEST_1'], self.data['raw_env_vars']['TEST_1'])
+
+        # raw_ssh_args set
+        self.assertIsNone(self.ansible.cli.get('raw_ssh_args'))
+        self.assertEqual(self.ansible.env['ANSIBLE_SSH_ARGS'], ' '.join(self.data['raw_ssh_args']))
+
+        # host_key_checking gets set in environment as string 'false'
+        self.assertIsNone(self.ansible.cli.get('host_key_checking'))
+        self.assertEqual(self.ansible.env['ANSIBLE_HOST_KEY_CHECKING'], 'false')
+
+        # config_file is set in environment
+        self.assertIsNone(self.ansible.cli.get('config_file'))
+        self.assertEqual(self.ansible.env['ANSIBLE_CONFIG'], self.data['config_file'])
+
+        # playbook is set as attribute
+        self.assertIsNone(self.ansible.cli.get('playbook'))
+        self.assertEqual(self.ansible.playbook, self.data['playbook'])
+
+        # verbose is set in the right place
+        self.assertIsNone(self.ansible.cli.get('verbose'))
+        self.assertIn('-' + self.data['verbose'], self.ansible.cli_pos)
+
+    def test_add_cli_arg(self):
+        # redefine a previously defined value
+        self.ansible.add_cli_arg('limit', 'test')
+        self.assertEqual(self.ansible.cli['limit'], 'test')
+
+        # add a new value
+        self.ansible.add_cli_arg('molecule_1', 'test')
+        self.assertEqual(self.ansible.cli['molecule_1'], 'test')
+
+        # values set as false shouldn't get added
+        self.ansible.add_cli_arg('molecule_2', None)
+        self.assertNotIn('molecule_2', self.ansible.cli)
+
+    def test_remove_cli_arg(self):
+        self.ansible.remove_cli_arg('limit')
+        self.assertNotIn('limit', self.ansible.cli)
+
+    def test_add_env_arg(self):
+        # redefine a previously defined value
+        self.ansible.add_env_arg('TEST_1', 'now')
+        self.assertEqual(self.ansible.env['TEST_1'], 'now')
+
+        # add a new value
+        self.ansible.add_env_arg('MOLECULE_1', 'test')
+        self.assertEqual(self.ansible.env['MOLECULE_1'], 'test')
+
+    def test_remove_env_arg(self):
+        self.ansible.remove_env_arg('TEST_1')
+        self.assertNotIn('TEST_1', self.ansible.env)
+
+    def test_bake(self):
+        self.ansible.bake()
+        self.assertIn('playbook.yml -vvvv --diff --limit=all', str(self.ansible.ansible))


### PR DESCRIPTION
* Created a dedicated AnsiblePlaybook class that captures all previous functionality in a cleaner, more concise manner.

* Updated commands to use new class rather than shell out to ansible-playbook directly.

* Removed unused creation of MOLECULE_TAGS environment variable.

* Moved _create_playbook_args out of core, all logic now contained within AnsiblePlaybook class.

* Added tests for all the new/moved things.