### PR TITLE
Make verbose option for ansible config block more flexible

### DIFF
--- a/docs/source/providers.rst
+++ b/docs/source/providers.rst
@@ -67,7 +67,7 @@ Simple Example
       ansible:
         playbook: playbook.yml
         sudo: True
-        verbose: True
+        verbose: vvvv
 
       vagrant:
         raw_config_args:
@@ -102,7 +102,7 @@ This example is far more extensive than you likely need and it demonstrates lots
         playbook: playbook.yml
         sudo: True
         sudo_user: False
-        verbose: True
+        verbose: vvvv
 
       vagrant:
         raw_config_args:

--- a/molecule/ansible_playbook.py
+++ b/molecule/ansible_playbook.py
@@ -101,6 +101,9 @@ class AnsiblePlaybook:
 
         # verbose is weird, must be -vvvv not verbose=vvvv
         if name == 'verbose' and value:
+            # for cases where someone passes in verbose: True
+            if value is True:
+                value = 'vvvv'
             self.cli_pos.append('-' + value)
             return
 


### PR DESCRIPTION
* Fixes documentation showing `verbose: True` which wasn't actually supported.
* Adds support for `verbose: True` and sets it to `vvvv`. Necessary for better clarity since we'll accept `verbose: False`.
* Fixes #134 