### PR TITLE
Automatically install role dependencies

### DIFF
--- a/molecule/ansible_galaxy_install.py
+++ b/molecule/ansible_galaxy_install.py
@@ -1,0 +1,89 @@
+#  Copyright (c) 2015 Cisco Systems
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
+import os
+import sys
+
+import sh
+
+from utilities import print_stderr
+from utilities import print_stdout
+
+
+class AnsibleGalaxyInstall:
+    def __init__(self, requirements_file, _env=None, _out=print_stdout, _err=print_stderr):
+        """
+        Sets up requirements for ansible-galaxy
+
+        :param requirements_file: Path to requirements file for ansible-galaxy
+        :param _env: Environment dictionary to use. os.environ.copy() is used by default
+        :param _out: Function passed to sh for STDOUT
+        :param _err: Function passed to sh for STDERR
+        :return: None
+        """
+        self.env = _env if _env else os.environ.copy()
+        self.out = _out
+        self.err = _err
+        self.requirements_file = requirements_file
+        self.galaxy = None
+
+        # defaults can be redefined with call to add_env_arg() before baking
+        self.add_env_arg('PYTHONUNBUFFERED', '1')
+        self.add_env_arg('ANSIBLE_FORCE_COLOR', 'true')
+
+    def bake(self):
+        """
+        Bake ansible-galaxy command so it's ready to execute.
+
+        :return: None
+        """
+        self.galaxy = sh.ansible_galaxy.bake('install',
+                                             '-f',
+                                             '-r',
+                                             self.requirements_file,
+                                             _env=self.env,
+                                             _out=self.out,
+                                             _err=self.err)
+
+    def add_env_arg(self, name, value):
+        """
+        Adds argument to environment passed to ansible-galaxy
+
+        :param name: Name of argument to be added
+        :param value: Value of argument to be added
+        :return: None
+        """
+        self.env[name] = value
+
+    def execute(self):
+        """
+        Executes ansible-galaxy install
+
+        :return: sh.stdout on success, else None
+        :return: None
+        """
+        if self.galaxy is None:
+            self.bake()
+
+        try:
+            return self.galaxy().stdout
+        except sh.ErrorReturnCode as e:
+            print('ERROR: {}'.format(e))
+            sys.exit(e.exit_code)

--- a/molecule/ansible_playbook.py
+++ b/molecule/ansible_playbook.py
@@ -72,6 +72,10 @@ class AnsiblePlaybook:
         :param value: Value of argument to be added
         :return: None
         """
+        # skip `requirements_file` since it used by ansible-galaxy only
+        if name == 'requirements_file':
+            return
+
         if name == 'raw_env_vars':
             for k, v in value.iteritems():
                 self.add_env_arg(k, v)

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -174,8 +174,10 @@ class Molecule(object):
         :return: None
         """
         # ansible.cfg
+        kwargs = {'molecule_dir': self._config.config['molecule']['molecule_dir']}
         utilities.write_template(self._config.config['molecule']['ansible_config_template'],
-                                 self._config.config['molecule']['config_file'])
+                                 self._config.config['molecule']['config_file'],
+                                 kwargs=kwargs)
 
         # rakefile
         kwargs = {

--- a/molecule/templates/ansible.cfg.j2
+++ b/molecule/templates/ansible.cfg.j2
@@ -1,4 +1,4 @@
 [defaults]
 
-roles_path = ../
+roles_path = {{ molecule_dir }}/roles:../
 library    = library

--- a/molecule/templates/molecule.yml.j2
+++ b/molecule/templates/molecule.yml.j2
@@ -52,6 +52,9 @@
 #   # playbook to execute during `molecule converge`
 #   playbook: playbook.yml
 
+#   # install role dependencies from that file with `ansible-galaxy` during `molecule converge`
+#   requirements_file: requirements.yml
+
 #   # verbosity for ansible-playbook
 #   verbose: vvvv
 

--- a/tests/test_ansible_galaxy_install.py
+++ b/tests/test_ansible_galaxy_install.py
@@ -1,0 +1,42 @@
+#  Copyright (c) 2015 Cisco Systems
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
+import testtools
+
+from molecule.ansible_galaxy_install import AnsibleGalaxyInstall
+
+
+class TestConfig(testtools.TestCase):
+    def setUp(self):
+        super(TestConfig, self).setUp()
+
+        self.data = {
+            'config_file': 'test.cfg',
+            'requirements_file': 'requirements.yml'
+        }
+
+        self.galaxy_install = AnsibleGalaxyInstall(self.data['requirements_file'])
+
+    def test_requirements_file_loading(self):
+        self.assertEqual(self.galaxy_install.requirements_file, self.data['requirements_file'])
+
+    def test_add_env_arg(self):
+        self.galaxy_install.add_env_arg('MOLECULE_1', 'test')
+        self.assertEqual(self.galaxy_install.env['MOLECULE_1'], 'test')


### PR DESCRIPTION
This is PR for #71. 

The main goal is to simplify the testing of roles that have some dependencies. For the moment I'm using a simple wrapper around molecule to install extra roles with `ansible-galaxy`. But would like to use molecule only for that.

Changes in brief:

- update `ansible.cfg.j2` template to set `roles_path` to something like `.molecule/roles:../`
- add `requirements_file` option to `ansible` section of `molecule.yml`
- if `requirements_file` is set, then role dependencies will be automatically installed with `ansible-galaxy` during `molecule converge` to first directory specified in `roles_path`.