### PR TITLE
Ensure that Jinja2>=2.8 is installed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 colorama==0.3.6
 docopt==0.6.2
-Jinja2
+Jinja2>=2.8
 paramiko
 pbr
 pexpect==4.0.1


### PR DESCRIPTION
The `FileSystemLoader` class inside Jinja2 added the `followlinks` keyword argument in version 2.8. This keyword is being used in `molecule/utilities.py` and produces a runtime error when the system with Molecule installed has an older version of Jinja2 installed.

Resolves #149