### PR TITLE
Fix interface definitions in usage docs

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -314,10 +314,10 @@ simply be named vagrant-01 instead of vagrant-01-rhel-7.
             - network_name: private_network
               type: dhcp
               auto_config: true
-              auto_config: false
             - network_name: private_network
               type: static
               ip: 192.168.0.1
+              auto_config: true
           options:
             append_platform_to_hostname: no
           raw_config_args:


### PR DESCRIPTION
The usage documentation had `auto_config` listed twice for the first interface, and not at all for the second (which results in an error). I fixed the documentation, but it might also be worth looking into defaulting `auto_config` to `true` in the Vagrantfile template.