### PR TITLE
Run tests in parallel

### DIFF
--- a/molecule/validators.py
+++ b/molecule/validators.py
@@ -173,7 +173,8 @@ def testinfra(inventory, testinfra_dir, debug=False, env=None, out=print_stdout,
         'debug': debug,
         'ansible_inventory': inventory,
         'sudo': True,
-        'connection': 'ansible'
+        'connection': 'ansible',
+        'n': 3
     }
 
     if 'HOME' not in kwargs['_env']:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ paramiko
 pbr
 pexpect==4.0.1
 PrettyTable==0.7.2
+pytest-xdist
 python-vagrant==0.5.10
 PyYAML==3.11
 sh==1.11


### PR DESCRIPTION
Testinfra is fairly slow when using the ansible connection backend.
Parallel tests help some.  Although, I'm thinking there is some
fact gathering that is the culprit.