### PR TITLE
Fix init command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,10 @@
 CHANGELOG for molecule
 ======================
+1.2.4
+----
+
+* Fixed a bug introduced in 1.2.3 preventing ``init`` from working.
+
 1.2.3
 ----
 

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -56,6 +56,10 @@ class AbstractCommand:
         else:
             self.molecule = molecule
 
+        # init doesn't need to load molecule files
+        if self.__class__.__name__ == 'Init':
+            return
+
         # assume static inventory if no vagrant config block is defined
         if self.molecule._provisioner is None:
             self.static = True


### PR DESCRIPTION
1.2.3 introduced a bug that prevents `init` from working properly.

The `init` command is generally not called in a directory where molecule.yml is present, since it's used to create a new role, so we have to bypass all the logic around loading config files. With the move of provisioners to its own class, one of these checks was missing.