### PR TITLE
Destroy flexibility for molecule test

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -137,7 +137,6 @@ Here is a commented example:
           - converge
           - idempotence
           - verify
-          - destroy
 
       init:
         # default platform to populate when doing `molecule init`
@@ -391,8 +390,13 @@ directory of your role.
   role compatible with molecule.
 * ``molecule test``: Runs a series of commands to create, verify and destroy instances.
 
-Note: The exact sequence of commands run during the ``test`` command can be configured
+The exact sequence of commands run during the ``test`` command can be configured
 in the `test['sequence']` config option.
+
+The ``test`` command supports a ``--destroy`` argument that will accept the values
+always, never, and passing. Use these to tune the behavior for various use cases.
+For example, ``--destroy=always`` might be useful when using molecule for CI/CD.
+
 
 Integration Testing
 --------------------

--- a/molecule/ansible_playbook.py
+++ b/molecule/ansible_playbook.py
@@ -145,18 +145,19 @@ class AnsiblePlaybook:
         """
         self.env.pop(name, None)
 
-    def execute(self):
+    def execute(self, exit=True):
         """
         Executes ansible-playbook
 
-        :return: sh.stdout on success, else None
-        :return: None
+        :returns: exit code if any, output of command as string
         """
         if self.ansible is None:
             self.bake()
 
         try:
-            return self.ansible().stdout
+            return None, self.ansible().stdout
         except sh.ErrorReturnCode as e:
             print('ERROR: {}'.format(e))
-            sys.exit(e.exit_code)
+            if exit:
+                sys.exit(e.exit_code)
+            return e.exit_code, None

--- a/molecule/ansible_playbook.py
+++ b/molecule/ansible_playbook.py
@@ -21,7 +21,6 @@
 from __future__ import print_function
 
 import os
-import sys
 
 import sh
 
@@ -145,7 +144,7 @@ class AnsiblePlaybook:
         """
         self.env.pop(name, None)
 
-    def execute(self, exit=True):
+    def execute(self, hide_errors=False):
         """
         Executes ansible-playbook
 
@@ -156,8 +155,8 @@ class AnsiblePlaybook:
 
         try:
             return None, self.ansible().stdout
-        except sh.ErrorReturnCode as e:
-            print('ERROR: {}'.format(e))
-            if exit:
-                sys.exit(e.exit_code)
+        except (sh.ErrorReturnCode, sh.ErrorReturnCode_2) as e:
+            if not hide_errors:
+                print('ERROR: {}'.format(e))
+
             return e.exit_code, None

--- a/molecule/cli.py
+++ b/molecule/cli.py
@@ -59,7 +59,7 @@ class CLI(object):
             raise DocoptExit()
 
         c = command_class(command_args, args)
-        sys.exit(c.execute())
+        sys.exit(c.execute()[0])
 
 
 def main():

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -121,8 +121,8 @@ class Create(AbstractCommand):
         except CalledProcessError as e:
             print('ERROR: {}'.format(e))
             if exit:
-                sys.exit(e.exit_code)
-            return e.exit_code, None
+                sys.exit(e.returncode)
+            return e.returncode, None
         return None, None
 
 
@@ -160,8 +160,8 @@ class Destroy(AbstractCommand):
         except CalledProcessError as e:
             print('ERROR: {}'.format(e))
             if exit:
-                sys.exit(e.exit_code)
-            return e.exit_code, None
+                sys.exit(e.returncode)
+            return e.returncode, None
         self.molecule._remove_templates()
         return None, None
 
@@ -465,7 +465,7 @@ class Status(AbstractCommand):
             status = self.molecule._provisioner.status()
         except CalledProcessError as e:
             print('ERROR: {}'.format(e))
-            return e.exit_code, None
+            return e.returncode, None
 
         x = prettytable.PrettyTable(['Name', 'State', 'Provider'])
         x.align = 'l'
@@ -590,7 +590,7 @@ class Init(AbstractCommand):
             sh.ansible_galaxy('init', role)
         except (CalledProcessError, sh.ErrorReturnCode_1) as e:
             print('ERROR: {}'.format(e))
-            sys.exit(e.exit_code)
+            sys.exit(e.returncode)
 
         self.clean_meta_main(role_path)
 

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -109,7 +109,7 @@ class Create(AbstractCommand):
         --debug                get more detail
     """
 
-    def execute(self):
+    def execute(self, exit=True):
         if self.static:
             self.disabled('create')
 
@@ -120,7 +120,9 @@ class Create(AbstractCommand):
             self.molecule._write_state_file()
         except CalledProcessError as e:
             print('ERROR: {}'.format(e))
-            sys.exit(e.returncode)
+            if exit:
+                sys.exit(e.returncode)
+            return e.returncode
 
 
 class Destroy(AbstractCommand):
@@ -136,7 +138,7 @@ class Destroy(AbstractCommand):
         --debug                get more detail
     """
 
-    def execute(self):
+    def execute(self, exit=True):
         """
         Removes template files.
         Clears state file of all info (default platform).
@@ -156,7 +158,9 @@ class Destroy(AbstractCommand):
             self.molecule._write_state_file()
         except CalledProcessError as e:
             print('ERROR: {}'.format(e))
-            sys.exit(e.returncode)
+            if exit:
+                sys.exit(e.returncode)
+            return e.returncode
         self.molecule._remove_templates()
 
 
@@ -174,7 +178,7 @@ class Converge(AbstractCommand):
         --debug                get more detail
     """
 
-    def execute(self, idempotent=False, create_instances=True, create_inventory=True):
+    def execute(self, idempotent=False, create_instances=True, create_inventory=True, exit=True):
         """
         :param idempotent: Optionally provision servers quietly so output can be parsed for idempotence
         :param create_inventory: Toggle inventory creation
@@ -274,7 +278,7 @@ class Idempotence(AbstractCommand):
         --debug                get more detail
     """
 
-    def execute(self):
+    def execute(self, exit=True):
         if self.static:
             self.disabled('idempotence')
 
@@ -300,7 +304,9 @@ class Idempotence(AbstractCommand):
                 "Therefore the failure details cannot be displayed."
 
             print('{}{}{}'.format(Fore.YELLOW, warning_msg, Fore.RESET))
-        sys.exit(1)
+        if exit:
+            sys.exit(1)
+        return 1
 
 
 class Verify(AbstractCommand):
@@ -316,7 +322,7 @@ class Verify(AbstractCommand):
         --debug                get more detail
     """
 
-    def execute(self):
+    def execute(self, exit=True):
         if self.static:
             self.disabled('verify')
 
@@ -367,7 +373,9 @@ class Verify(AbstractCommand):
                 print(msg.format(Fore.YELLOW, serverspec_dir, Fore.RESET))
         except sh.ErrorReturnCode as e:
             print('ERROR: {}'.format(e))
-            sys.exit(e.exit_code)
+            if exit:
+                sys.exit(e.exit_code)
+            return e.exit_code
 
 
 class Test(AbstractCommand):

--- a/molecule/conf/defaults.yml
+++ b/molecule/conf/defaults.yml
@@ -50,7 +50,6 @@ molecule:
       - converge
       - idempotence
       - verify
-      - destroy
 
   init:
     # default platform to populate when doing `molecule init`

--- a/molecule/templates/molecule.yml.j2
+++ b/molecule/templates/molecule.yml.j2
@@ -42,7 +42,6 @@
 #       - converge
 #       - idempotence
 #       - verify
-#       - destroy
 
 # configuration options for the internal call to ansible-playbook
 # ansible:

--- a/molecule/utilities.py
+++ b/molecule/utilities.py
@@ -74,7 +74,7 @@ def merge_dicts(a, b, raise_conflicts=False, path=None):
 
 def write_template(src, dest, kwargs={}, _module='molecule', _dir='templates'):
     """
-    Writes a file from a jinja2 template
+    Writes a file from a jinja2 template.
     :param src: the target template files to use
     :param dest: destination of the templatized file to be written
     :param kwargs: dictionary of arguments passed to jinja2 when rendering template
@@ -114,7 +114,7 @@ def write_file(filename, content):
 
 def format_instance_name(name, platform, instances):
     """
-    Takes an instance name and formats it according to options specified in the instance's config
+    Takes an instance name and formats it according to options specified in the instance's config.
     :param name: the name of the instance
     :param platform: the current molecule platform in use
     :param instances: the current molecule instances dict in use
@@ -143,6 +143,36 @@ def format_instance_name(name, platform, instances):
     # if we fall through, return the default name
     return name + '-' + platform
 
+def remove_args(command_args, args, kill):
+    """
+    Removes args so commands can be passed around easily.
+    :param command_args: list of command args from DocOpt
+    :param args: dict of arguments from DocOpt
+    :kill: list of args to remove from returned values
+    :return: pruned command_args list, pruned args dict
+    """
+
+    new_args = {}
+    new_command_args = []
+    skip_next = False
+
+    # remove killed command args and their adjacent items
+    for item in command_args:
+        if skip_next:
+            skip_next = False
+            continue
+        if item.lower() in kill:
+            skip_next = True
+            continue
+        new_command_args.append(item)
+
+    # remove killed command args
+    for k, v in new_args.iteritems():
+        if k not in kill:
+            new_args[k] = v
+
+    return new_command_args, new_args
+
 
 def print_stdout(line):
     """
@@ -166,7 +196,7 @@ def print_stderr(line):
 
 def debug(title, data):
     """
-    Prints colorized output for use when debugging portions of molecule
+    Prints colorized output for use when debugging portions of molecule.
     :param title: title of debug output
     :param data: data of debug output
     :return: None

--- a/molecule/utilities.py
+++ b/molecule/utilities.py
@@ -143,6 +143,7 @@ def format_instance_name(name, platform, instances):
     # if we fall through, return the default name
     return name + '-' + platform
 
+
 def remove_args(command_args, args, kill):
     """
     Removes args so commands can be passed around easily.
@@ -167,7 +168,7 @@ def remove_args(command_args, args, kill):
         new_command_args.append(item)
 
     # remove killed command args
-    for k, v in new_args.iteritems():
+    for k, v in args.iteritems():
         if k not in kill:
             new_args[k] = v
 

--- a/molecule/validators.py
+++ b/molecule/validators.py
@@ -31,7 +31,7 @@ from utilities import print_stderr
 from utilities import print_stdout
 
 
-def check_trailing_cruft(ignore_paths=[]):
+def check_trailing_cruft(ignore_paths=[], exit=True):
     """
     Recursively finds all files relative to CWD and checks them for trailing whitespace and newlines
 
@@ -72,17 +72,17 @@ def check_trailing_cruft(ignore_paths=[]):
         whitespace = trailing_whitespace(data)
 
         if newline:
-            error = '{}Trailing newline found at the end of {}{}'
+            error = '{}Trailing newline found at the end of {}{}\n'
             print(error.format(Fore.RED, filename, Fore.RESET))
             found_error = True
 
         if whitespace:
-            error = '{}Trailing whitespace found in {} on lines: {}{}'
+            error = '{}Trailing whitespace found in {} on lines: {}{}\n'
             lines = ', '.join(str(x) for x in whitespace)
             print(error.format(Fore.RED, filename, lines, Fore.RESET))
             found_error = True
 
-    if found_error:
+    if exit and found_error:
         sys.exit(1)
 
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -162,3 +162,12 @@ class TestUtilities(testtools.TestCase):
         expected = 'test-01-rhel-7'
         actual = utilities.format_instance_name('test-01', 'rhel-7', instances)
         self.assertEqual(expected, actual)
+
+    def test_remove_args(self):
+        test_list = ['tags', 'molecule1', 'platform', 'ubuntu', 'tags', 'molecule2']
+        test_dict = {'tags': 'molecule1', 'platform': 'ubuntu'}
+        expected_list = ['platform', 'ubuntu']
+        expected_dict = {'platform': 'ubuntu'}
+        actual_list, actual_dict = utilities.remove_args(test_list, test_dict, ['tags'])
+        self.assertEqual(actual_list, expected_list)
+        self.assertEqual(actual_dict, expected_dict)


### PR DESCRIPTION
* Fixes #109 
* Makes `molecule test` more flexible for CI/CD use by giving it destroy options
* Fixes an edge case where calling `molecule idempotence` on a playbook with errors would print a bunch of broken provisioning output. Now it exits gracefully.
* Makes argument sanitizing cleaner by moving it to a utility function (with test)
* Commands now have multiple return values for capturing exit_code and stdout.
* Commands can now optionally exit during execution error or return the exit status for handling elsewhere. Necessary for supporting commands called directly and programmatically during `molecule test`.