### PR TITLE
76/docopt subcommands

### DIFF
--- a/molecule/cli.py
+++ b/molecule/cli.py
@@ -53,7 +53,6 @@
 #     --debug                get more detail
 #     -m                     machine readable output
 # """
-
 """
 Usage:
     molecule [-hv] <command> [<args>...]
@@ -87,7 +86,7 @@ import molecule.commands
 class CLI(object):
     def main(self):
         args = docopt(__doc__, version=molecule.__version__, options_first=True)
-        command_name = args.pop('<command>').capitalize()
+        command_name = args.get('<command>').capitalize()
         command_args = {} if args.get('<args>') is None else args.pop('<args>')
 
         try:

--- a/molecule/cli.py
+++ b/molecule/cli.py
@@ -17,41 +17,62 @@
 #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
+# """
+# Usage:
+#     molecule create      [--platform=<platform>] [--provider=<provider>] [--debug]
+#     molecule converge    [--platform=<platform>] [--provider=<provider>] [--tags=<tag1,tag2>] [--debug]
+#     molecule idempotence [--platform=<platform>] [--provider=<provider>] [--debug]
+#     molecule test        [--platform=<platform>] [--provider=<provider>] [--debug]
+#     molecule verify      [--platform=<platform>] [--provider=<provider>] [--debug]
+#     molecule destroy     [--platform=<platform>] [--provider=<provider>] [--debug]
+#     molecule status      [--platform=<platform>] [--provider=<provider>] [--debug]
+#     molecule list        [--debug] [-m]
+#     molecule login <host>
+#     molecule init <role>
+#     molecule -v | --version
+#     molecule -h | --help
+
+# Commands:
+#     create       create instances
+#     converge     create and provision instances
+#     idempotence  converge and check the output for changes
+#     test         run a full test cycle: destroy, create, converge, idempotency-check, verify and destroy instances
+#     verify       create, provision and test instances
+#     destroy      destroy instances
+#     status       show status of instances
+#     list         show available platforms, providers
+#     login        connects to instance via SSH
+#     init         creates the directory structure and files for a new Ansible role compatible with molecule
+
+# Options:
+#     -h --help              shows this screen
+#     -v --version           shows the version
+#     --platform=<platform>  specify a platform
+#     --provider=<provider>  specify a provider
+#     --tags=<tag1,tag2>     comma separated list of ansible tags to target
+#     --debug                get more detail
+#     -m                     machine readable output
+# """
+
 """
 Usage:
-    molecule create      [--platform=<platform>] [--provider=<provider>] [--debug]
-    molecule converge    [--platform=<platform>] [--provider=<provider>] [--tags=<tag1,tag2>] [--debug]
-    molecule idempotence [--platform=<platform>] [--provider=<provider>] [--debug]
-    molecule test        [--platform=<platform>] [--provider=<provider>] [--debug]
-    molecule verify      [--platform=<platform>] [--provider=<provider>] [--debug]
-    molecule destroy     [--platform=<platform>] [--provider=<provider>] [--debug]
-    molecule status      [--platform=<platform>] [--provider=<provider>] [--debug]
-    molecule list        [--debug] [-m]
-    molecule login <host>
-    molecule init <role>
-    molecule -v | --version
-    molecule -h | --help
+    molecule [-hv] <command> [<args>...]
 
 Commands:
-    create       create instances
-    converge     create and provision instances
-    idempotence  converge and check the output for changes
-    test         run a full test cycle: destroy, create, converge, idempotency-check, verify and destroy instances
-    verify       create, provision and test instances
-    destroy      destroy instances
-    status       show status of instances
-    list         show available platforms, providers
-    login        connects to instance via SSH
-    init         creates the directory structure and files for a new Ansible role compatible with molecule
+    create        create instances
+    converge      create and provision instances
+    idempotence   converge and check the output for changes
+    test          run a full test cycle: destroy, create, converge, idempotency-check, verify and destroy instances
+    verify        create, provision and test instances
+    destroy       destroy instances
+    status        show status of instances
+    list          show available platforms, providers
+    login         connects to instance via SSH
+    init          creates the directory structure and files for a new Ansible role compatible with molecule
 
 Options:
-    -h --help              shows this screen
-    -v --version           shows the version
-    --platform=<platform>  specify a platform
-    --provider=<provider>  specify a provider
-    --tags=<tag1,tag2>     comma separated list of ansible tags to target
-    --debug                get more detail
-    -m                     machine readable output
+    -h --help     shows this screen
+    -v --version  shows the version
 """
 
 import sys
@@ -65,20 +86,16 @@ import molecule.commands
 
 class CLI(object):
     def main(self):
-        args = docopt(__doc__)
-        if args['--version']:
-            print(molecule.__version__)
-            sys.exit(0)
+        args = docopt(__doc__, version=molecule.__version__, options_first=True)
+        command_name = args.pop('<command>').capitalize()
+        command_args = {} if args.get('<args>') is None else args.pop('<args>')
 
-        commands = ['create', 'converge', 'idempotence', 'test', 'verify', 'destroy', 'status', 'list', 'login', 'init']
-        for command in commands:
-            if args[command]:
-                try:
-                    command_class = getattr(molecule.commands, command.capitalize())
-                except AttributeError:
-                    raise DocoptExit()
+        try:
+            command_class = getattr(molecule.commands, command_name)
+        except AttributeError:
+            raise DocoptExit()
 
-        c = command_class(args)
+        c = command_class(command_args, args)
         sys.exit(c.execute())
 
 

--- a/molecule/cli.py
+++ b/molecule/cli.py
@@ -17,42 +17,6 @@
 #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
-# """
-# Usage:
-#     molecule create      [--platform=<platform>] [--provider=<provider>] [--debug]
-#     molecule converge    [--platform=<platform>] [--provider=<provider>] [--tags=<tag1,tag2>] [--debug]
-#     molecule idempotence [--platform=<platform>] [--provider=<provider>] [--debug]
-#     molecule test        [--platform=<platform>] [--provider=<provider>] [--debug]
-#     molecule verify      [--platform=<platform>] [--provider=<provider>] [--debug]
-#     molecule destroy     [--platform=<platform>] [--provider=<provider>] [--debug]
-#     molecule status      [--platform=<platform>] [--provider=<provider>] [--debug]
-#     molecule list        [--debug] [-m]
-#     molecule login <host>
-#     molecule init <role>
-#     molecule -v | --version
-#     molecule -h | --help
-
-# Commands:
-#     create       create instances
-#     converge     create and provision instances
-#     idempotence  converge and check the output for changes
-#     test         run a full test cycle: destroy, create, converge, idempotency-check, verify and destroy instances
-#     verify       create, provision and test instances
-#     destroy      destroy instances
-#     status       show status of instances
-#     list         show available platforms, providers
-#     login        connects to instance via SSH
-#     init         creates the directory structure and files for a new Ansible role compatible with molecule
-
-# Options:
-#     -h --help              shows this screen
-#     -v --version           shows the version
-#     --platform=<platform>  specify a platform
-#     --provider=<provider>  specify a provider
-#     --tags=<tag1,tag2>     comma separated list of ansible tags to target
-#     --debug                get more detail
-#     -m                     machine readable output
-# """
 """
 Usage:
     molecule [-hv] <command> [<args>...]

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -159,12 +159,12 @@ class Converge(AbstractCommand):
     Provisions all instances defined in molecule.yml.
 
     Usage:
-        converge [--platform=<platform>] [--provider=<provider>] [--tags=<tag1,tag2>] [--debug]
+        converge [--platform=<platform>] [--provider=<provider>] [--tags=<tags>...] [--debug]
 
     Options:
         --platform=<platform>  specify a platform
         --provider=<provider>  specify a provider
-        --tags=<tag1,tag2>     comma separated list of ansible tags to target
+        --tags=<tags>          comma separated list of ansible tags to target
         --debug                get more detail
     """
 
@@ -203,7 +203,8 @@ class Converge(AbstractCommand):
         ansible = AnsiblePlaybook(self.molecule._config.config['ansible'])
 
         # target tags passed in via CLI
-        ansible.add_cli_arg('tags', self.molecule._args.get('--tags'))
+        if self.molecule._args.get('--tags'):
+            ansible.add_cli_arg('tags', self.molecule._args.pop('--tags'))
 
         if idempotent:
             ansible.remove_cli_arg('_out')

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -204,7 +204,7 @@ class Converge(AbstractCommand):
 
         # target tags passed in via CLI
         if self.molecule._args.get('--tags'):
-            ansible.add_cli_arg('tags', self.molecule._args.pop('--tags'))
+            ansible.add_cli_arg('tags', self.molecule._args['--tags'].pop(0))
 
         if idempotent:
             ansible.remove_cli_arg('_out')

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -159,12 +159,12 @@ class Converge(AbstractCommand):
     Provisions all instances defined in molecule.yml.
 
     Usage:
-        converge [--platform=<platform>] [--provider=<provider>] [--tags=<tags>...] [--debug]
+        converge [--platform=<platform>] [--provider=<provider>] [--tags=<tag1,tag2>] [--debug]
 
     Options:
         --platform=<platform>  specify a platform
         --provider=<provider>  specify a provider
-        --tags=<tags>          comma separated list of ansible tags to target
+        --tags=<tag1,tag2>     comma separated list of ansible tags to target
         --debug                get more detail
     """
 
@@ -203,8 +203,7 @@ class Converge(AbstractCommand):
         ansible = AnsiblePlaybook(self.molecule._config.config['ansible'])
 
         # target tags passed in via CLI
-        if self.molecule._args.get('--tags'):
-            ansible.add_cli_arg('tags', self.molecule._args['--tags'].pop(0))
+        ansible.add_cli_arg('tags', self.molecule._args.get('--tags'))
 
         if idempotent:
             ansible.remove_cli_arg('_out')

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -50,10 +50,12 @@ class AbstractCommand:
         :param molecule: molecule instance
         """
         self.args = docopt(self.__doc__, argv=command_args)
-        self.global_args = global_args
+        self.args['<command>'] = self.__class__.__name__.lower()
+        self.command_args = command_args
+
         self.static = False
 
-        # only create a molecule instance if one doesn't exist
+        # give us the option to reuse an existing molecule instance
         if not molecule:
             self.molecule = Molecule(self.args)
             self.molecule.main()
@@ -89,13 +91,19 @@ class AbstractCommand:
 
 
 class Create(AbstractCommand):
-    def execute(self):
-        """
-        Creates all instances defined in molecule.yml.
-        Creates all template files used by molecule, vagrant, ansible-playbook.
+    """
+    Creates all instances defined in molecule.yml.
 
-        :return: None
-        """
+    Usage:
+        create [--platform=<platform>] [--provider=<provider>] [--debug]
+
+    Options:
+        --platform=<platform>  specify a platform
+        --provider=<provider>  specify a provider
+        --debug                get more detail
+    """
+
+    def execute(self):
         if self.static:
             self.disabled('create')
 
@@ -110,9 +118,20 @@ class Create(AbstractCommand):
 
 
 class Destroy(AbstractCommand):
+    """
+    Destroys all instances created by molecule.
+
+    Usage:
+        destroy [--platform=<platform>] [--provider=<provider>] [--debug]
+
+    Options:
+        --platform=<platform>  specify a platform
+        --provider=<provider>  specify a provider
+        --debug                get more detail
+    """
+
     def execute(self):
         """
-        Halts and destroys all instances created by molecule.
         Removes template files.
         Clears state file of all info (default platform).
 
@@ -136,16 +155,26 @@ class Destroy(AbstractCommand):
 
 
 class Converge(AbstractCommand):
+    """
+    Provisions all instances defined in molecule.yml.
+
+    Usage:
+        converge [--platform=<platform>] [--provider=<provider>] [--tags=<tag1,tag2>] [--debug]
+
+    Options:
+        --platform=<platform>  specify a platform
+        --provider=<provider>  specify a provider
+        --tags=<tag1,tag2>     comma separated list of ansible tags to target
+        --debug                get more detail
+    """
+
     def execute(self, idempotent=False, create_instances=True, create_inventory=True):
         """
-        Provisions all instances using ansible-playbook.
-
         :param idempotent: Optionally provision servers quietly so output can be parsed for idempotence
         :param create_inventory: Toggle inventory creation
         :param create_instances: Toggle instance creation
         :return: Provisioning output
         """
-
         if self.molecule._state.get('created'):
             create_instances = False
 
@@ -157,7 +186,7 @@ class Converge(AbstractCommand):
             create_inventory = False
 
         if create_instances and not idempotent:
-            c = Create(self.args, self.molecule)
+            c = Create(self.command_args, self.args, self.molecule)
             c.execute()
 
         if create_inventory:
@@ -194,7 +223,7 @@ class Converge(AbstractCommand):
                                     os.path.join(sys.prefix, 'share/molecule/ansible/plugins/callback/idempotence'))
 
         ansible.bake()
-        if self.molecule._args['--debug']:
+        if self.molecule._args.get('--debug'):
             ansible_env = {k: v for (k, v) in ansible.env.items() if 'ANSIBLE' in k}
             other_env = {k: v for (k, v) in ansible.env.items() if 'ANSIBLE' not in k}
             utilities.debug('OTHER ENVIRONMENT', yaml.dump(other_env, default_flow_style=False, indent=2))
@@ -211,18 +240,25 @@ class Converge(AbstractCommand):
 
 
 class Idempotence(AbstractCommand):
-    def execute(self):
-        """
-        Provisions instances and parses output to determine idempotence
+    """
+    Provisions instances and parses output to determine idempotence.
 
-        :return: None
-        """
+    Usage:
+        idempotence [--platform=<platform>] [--provider=<provider>] [--debug]
+
+    Options:
+        --platform=<platform>  specify a platform
+        --provider=<provider>  specify a provide
+        --debug                get more detail
+    """
+
+    def execute(self):
         if self.static:
             self.disabled('idempotence')
 
         print('{}Idempotence test in progress (can take a few minutes)...{}'.format(Fore.CYAN, Fore.RESET))
 
-        c = Converge(self.args, self.molecule)
+        c = Converge(self.command_args, self.args, self.molecule)
         output = c.execute(idempotent=True)
         idempotent, changed_tasks = self.molecule._parse_provisioning_output(output)
 
@@ -245,15 +281,19 @@ class Idempotence(AbstractCommand):
 
 
 class Verify(AbstractCommand):
-    def execute(self):
-        """
-        Performs verification steps on running instances.
-        Checks files for trailing whitespace and newlines.
-        Runs testinfra against instances.
-        Runs serverspec against instances (also calls rubocop on spec files).
+    """
+    Performs verification steps on running instances.
 
-        :return: None if no tests are found, otherwise return code of underlying command
-        """
+    Usage:
+        verify [--platform=<platform>] [--provider=<provider>] [--debug]
+
+    Options:
+        --platform=<platform>  specify a platform
+        --provider=<provider>  specify a provider
+        --debug                get more detail
+    """
+
+    def execute(self):
         if self.static:
             self.disabled('verify')
 
@@ -275,7 +315,7 @@ class Verify(AbstractCommand):
         self.molecule._write_ssh_config()
         kwargs = {'env': self.molecule._env}
         kwargs['env']['PYTHONDONTWRITEBYTECODE'] = '1'
-        kwargs['debug'] = True if self.molecule._args['--debug'] else False
+        kwargs['debug'] = True if self.molecule._args.get('--debug') else False
 
         try:
             # testinfra
@@ -292,28 +332,41 @@ class Verify(AbstractCommand):
 
 
 class Test(AbstractCommand):
-    def execute(self):
-        """
-        Runs a series of commands (defined in config) against instances for a full test/verify run
+    """
+    Runs a series of commands (defined in config) against instances for a full test/verify run.
 
-        :return: None
-        """
+    Usage:
+        test [--platform=<platform>] [--provider=<provider>] [--debug]
+
+    Options:
+        --platform=<platform>  specify a platform
+        --provider=<provider>  specify a provider
+        --debug                get more detail
+    """
+
+    def execute(self):
         if self.static:
             self.disabled('test')
 
         for task in self.molecule._config.config['molecule']['test']['sequence']:
             command = getattr(sys.modules[__name__], task.capitalize())
-            c = command(self.args, self.molecule)
+            c = command(self.command_args, self.args)
             c.execute()
 
 
 class List(AbstractCommand):
-    def execute(self):
-        """
-        Prints a list of currently available platforms
+    """
+    Prints a list of currently available platforms
 
-        :return: None
-        """
+    Usage:
+        list [--debug] [-m]
+
+    Options:
+        --debug  get more detail
+        -m       machine readable output
+    """
+
+    def execute(self):
         if self.static:
             self.disabled('list')
 
@@ -322,18 +375,17 @@ class List(AbstractCommand):
 
 
 class Status(AbstractCommand):
+    """
+    Prints status of configured instances.
+
+    Usage:
+        status [--debug]
+
+    Options:
+        --debug  get more detail
+    """
+
     def execute(self):
-        """
-        Prints status of configured instances.
-
-        Usage:
-            status [--platform=<platform>] [--provider=<provider>] [--debug]
-
-        Options:
-            --platform=<platform>  specify a platform
-            --provider=<provider>  specify a provider
-            --debug                get more detail
-        """
         if self.static:
             self.disabled('status')
 
@@ -366,12 +418,14 @@ class Status(AbstractCommand):
 
 
 class Login(AbstractCommand):
-    def execute(self):
-        """
-        Initiates an interactive ssh session with a given instance name.
+    """
+    Initiates an interactive ssh session with the given host.
 
-        :return: None
-        """
+    Usage:
+        login <host>
+    """
+
+    def execute(self):
         if self.static:
             self.disabled('login')
 
@@ -396,12 +450,14 @@ class Login(AbstractCommand):
 
 
 class Init(AbstractCommand):
-    def execute(self):
-        """
-        Creates the scaffolding for a new role intended for use with molecule
+    """
+    Creates the scaffolding for a new role intended for use with molecule.
 
-        :return: None
-        """
+    Usage:
+        init <role>
+    """
+
+    def execute(self):
         role = self.molecule._args['<role>']
         role_path = os.path.join(os.curdir, role)
 

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -159,7 +159,7 @@ class Converge(AbstractCommand):
     Provisions all instances defined in molecule.yml.
 
     Usage:
-        converge [--platform=<platform>] [--provider=<provider>] [--tags=<tag1,tag2>] [--debug]
+        converge [--platform=<platform>] [--provider=<provider>] [--tags=<tag1,tag2>...] [--debug]
 
     Options:
         --platform=<platform>  specify a platform
@@ -203,7 +203,8 @@ class Converge(AbstractCommand):
         ansible = AnsiblePlaybook(self.molecule._config.config['ansible'])
 
         # target tags passed in via CLI
-        ansible.add_cli_arg('tags', self.molecule._args.get('--tags'))
+        if self.molecule._args.get('--tags'):
+            ansible.add_cli_arg('tags', self.molecule._args['--tags'].pop(0))
 
         if idempotent:
             ansible.remove_cli_arg('_out')

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -29,6 +29,7 @@ import prettytable
 import sh
 import yaml
 from colorama import Fore
+from docopt import docopt
 from jinja2 import Environment
 from jinja2 import PackageLoader
 
@@ -40,14 +41,16 @@ from molecule.core import Molecule
 
 
 class AbstractCommand:
-    def __init__(self, args, molecule=False):
+    def __init__(self, command_args, global_args, molecule=False):
         """
         Initialize commands
 
-        :param args: arguments from the CLI
+        :param command_args: arguments of the command
+        :param global_args: arguments from the CLI
         :param molecule: molecule instance
         """
-        self.args = args
+        self.args = docopt(self.__doc__, argv=command_args)
+        self.global_args = global_args
         self.static = False
 
         # only create a molecule instance if one doesn't exist
@@ -321,9 +324,15 @@ class List(AbstractCommand):
 class Status(AbstractCommand):
     def execute(self):
         """
-        Prints status of currently converged instances, similar to `vagrant status`
+        Prints status of configured instances.
 
-        :return: Return code of underlying command if there's an exception, otherwise None
+        Usage:
+            status [--platform=<platform>] [--provider=<provider>] [--debug]
+
+        Options:
+            --platform=<platform>  specify a platform
+            --provider=<provider>  specify a provider
+            --debug                get more detail
         """
         if self.static:
             self.disabled('status')

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -50,7 +50,7 @@ class Molecule(object):
         self._config.merge_molecule_config_files()
 
         # init command doesn't need to load molecule.yml
-        if self._args['<command>'] == 'init':
+        if self._args.get('<command>') == 'init':
             return  # exits program
 
         # merge in molecule.yml
@@ -69,11 +69,13 @@ class Molecule(object):
         except provisioners.InvalidProviderSpecified:
             print("\n{}Invalid provider '{}'\n".format(Fore.RED, self._args['--provider'], Fore.RESET))
             self._args['--provider'] = None
+            self._args['--platform'] = None
             self._provisioner = provisioners.get_provisioner(self)
             self._print_valid_providers()
             sys.exit(1)
         except provisioners.InvalidPlatformSpecified:
             print("\n{}Invalid platform '{}'\n".format(Fore.RED, self._args['--platform'], Fore.RESET))
+            self._args['--provider'] = None
             self._args['--platform'] = None
             self._provisioner = provisioners.get_provisioner(self)
             self._print_valid_platforms()
@@ -84,7 +86,7 @@ class Molecule(object):
 
         # updates instances config with full machine names
         self._config.populate_instance_names(self._env['MOLECULE_PLATFORM'])
-        if self._args['--debug']:
+        if self._args.get('--debug'):
             utilities.debug('RUNNING CONFIG', yaml.dump(self._config.config, default_flow_style=False, indent=2))
 
         self._write_state_file()

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -50,7 +50,7 @@ class Molecule(object):
         self._config.merge_molecule_config_files()
 
         # init command doesn't need to load molecule.yml
-        if self._args['init']:
+        if self._args['<command>'] == 'init':
             return  # exits program
 
         # merge in molecule.yml

--- a/molecule/provisioners.py
+++ b/molecule/provisioners.py
@@ -165,7 +165,7 @@ class VagrantProvisioner(BaseProvisioner):
         self._vagrant.env = molecule._env
 
     def _get_provider(self):
-        if self.m._args['--provider']:
+        if self.m._args.get('--provider'):
             if not [item
                     for item in self.m._config.config['vagrant']['providers']
                     if item['name'] == self.m._args['--provider']]:
@@ -178,7 +178,7 @@ class VagrantProvisioner(BaseProvisioner):
         return self.m._env['VAGRANT_DEFAULT_PROVIDER']
 
     def _get_platform(self):
-        if self.m._args['--platform']:
+        if self.m._args.get('--platform'):
             if not [item
                     for item in self.m._config.config['vagrant']['platforms']
                     if item['name'] == self.m._args['--platform']]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,7 +42,7 @@ class TestCLI(testtools.TestCase):
                 result = self.assertRaises(SystemExit, lambda: self._cli.main())
                 stdout = mocked_stdout.getvalue().strip()
 
-                self.assertEqual(result.code, 0)
+                self.assertEqual(result.code, None)
                 self.assertThat(stdout, MatchesRegex('^\d\.\d\.\d'))
 
     def test_cli_raises_usage_with_invalid_sub_command(self):


### PR DESCRIPTION
* Fully implements Remy's DocOpt subcommand pattern. Fixes #76.
* Simplifies CLI logic around allowed commands.
* Uses get() to access CLI args throughout since they're not longer guaranteed to be present.
* Fixed a bug where `molecule test --platform xxx` wouldn't preserve platform in state file throughout entire run.
* Fixed a bug where specifying an invalid platform and provider simultaneously would blow up with stack trace.
* Updated test to look for different SystemExit response code when using DocOpt's built-in --version.