### PR TITLE
Vagrantfile Template Bug Fix

### DIFF
--- a/molecule/templates/vagrantfile.j2
+++ b/molecule/templates/vagrantfile.j2
@@ -40,8 +40,12 @@ Vagrant.configure('2') do |config|
     {%- if provider.type is defined and provider.type == 'virtualbox' and provider.name == current_provider %}
   config.vm.provider 'virtualbox' do |vb|
     {%- if provider.options %}
-      {%- for k, v in provider.options.iteritems()|sort %}
+      {%- for k, v in provider.options.iteritems() | sort %}
+        {%- if v == true or v == false %}
+    vb.{{ k }} = {{ v | lower }}
+        {%- else %}
     vb.{{ k }} = {{ v }}
+        {%- endif %}
       {%- endfor %}
       {%- if not provider.options.memory %}
     vb.memory = 512
@@ -49,7 +53,7 @@ Vagrant.configure('2') do |config|
       {%- if not provider.options.cpus %}
     vb.cpus = 2
       {%- endif %}
-      {%- if not provider.options.linked_clone %}
+      {%- if provider.options.linked_clone == none %}
     vb.linked_clone = true if Vagrant::VERSION =~ /^1.8/
       {%- endif %}
     {%- else %}


### PR DESCRIPTION
This PR addresses one bug fix and one improvement to the vagrantfile template. 
### Bug
When key values are specified under `provider.options` contains boolean values, the following error occurs

$> molecule create
There was an error loading a Vagrantfile. The file being loaded
and the error message are shown below. This is usually caused by
a syntax error.

Path: <provider config: virtualbox>
Line number: 7
Message: NameError: uninitialized constant False
ERROR: Command '['/usr/local/bin/vagrant', 'up', '--no-provision']' returned non-zero exit status 1

Eg:
```
  providers:
    - name: virtualbox
      type: virtualbox
      options:
        linked_clone: false
```

### Improvement
For the above example when the bug is fixed `vb.linked_clone` will be set twice as shown below
```
config.vm.provider 'virtualbox' do |vb|
    vb.cpus = 2
    vb.linked_clone = false
    vb.memory = 512
    vb.linked_clone = true if Vagrant::VERSION =~ /^1.8/
  end
```