### PR TITLE
Config options for default_provider and default_platform

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -124,6 +124,14 @@ Here is a commented example:
       ansible_config_template: ansible.cfg.j2
       rakefile_template: rakefile.j2
 
+      # default provider to use when no --provider flag is specified
+      # comment this out to default to the first in the provider list
+      # default_provider: virtualbox
+
+      # default platform to use when no --platform flag is specified
+      # comment this out to default to the first in the platform list
+      # default_platform: rhel-7
+
       # ssh arguments passed to molecule login command
       raw_ssh_args:
         - -o StrictHostKeyChecking=no

--- a/molecule/conf/defaults.yml
+++ b/molecule/conf/defaults.yml
@@ -37,6 +37,14 @@ molecule:
   ansible_config_template: ansible.cfg.j2
   rakefile_template: rakefile.j2
 
+  # default provider to use when no --provider flag is specified
+  # comment this out to default to the first in the provider list
+  # default_provider: virtualbox
+
+  # default platform to use when no --platform flag is specified
+  # comment this out to default to the first in the platform list
+  # default_platform: rhel-7
+
   # ssh arguments passed to molecule login command
   raw_ssh_args:
     - -o StrictHostKeyChecking=no

--- a/molecule/provisioners.py
+++ b/molecule/provisioners.py
@@ -215,7 +215,10 @@ class VagrantProvisioner(BaseProvisioner):
         if self.m._config.config['vagrant'].get('providers') is None:
             return 'static'
 
-        default_provider = self.m._config.config['vagrant']['providers'][0]['name']
+        # take config's default_provider if specified, otherwise use the first in the provider list
+        default_provider = self.m._config.config['molecule'].get('default_provider')
+        if default_provider is None:
+            default_provider = self.m._config.config['vagrant']['providers'][0]['name']
 
         # default to first entry if no entry for provider exists or provider is false
         if not self.m._state.get('default_provider'):
@@ -233,7 +236,10 @@ class VagrantProvisioner(BaseProvisioner):
         if self.m._config.config['vagrant'].get('platforms') is None:
             return 'static'
 
-        default_platform = self.m._config.config['vagrant']['platforms'][0]['name']
+        # take config's default_platform if specified, otherwise use the first in the platform list
+        default_platform = self.m._config.config['molecule'].get('default_platform')
+        if default_platform is None:
+            default_platform = self.m._config.config['vagrant']['platforms'][0]['name']
 
         # default to first entry if no entry for platform exists or platform is false
         if not self.m._state.get('default_platform'):


### PR DESCRIPTION
These options are not required and are off by default, which will retain the existing behavior of picking the first platform and provider from the list. However, it's possible for users to override this behavior by specifying values in their `~/.config/molecule/config.yml`.