### PR TITLE
CIA-347: Remove halt, use vagrant-triggers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,10 @@
 CHANGELOG for molecule
 ======================
+1.3.0
+----
+
+* Added very basic support for the vagrant-triggers plugin
+
 1.2.4
 ----
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ CHANGELOG for molecule
 1.3.0
 ----
 
-* Added very basic support for the vagrant-triggers plugin
+* Added very basic support for the vagrant-triggers plugin.
 
 1.2.4
 ----

--- a/docs/source/providers.rst
+++ b/docs/source/providers.rst
@@ -115,6 +115,12 @@ This example is far more extensive than you likely need and it demonstrates lots
             box: trusty64
             box_version: "~> 20151130.0.0"
             box_url: https://vagrantcloud.com/ubuntu/boxes/trusty64/versions/14.04/providers/virtualbox.box
+          - name: rhel-7
+            box: rhel/rhel-7
+            triggers:
+              - trigger: before
+                action: destroy
+                cmd: run_remote 'subscription-manager unregister'
 
         providers:
           - name: virtualbox
@@ -162,6 +168,8 @@ Other Notes
 * `private_key_path`, as with several other values, can be any valid Ruby because it will appear in the Vagrantfile that molecule will generate.
 
 * `box_version`, defaults to '=', can include an constraints like '<, >, >=, <=, ~.' as listed in the `Versioning`_ docs.
+
+* `triggers` enables very basic support for the vagrant-triggers plugin
 
 ..  _`configuration for vagrant-openstack-provider`: https://github.com/ggiamarchi/vagrant-openstack-provider/blob/master/README.md#configuration
 .. _`VirtualBox`: http://docs.vagrantup.com/v2/virtualbox/index.html

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -119,7 +119,6 @@ class Destroy(AbstractCommand):
 
         self.molecule._create_templates()
         try:
-            self.molecule._provisioner.halt()
             self.molecule._provisioner.destroy()
             self.molecule._state['default_platform'] = False
             self.molecule._state['default_provider'] = False

--- a/molecule/provisioners.py
+++ b/molecule/provisioners.py
@@ -139,14 +139,6 @@ class BaseProvisioner(object):
         return
 
     @abc.abstractmethod
-    def halt(self):
-        """
-        Halts the VMs
-        :return:
-        """
-        return
-
-    @abc.abstractmethod
     def status(self):
         """
         Returns the running status of the VMs
@@ -274,13 +266,9 @@ class VagrantProvisioner(BaseProvisioner):
         self._vagrant.up(no_provision)
 
     def destroy(self):
-        self._vagrant.halt()
+        self._write_vagrant_file()
         self._vagrant.destroy()
         os.remove(self.m._config.config['molecule']['vagrantfile_file'])
-
-    def halt(self):
-        self._write_vagrant_file()
-        self._vagrant.halt()
 
     def status(self):
         return self._vagrant.status()

--- a/molecule/provisioners.py
+++ b/molecule/provisioners.py
@@ -267,9 +267,8 @@ class VagrantProvisioner(BaseProvisioner):
 
     def destroy(self):
         self._write_vagrant_file()
-        for status in self._vagrant.status():
-            if status[1] == 'running':
-                self._vagrant.destroy(vm_name=status[0])
+        if self.m._state.get('created'):
+            self._vagrant.destroy()
 
         os.remove(self.m._config.config['molecule']['vagrantfile_file'])
 

--- a/molecule/provisioners.py
+++ b/molecule/provisioners.py
@@ -267,7 +267,10 @@ class VagrantProvisioner(BaseProvisioner):
 
     def destroy(self):
         self._write_vagrant_file()
-        self._vagrant.destroy()
+        for status in self._vagrant.status():
+            if status[1] == 'running':
+                self._vagrant.destroy(vm_name=status[0])
+
         os.remove(self.m._config.config['molecule']['vagrantfile_file'])
 
     def status(self):

--- a/molecule/templates/molecule.yml.j2
+++ b/molecule/templates/molecule.yml.j2
@@ -96,8 +96,13 @@ vagrant:
     - name: {{ config.molecule.init.platform.name }}
       box: {{ config.molecule.init.platform.box }}
       box_url: {{ config.molecule.init.platform.box_url }}
-      # Optional item, box_version - support for vagrant versioning
+      # Optional: box_version - support for vagrant versioning
       # box_version: {{ config.molecule.init.platform.box_version }}
+      # Optional: very basic support for vagrant-triggers plugin
+      # triggers:
+      #  - trigger: before
+      #    action: destroy
+      #    cmd: run_remote 'subscription-manager unregister'
 
   providers:
     - name: virtualbox

--- a/molecule/templates/vagrantfile.j2
+++ b/molecule/templates/vagrantfile.j2
@@ -24,6 +24,7 @@ Vagrant.configure('2') do |config|
   config.{{ line }}
     {%- endfor %}
   {%- endif %}
+
   {%- for provider in config.vagrant.providers %}
     {%- if provider.type is defined and provider.type == 'virtualbox' and provider.name == current_provider %}
   config.vm.provider :virtualbox do |vb|

--- a/molecule/templates/vagrantfile.j2
+++ b/molecule/templates/vagrantfile.j2
@@ -17,7 +17,13 @@ Vagrant.configure('2') do |config|
   config.{{ line }}
     {%- endfor %}
   {%- endif %}
-
+  {%- if 'triggers' in config.vagrant %}
+    {%- for trigger in config.vagrant.triggers %}
+  config.trigger.{{ trigger.trigger }} :{{ trigger.action }} do
+    {{ trigger.cmd }}
+  end
+    {%- endfor %}
+  {%- endif %}
   {%- for provider in config.vagrant.providers %}
     {%- if provider.type is defined and provider.type == 'virtualbox' and provider.name == current_provider %}
   config.vm.provider :virtualbox do |vb|

--- a/molecule/templates/vagrantfile.j2
+++ b/molecule/templates/vagrantfile.j2
@@ -9,19 +9,19 @@ Vagrant.configure('2') do |config|
       {%- if 'box_url' in platform and 'box_version' not in platform %}
   config.vm.box_url = '{{ platform.box_url }}'
       {%- endif %}
+      {%- if 'triggers' in platform %}
+        {%- for trigger in platform.triggers %}
+  config.trigger.{{ trigger.trigger }} :{{ trigger.action }} do
+    {{ trigger.cmd }}
+  end
+        {%- endfor %}
+      {%- endif %}
     {%- endif %}
   {%- endfor %}
 
   {%- if 'raw_config_args' in config.vagrant %}
     {%- for line in config.vagrant.raw_config_args %}
   config.{{ line }}
-    {%- endfor %}
-  {%- endif %}
-  {%- if 'triggers' in config.vagrant %}
-    {%- for trigger in config.vagrant.triggers %}
-  config.trigger.{{ trigger.trigger }} :{{ trigger.action }} do
-    {{ trigger.cmd }}
-  end
     {%- endfor %}
   {%- endif %}
   {%- for provider in config.vagrant.providers %}

--- a/molecule/templates/vagrantfile.j2
+++ b/molecule/templates/vagrantfile.j2
@@ -11,7 +11,7 @@ Vagrant.configure('2') do |config|
       {%- endif %}
       {%- if 'triggers' in platform %}
         {%- for trigger in platform.triggers %}
-  config.trigger.{{ trigger.trigger }} :{{ trigger.action }} do
+  config.trigger.{{ trigger.trigger }} :{{ trigger.action }}, :force => true do
     {{ trigger.cmd }}
   end
         {%- endfor %}


### PR DESCRIPTION
* Remove call to `vagrant halt` when doing a `molecule destroy`
* `molecule destroy` will no longer attempt to `vagrant destroy` instances not in the running state
* Added very basic support to default vagrantfile template for vagrant-triggers plugin
* This will be released as 1.3.0