### PR TITLE
fix boolean to str

### DIFF
--- a/molecule/ansible_playbook.py
+++ b/molecule/ansible_playbook.py
@@ -100,8 +100,9 @@ class AnsiblePlaybook:
             return
 
         # verbose is weird, must be -vvvv not verbose=vvvv
+        # since it value is bool and only -vvv, -vvvv and --verbose work
         if name == 'verbose' and value:
-            self.cli_pos.append('-' + value)
+            self.cli_pos.append('-vvvv')
             return
 
         self.add_cli_arg(name, value)


### PR DESCRIPTION
https://github.com/metacloud/molecule/issues/134
and https://metacloud.jira.com/projects/ORBITAL/issues/ORBITAL-110
I deploy it at a openstack cluster in the SF lab see my gist

when I run "molecule test", i got the follow error:
```
(metamole) ZOCHAO-M-K06M:zohan zochao$ export -n  VAGRANT_OPENSTACK_LOG=debug
(metamole) ZOCHAO-M-K06M:zohan zochao$ molecule test
Bringing machine 'zohan-01' up with 'openstack' provider...
==> zohan-01: Finding flavor for server...
==> zohan-01: Finding image for server...
==> zohan-01: Finding network(s) for server...
==> zohan-01: Launching a server with the following settings...
==> zohan-01:  -- Tenant          : admin
==> zohan-01:  -- Name            : zohan-01
==> zohan-01:  -- Flavor          : m1.small
==> zohan-01:  -- FlavorRef       : 2
==> zohan-01:  -- Image           : ubuntu
==> zohan-01:  -- ImageRef        : befdf61f-9eb9-4304-aa09-6add8769bac9
==> zohan-01:  -- KeyPair         : omg_key2
==> zohan-01:  -- Network         : e895de35-30f7-4f38-8cb4-8aec7f9132b5
==> zohan-01: Waiting for the server to be built...
==> zohan-01: Waiting for SSH to become available...
ssh: connect to host 10.35.3.9 port 22: Connection refused
ssh: connect to host 10.35.3.9 port 22: Connection refused
ssh: connect to host 10.35.3.9 port 22: Connection refused
ssh: connect to host 10.35.3.9 port 22: Connection refused
ssh: connect to host 10.35.3.9 port 22: Connection refused
==> zohan-01: Waiting for SSH to become available...
ssh: connect to host 10.35.3.9 port 22: Connection refused
ssh: connect to host 10.35.3.9 port 22: Connection refused
ssh: connect to host 10.35.3.9 port 22: Connection refused
Connection to 10.35.3.9 closed.
==> zohan-01: The server is ready!
==> zohan-01: Rsyncing folder: /Users/zochao/metamole/ansible-systems/roles/zohan/ => /vagrant
==> zohan-01: Machine not provisioned because `--no-provision` is specified.
Traceback (most recent call last):
  File "/Users/zochao/.virtualenvs/metamole/bin/molecule", line 10, in <module>
    sys.exit(main())
  File "/Users/zochao/metamole/molecule/molecule/cli.py", line 66, in main
    CLI().main()
  File "/Users/zochao/metamole/molecule/molecule/cli.py", line 62, in main
    sys.exit(c.execute())
  File "/Users/zochao/metamole/molecule/molecule/commands.py", line 393, in execute
    c.execute()
  File "/Users/zochao/metamole/molecule/molecule/commands.py", line 224, in execute
    ansible = AnsiblePlaybook(self.molecule._config.config['ansible'])
  File "/Users/zochao/metamole/molecule/molecule/ansible_playbook.py", line 51, in __init__
    self.parse_arg(k, v)
  File "/Users/zochao/metamole/molecule/molecule/ansible_playbook.py", line 104, in parse_arg
    self.cli_pos.append('-' + value)
TypeError: cannot concatenate 'str' and 'bool' objects
```


since name = 'verbose' and value = True in this case.
also
```
  -v, --verbose         verbose mode (-vvv for more, -vvvv to enable
                        connection debugging)
```
