### PR TITLE
Add support for group_vars

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -132,6 +132,9 @@ Here is a commented example:
       # comment this out to default to the first in the platform list
       # default_platform: rhel-7
 
+      # directory containing group_vars to use with ansible
+      # group_vars: ../../../inventory/my_az/group_vars/
+
       # ssh arguments passed to molecule login command
       raw_ssh_args:
         - -o StrictHostKeyChecking=no

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -80,6 +80,9 @@ class AbstractCommand:
         if self.molecule._provisioner.instances is None:
             self.static = True
 
+        # Add or update the group_vars if needed.
+        self.molecule._add_or_update_group_vars()
+
     def disabled(self, cmd):
         """
         Prints 'command disabled' message and exits program.

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -247,3 +247,29 @@ class Molecule(object):
         except IOError:
             print('{}WARNING: could not write inventory file {}{}'.format(
                 Fore.YELLOW, inventory_file, Fore.RESET))
+
+    def _add_or_update_group_vars(self):
+        """Creates or updates the symlink to group_vars if needed."""
+        SYMLINK_NAME = 'group_vars'
+        group_vars_target = self._config.config.get('molecule',
+                                                    {}).get('group_vars')
+        molecule_dir = self._config.config['molecule']['molecule_dir']
+        group_vars_link_path = os.path.join(molecule_dir, SYMLINK_NAME)
+
+        # Remove any previous symlink.
+        if os.path.lexists(group_vars_link_path):
+            os.unlink(group_vars_link_path)
+
+        # Do not create the symlink if nothing is specified in the config.
+        if not group_vars_target:
+            return
+
+        # Otherwise create the new symlink.
+        symlink = os.path.join(
+            os.path.abspath(molecule_dir), group_vars_target)
+        if not os.path.exists(symlink):
+            print(
+                'ERROR: the group_vars path {} does not exist. Check your configuration file'.format(
+                    group_vars_target))
+            sys.exit(1)
+        os.symlink(group_vars_target, group_vars_link_path)

--- a/molecule/templates/molecule.yml.j2
+++ b/molecule/templates/molecule.yml.j2
@@ -29,6 +29,9 @@
 #   ansible_config_template: ansible.cfg.j2
 #   rakefile_template: rakefile.j2
 
+#   # directory containing group_vars to use with ansible
+#   # group_vars: ../../../inventory/my_az/group_vars/
+
 #   # ssh arguments passed to `molecule login` command
 #   raw_ssh_args:
 #     - -o StrictHostKeyChecking=no


### PR DESCRIPTION
It happens that for testing some roles in a specific context, you want
to use group_vars instead of maintaining copies of the variables in the
molecule playbook.

This patch adds a configuration option in the molecule section allowing
you to specify the path of the group_vars to use.