### PR TITLE
VirtualBox: set all interfaces to promiscuous mode

### DIFF
--- a/molecule/templates/vagrantfile.j2
+++ b/molecule/templates/vagrantfile.j2
@@ -118,6 +118,10 @@ Vagrant.configure('2') do |config|
     c.vm.hostname = '{{ instance.vm_name }}'
     {%- for interface in instance.interfaces %}
     c.vm.network '{{ interface.network_name }}', type: '{{ interface.type }}', auto_config: {{ interface.auto_config|lower }}
+    # VBox disables promiscuous mode by default.  Enable it.
+    c.vm.provider :virtualbox do |vb|
+      vb.customize ['modifyvm', :id, "--nicpromisc{{ 1 + loop.index }}", 'allow-all']
+    end
     {%- endfor %}
     {%- if 'raw_config_args' in instance %}
       {%- for line in instance.raw_config_args %}


### PR DESCRIPTION
Promiscuous mode is blocked on VMs by default on VirtualBox; this
makes things not work as expected.  Enable promiscuous mode on all
private_network interfaces

Fixes Issue #114