### PR TITLE
Remove testinfra as dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ PrettyTable==0.7.2
 python-vagrant==0.5.10
 PyYAML==3.11
 sh==1.11
-testinfra

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,3 +5,4 @@ testtools
 tox
 wheel
 yapf
+testinfra

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,4 +5,3 @@ testtools
 tox
 wheel
 yapf
-testinfra


### PR DESCRIPTION
testinfra is not required to run molecule or its tests. It should not be a dependency. A suggested/recommended package on a package manager that support it may be.