### PR TITLE
Install vagrant-triggers plugin if it not installed

### DIFF
--- a/docs/source/providers.rst
+++ b/docs/source/providers.rst
@@ -169,7 +169,7 @@ Other Notes
 
 * `box_version`, defaults to '=', can include an constraints like '<, >, >=, <=, ~.' as listed in the `Versioning`_ docs.
 
-* `triggers` enables very basic support for the vagrant-triggers plugin
+* `triggers` enables very basic support for the vagrant-triggers plugin. During `molecule create`, if the plugin is not found it will be automatically installed.
 
 ..  _`configuration for vagrant-openstack-provider`: https://github.com/ggiamarchi/vagrant-openstack-provider/blob/master/README.md#configuration
 .. _`VirtualBox`: http://docs.vagrantup.com/v2/virtualbox/index.html

--- a/molecule/templates/vagrantfile.j2
+++ b/molecule/templates/vagrantfile.j2
@@ -1,3 +1,13 @@
+{%- for platform in config.vagrant.platforms %}
+  {%- if platform.name == current_platform %}
+    {%- if 'triggers' in platform %}
+unless Vagrant.has_plugin?('vagrant-triggers')
+  system "vagrant plugin install vagrant-triggers"
+  exec "vagrant #{ARGV.join' '}"
+end
+    {%- endif %}
+  {%- endif %}
+{%- endfor %}
 Vagrant.configure('2') do |config|
   config.cache.scope = 'machine' if Vagrant.has_plugin?('vagrant-cachier')
   {%- for platform in config.vagrant.platforms %}


### PR DESCRIPTION
Just a minor addition for #102 to automatically install vagrant-trigger plugin, it it has not been yet installed