### PR TITLE
Disable the vagrant-vbguest plugin if it's installed

### DIFF
--- a/molecule/templates/vagrantfile.j2
+++ b/molecule/templates/vagrantfile.j2
@@ -40,6 +40,10 @@ Vagrant.configure('2') do |config|
     vb.linked_clone = true if Vagrant::VERSION =~ /^1.8/
     {%- endif %}
   end
+  # This plugin tries to install packages before the system is registered.  Disable it.
+  if Vagrant.has_plugin?('vagrant-vbguest')
+    config.vbguest.auto_update = false
+  end
     {%- endif %}
     {%- if provider.type is defined and provider.type == 'openstack' and provider.name == current_provider %}
     {%- for pform in provider.platforms %}


### PR DESCRIPTION
This plugin is useful most of the time, but on RHEL VMs, it tries
to install packages before the system is registered.

Disable it.