### PR TITLE
added libvirt to the vagrantfile template

### DIFF
--- a/docs/source/providers.rst
+++ b/docs/source/providers.rst
@@ -179,3 +179,106 @@ Other Notes
 .. _`Volumes`: https://github.com/ggiamarchi/vagrant-openstack-provider/blob/master/README.md#volumes
 .. _`Stacks`: https://github.com/ggiamarchi/vagrant-openstack-provider/blob/master/README.md#orchestration-stacks
 .. _`Versioning`: https://docs.vagrantup.com/v2/boxes/versioning.html
+
+Libvirt
+---------
+
+The libvirt toolkit is known to work with the `vagrant-libvirt`_ provider plugin. But before installing this plugin you need to have libvirt installed(if you plan to run the tests on your local machine). Some users have reported dependency issues while installing vagrant-libvirt, so it is highly recommended to check `this section`_. You also need a vagrant compatible version installed on your machine(note that, not all versions are supported. Check the vagrant-libvirt documentation).
+
+
+You can install the vagrant-libvirt plugin with::
+
+      $ vagrant plugin install vagrant-libvirt
+
+.. _`vagrant-libvirt`: https://github.com/pradels/vagrant-libvirt
+
+
+.. _`this section`: https://github.com/pradels/vagrant-libvirt#possible-problems-with-plugin-installation-on-linux
+
+Molecule allows to specify `provider options`_ and `domain specific options`_  within the molecule.yml file, in the providers section.
+
+.. _`domain specific options`: https://github.com/pradels/vagrant-libvirt#domain-specific-options
+
+Provider options
+^^^^^^^^^^^^^^^^
+These options are described in the `provider options`_ section of the vagrant-libvirt project site:
+
+Although it should work without any configuration for most people, this provider exposes quite a few provider-specific configuration options. The following options allow you to configure how vagrant-libvirt connects to libvirt, and are used to generate the [libvirt connection URI](http://libvirt.org/uri.html):
+
+* `driver` - A hypervisor name to access. For now only kvm and qemu are supported.
+* `host` - The name of the server, where libvirtd is running. You want to use this option when creating the VM in a remote host.
+* `connect_via_ssh` - If use ssh tunnel to connect to Libvirt. Absolutely needed to access libvirt on remote host. It will not be able to get the IP address of a started VM otherwise.
+* `username` - Username and password to access Libvirt.
+* `password` - Password to access Libvirt.
+* `id_ssh_key_file` - If not nil, uses this ssh private key to access Libvirt. Default is $HOME/.ssh/id_rsa. Prepends $HOME/.ssh/ if no directory.
+* `socket` - Path to the libvirt unix socket (eg: /var/run/libvirt/libvirt-sock)
+* `uri` - For advanced usage. Directly specifies what libvirt connection URI vagrant-libvirt should use. Overrides all other connection configuration options.
+
+Connection-independent options:
+
+* `storage_pool_name` - Libvirt storage pool name, where box image and instance snapshots will be stored.
+
+.. _`provider options`: https://github.com/pradels/vagrant-libvirt#provider-options
+
+Here is an example of how could look like your molecule.yml file:
+
+.. code-block:: yaml
+
+Domain Specific Options
+^^^^^^^^^^^^^^^^^^^^^^^
+
+* `disk_bus` - The type of disk device to emulate. Defaults to virtio if not set. Possible values are documented in libvirt's [description for _target_](http://libvirt.org/formatdomain.html#elementsDisks).
+* `nic_model_type` - parameter specifies the model of the network adapter when you create a domain value by default virtio KVM believe possible values, see the [documentation for libvirt](https://libvirt.org/formatdomain.html#elementsNICSModel).
+* `memory` - Amount of memory in MBytes. Defaults to 512 if not set.
+* `cpus` - Number of virtual cpus. Defaults to 1 if not set.
+* `nested` - [Enable nested virtualization](https://github.com/torvalds/linux/blob/master/Documentation/virtual/kvm/nested-vmx.txt). Default is false.
+* `cpu_mode` - [CPU emulation mode](https://libvirt.org/formatdomain.html#elementsCPU). Defaults to 'host-model' if not set. Allowed values: host-model, host-passthrough.
+* `Other options` - Such as graphics_port, suspend_mode, boot, etc. Please, take a look at the `vagrant-libvirt`_ documentation for seeing all available options.
+
+Usage
+^^^^^
+
+All libvirt specific options(such as the one above, provider specific and domain options) must be specified in the providers section. Nevertheless, other options such as synced or network settings should be added to the raw_config_args, as they are vagrant generic parameters. Note that you can use special libvirt parameters such as "libvirt__tunnel_type", as it is shown in the example below.
+
+Please, refer to the `vagrant-libvirt`_ documentation for getting a better understanding of all available options.
+
+There is an example:
+
+.. code-block:: yaml
+
+	---
+	vagrant:
+
+	  platforms:
+	    - name: rhel6
+	      box: rhel/rhel-6
+	    - name: rhel7
+	      box: rhel/rhel-7
+	    - name: centos7
+	      box: centos/7
+
+	  providers:
+	    - name: libvirt
+	      type: libvirt
+	      options:
+		memory: 1024
+		cpus: 2
+		driver: kvm #Note that the two available drivers are kvm and qemu(refer to the vagrant-libvirt doc).
+		video_type: vga
+
+	  instances:
+	    - name: ansible-role
+	      raw_config_args:
+		- "ssh.pty = true"
+		- "vm.synced_folder './', '/vagrant', type: '9p', disabled: true"
+		- "vm.network :private_network, :libvirt__dhcp_enabled=> false ,:libvirt__tunnel_type => 'server', :libvirt__tunnel_port => '11111'"
+	      options:
+		append_platform_to_hostname: no
+
+	      ansible_groups:
+		- group_1
+
+Notes
+^^^^^
+
+* Molecule destroy does not seem to work well. It removes some molecule files but not always destroys de VM. You may have to do it manually by using the virsh command.

--- a/docs/source/providers.rst
+++ b/docs/source/providers.rst
@@ -203,7 +203,7 @@ Provider options
 ^^^^^^^^^^^^^^^^
 These options are described in the `provider options`_ section of the vagrant-libvirt project site:
 
-Although it should work without any configuration for most people, this provider exposes quite a few provider-specific configuration options. The following options allow you to configure how vagrant-libvirt connects to libvirt, and are used to generate the [libvirt connection URI](http://libvirt.org/uri.html):
+Although it should work without any configuration for most people, this provider exposes quite a few provider-specific configuration options. The following options allow you to configure how vagrant-libvirt connects to libvirt, and are used to generate the `libvirt connection URI`_:
 
 * `driver` - A hypervisor name to access. For now only kvm and qemu are supported.
 * `host` - The name of the server, where libvirtd is running. You want to use this option when creating the VM in a remote host.
@@ -219,6 +219,7 @@ Connection-independent options:
 * `storage_pool_name` - Libvirt storage pool name, where box image and instance snapshots will be stored.
 
 .. _`provider options`: https://github.com/pradels/vagrant-libvirt#provider-options
+.. _`libvirt connection URI`: http://libvirt.org/uri.html
 
 Here is an example of how could look like your molecule.yml file:
 
@@ -227,13 +228,18 @@ Here is an example of how could look like your molecule.yml file:
 Domain Specific Options
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-* `disk_bus` - The type of disk device to emulate. Defaults to virtio if not set. Possible values are documented in libvirt's [description for _target_](http://libvirt.org/formatdomain.html#elementsDisks).
-* `nic_model_type` - parameter specifies the model of the network adapter when you create a domain value by default virtio KVM believe possible values, see the [documentation for libvirt](https://libvirt.org/formatdomain.html#elementsNICSModel).
+* `disk_bus` - The type of `disk device`_ to emulate. Defaults to virtio if not set.
+* `nic_model_type` - parameter specifies the model of the network adapter when you create a domain value by default virtio KVM believe possible values, see the `nics documentation`_.
 * `memory` - Amount of memory in MBytes. Defaults to 512 if not set.
-* `cpus` - Number of virtual cpus. Defaults to 1 if not set.
-* `nested` - [Enable nested virtualization](https://github.com/torvalds/linux/blob/master/Documentation/virtual/kvm/nested-vmx.txt). Default is false.
-* `cpu_mode` - [CPU emulation mode](https://libvirt.org/formatdomain.html#elementsCPU). Defaults to 'host-model' if not set. Allowed values: host-model, host-passthrough.
+* `cpus` - Number of virtual cpus. Defaults to 2 if not set.
+* `nested` - `Enable nested virtualization`_. Default is false.
+* `cpu_mode` - `CPU emulation mode`_. Defaults to 'host-model' if not set. Allowed values: host-model, host-passthrough.
 * `Other options` - Such as graphics_port, suspend_mode, boot, etc. Please, take a look at the `vagrant-libvirt`_ documentation for seeing all available options.
+
+.. _`disk device`: http://libvirt.org/formatdomain.html#elementsDisks
+.. _`nics documentation`: https://libvirt.org/formatdomain.html#elementsNICSModel
+.. _`Enable nested virtualization`: https://github.com/torvalds/linux/blob/master/Documentation/virtual/kvm/nested-vmx.txt
+.. _`CPU emulation mode`: https://libvirt.org/formatdomain.html#elementsCPU
 
 Usage
 ^^^^^

--- a/docs/source/providers.rst
+++ b/docs/source/providers.rst
@@ -276,7 +276,7 @@ There is an example:
 	    - name: ansible-role
 	      raw_config_args:
 		- "ssh.pty = true"
-		- "vm.synced_folder './', '/vagrant', type: '9p', disabled: true"
+		- "vm.synced_folder './', '/vagrant', disabled: true"
 		- "vm.network :private_network, :libvirt__dhcp_enabled=> false ,:libvirt__tunnel_type => 'server', :libvirt__tunnel_port => '11111'"
 	      options:
 		append_platform_to_hostname: no
@@ -284,7 +284,3 @@ There is an example:
 	      ansible_groups:
 		- group_1
 
-Notes
-^^^^^
-
-* Molecule destroy does not seem to work well. It removes some molecule files but not always destroys de VM. You may have to do it manually by using the virsh command.

--- a/molecule/templates/vagrantfile.j2
+++ b/molecule/templates/vagrantfile.j2
@@ -1,3 +1,13 @@
+{%- for platform in config.vagrant.platforms %}
+  {%- if platform.name == current_platform %}
+    {%- if 'triggers' in platform %}
+unless Vagrant.has_plugin?('vagrant-triggers')
+  system "vagrant plugin install vagrant-triggers"
+  exec "vagrant #{ARGV.join' '}"
+end
+    {%- endif %}
+  {%- endif %}
+{%- endfor %}
 Vagrant.configure('2') do |config|
   config.cache.scope = 'machine' if Vagrant.has_plugin?('vagrant-cachier')
   {%- for platform in config.vagrant.platforms %}
@@ -6,14 +16,21 @@ Vagrant.configure('2') do |config|
       {%- if 'box_version' in platform %}
   config.vm.box_version = "{{ platform.box_version }}"
       {%- endif %}
-      {%- if 'box_url' in platform %}
+      {%- if 'box_url' in platform and 'box_version' not in platform %}
   config.vm.box_url = '{{ platform.box_url }}'
+      {%- endif %}
+      {%- if 'triggers' in platform %}
+        {%- for trigger in platform.triggers %}
+  config.trigger.{{ trigger.trigger }} :{{ trigger.action }}, :force => true do
+    {{ trigger.cmd }}
+  end
+        {%- endfor %}
       {%- endif %}
     {%- endif %}
   {%- endfor %}
 
-  {%- if 'raw_config_args' in config.molecule %}
-    {%- for line in config.molecule.raw_config_args %}
+  {%- if 'raw_config_args' in config.vagrant %}
+    {%- for line in config.vagrant.raw_config_args %}
   config.{{ line }}
     {%- endfor %}
   {%- endif %}
@@ -31,9 +48,13 @@ Vagrant.configure('2') do |config|
       {%- if not provider.options.cpus %}
     vb.cpus = 2
       {%- endif %}
+      {%- if not provider.options.linked_clone %}
+    vb.linked_clone = true if Vagrant::VERSION =~ /^1.8/
+      {%- endif %}
     {%- else %}
     vb.memory = 512
     vb.cpus = 2
+    vb.linked_clone = true if Vagrant::VERSION =~ /^1.8/
     {%- endif %}
   end
     {%- endif %}

--- a/molecule/templates/vagrantfile.j2
+++ b/molecule/templates/vagrantfile.j2
@@ -1,13 +1,3 @@
-{%- for platform in config.vagrant.platforms %}
-  {%- if platform.name == current_platform %}
-    {%- if 'triggers' in platform %}
-unless Vagrant.has_plugin?('vagrant-triggers')
-  system "vagrant plugin install vagrant-triggers"
-  exec "vagrant #{ARGV.join' '}"
-end
-    {%- endif %}
-  {%- endif %}
-{%- endfor %}
 Vagrant.configure('2') do |config|
   config.cache.scope = 'machine' if Vagrant.has_plugin?('vagrant-cachier')
   {%- for platform in config.vagrant.platforms %}
@@ -16,21 +6,14 @@ Vagrant.configure('2') do |config|
       {%- if 'box_version' in platform %}
   config.vm.box_version = "{{ platform.box_version }}"
       {%- endif %}
-      {%- if 'box_url' in platform and 'box_version' not in platform %}
+      {%- if 'box_url' in platform %}
   config.vm.box_url = '{{ platform.box_url }}'
-      {%- endif %}
-      {%- if 'triggers' in platform %}
-        {%- for trigger in platform.triggers %}
-  config.trigger.{{ trigger.trigger }} :{{ trigger.action }}, :force => true do
-    {{ trigger.cmd }}
-  end
-        {%- endfor %}
       {%- endif %}
     {%- endif %}
   {%- endfor %}
 
-  {%- if 'raw_config_args' in config.vagrant %}
-    {%- for line in config.vagrant.raw_config_args %}
+  {%- if 'raw_config_args' in config.molecule %}
+    {%- for line in config.molecule.raw_config_args %}
   config.{{ line }}
     {%- endfor %}
   {%- endif %}
@@ -48,13 +31,9 @@ Vagrant.configure('2') do |config|
       {%- if not provider.options.cpus %}
     vb.cpus = 2
       {%- endif %}
-      {%- if not provider.options.linked_clone %}
-    vb.linked_clone = true if Vagrant::VERSION =~ /^1.8/
-      {%- endif %}
     {%- else %}
     vb.memory = 512
     vb.cpus = 2
-    vb.linked_clone = true if Vagrant::VERSION =~ /^1.8/
     {%- endif %}
   end
     {%- endif %}
@@ -62,7 +41,11 @@ Vagrant.configure('2') do |config|
   config.vm.provider :libvirt do |libvirt|
     {%- if provider.options %}
       {%- for k, v in provider.options.iteritems()|sort %}
+      {%- if  v  is number %}  
     libvirt.{{ k }} = {{ v }}
+      {%- else %}
+    libvirt.{{ k }} = "{{ v }}"
+      {%- endif %}
       {%- endfor %}
       {%- if not provider.options.memory %}
     libvirt.memory = 512

--- a/molecule/templates/vagrantfile.j2
+++ b/molecule/templates/vagrantfile.j2
@@ -58,6 +58,24 @@ Vagrant.configure('2') do |config|
     {%- endif %}
   end
     {%- endif %}
+    {%- if provider.type is defined and provider.type == 'libvirt' and provider.name == current_provider %}
+  config.vm.provider :libvirt do |libvirt|
+    {%- if provider.options %}
+      {%- for k, v in provider.options.iteritems()|sort %}
+    libvirt.{{ k }} = {{ v }}
+      {%- endfor %}
+      {%- if not provider.options.memory %}
+    libvirt.memory = 512
+      {%- endif %}
+      {%- if not provider.options.cpus %}
+    libvirt.cpus = 2
+      {%- endif %}
+    {%- else %}
+    libvirt.memory = 512
+    libvirt.cpus = 2
+    {%- endif %}
+  end
+    {%- endif %}
     {%- if provider.type is defined and provider.type == 'openstack' and provider.name == current_provider %}
     {%- for pform in provider.platforms %}
       {%- if pform.name == current_platform and 'username' in pform %}


### PR DESCRIPTION
Hi. I am using libvirt as provider, and added this lines for being able to set and configure libvirt from the molecule.yml file. It is not a big deal, but including these lines I would save copying a specific template for libvirt to the molecule templates directory each time I install molecule(which is quite frequent) on my virtual environments.

Thank you.