### PR TITLE
Vagrant halt/destroy needs a vagrantfile

### DIFF
--- a/molecule/provisioners.py
+++ b/molecule/provisioners.py
@@ -279,6 +279,7 @@ class VagrantProvisioner(BaseProvisioner):
         os.remove(self.m._config.config['molecule']['vagrantfile_file'])
 
     def halt(self):
+        self._write_vagrant_file()
         self._vagrant.halt()
 
     def status(self):


### PR DESCRIPTION
If a machine hasn't been created, and we call `molecule destroy`, an error will be produced since a vagrantfile isn't written. This becomes a problem with `molecule test` where typically the first command called is `destroy`, and often a VM hasn't been created yet.