### PR TITLE
Converge before create with tags

### DIFF
--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -99,7 +99,7 @@ class Create(AbstractCommand):
     Creates all instances defined in molecule.yml.
 
     Usage:
-        create [--platform=<platform>] [--provider=<provider>] [--debug]
+        create [--platform=<platform>] [--provider=<provider>] [--tags=<tag1,tag2>...] [--debug]
 
     Options:
         --platform=<platform>  specify a platform

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -99,7 +99,7 @@ class Create(AbstractCommand):
     Creates all instances defined in molecule.yml.
 
     Usage:
-        create [--platform=<platform>] [--provider=<provider>] [--tags=<tag1,tag2>...] [--debug]
+        create [--platform=<platform>] [--provider=<provider>] [--debug]
 
     Options:
         --platform=<platform>  specify a platform
@@ -190,7 +190,14 @@ class Converge(AbstractCommand):
             create_inventory = False
 
         if create_instances and not idempotent:
-            c = Create(self.command_args, self.args, self.molecule)
+            # remove args Create doesn't support
+            command_args = list(self.command_args)
+            args = dict(self.args)
+            pos = command_args.index('--tags')
+            del (command_args[pos:pos + 2])
+            del (args['--tags'])
+
+            c = Create(command_args, args, self.molecule)
             c.execute()
 
         if create_inventory:

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -191,10 +191,18 @@ class Converge(AbstractCommand):
 
         if create_instances and not idempotent:
             # remove args Create doesn't support
-            command_args = list(self.command_args)
+            command_args = []
+            skip_next = False
+            for item in self.command_args:
+                if skip_next:
+                    skip_next = False
+                    continue
+                if item.lower() == '--tags':
+                    skip_next = True
+                    continue
+                command_args.append(item)
+
             args = dict(self.args)
-            pos = command_args.index('--tags')
-            del (command_args[pos:pos + 2])
             del (args['--tags'])
 
             c = Create(command_args, args, self.molecule)


### PR DESCRIPTION
Because of how commands can call other commands, we need to be aware of how CLI args are also passed around. In this case, passing --tags to converge would fail because if it called create with that argument, DocOpt would error and exit.