### PR TITLE
_print_valid_platforms() throws stack trace

### DIFF
--- a/molecule/core.py
+++ b/molecule/core.py
@@ -68,10 +68,14 @@ class Molecule(object):
             self._provisioner = provisioners.get_provisioner(self)
         except provisioners.InvalidProviderSpecified:
             print("\n{}Invalid provider '{}'\n".format(Fore.RED, self._args['--provider'], Fore.RESET))
+            self._args['--provider'] = None
+            self._provisioner = provisioners.get_provisioner(self)
             self._print_valid_providers()
             sys.exit(1)
         except provisioners.InvalidPlatformSpecified:
             print("\n{}Invalid platform '{}'\n".format(Fore.RED, self._args['--platform'], Fore.RESET))
+            self._args['--platform'] = None
+            self._provisioner = provisioners.get_provisioner(self)
             self._print_valid_platforms()
             sys.exit(1)
 


### PR DESCRIPTION
When an invalid platform or provider are specified, an exception is raised which is then caught in core.py to print an error message and then prints valid platforms and providers. Those print methods require a valid instance of provisioners which isn't created if an exception is raised, so here we create it without the offending option to be used later.

Fixes #101 