### PR TITLE
Rubocop can't share kwargs with testinfra

### DIFF
--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -388,17 +388,21 @@ class Verify(AbstractCommand):
         ansible = AnsiblePlaybook(self.molecule._config.config['ansible'],
                                   _env=self.molecule._env)
 
-        kwargs = self.molecule._provisioner.testinfra_args
-        kwargs['env'] = ansible.env
-        kwargs['env']['PYTHONDONTWRITEBYTECODE'] = '1'
-        kwargs['debug'] = True if self.molecule._args.get('--debug') else False
+        testinfra_kwargs = self.molecule._provisioner.testinfra_args
+        serverspec_kwargs = self.molecule._provisioner.serverspec_args
+        testinfra_kwargs['env'] = ansible.env
+        testinfra_kwargs['env']['PYTHONDONTWRITEBYTECODE'] = '1'
+        testinfra_kwargs['debug'] = True if self.molecule._args.get(
+            '--debug') else False
+        serverspec_kwargs['env'] = testinfra_kwargs['env']
+        serverspec_kwargs['debug'] = testinfra_kwargs['debug']
 
         try:
             # testinfra
             if os.path.isdir(testinfra_dir):
                 msg = '\n{}Executing testinfra tests found in {}/.{}'
                 print(msg.format(Fore.MAGENTA, testinfra_dir, Fore.RESET))
-                validators.testinfra(testinfra_dir, **kwargs)
+                validators.testinfra(testinfra_dir, **testinfra_kwargs)
                 print()
             else:
                 msg = '{}No testinfra tests found in {}/.\n{}'
@@ -408,12 +412,12 @@ class Verify(AbstractCommand):
             if os.path.isdir(serverspec_dir):
                 msg = '{}Executing rubocop on *.rb files found in {}/.{}'
                 print(msg.format(Fore.MAGENTA, serverspec_dir, Fore.RESET))
-                validators.rubocop(serverspec_dir, **kwargs)
+                validators.rubocop(serverspec_dir, **serverspec_kwargs)
                 print()
 
                 msg = '{}Executing serverspec tests found in {}/.{}'
                 print(msg.format(Fore.MAGENTA, serverspec_dir, Fore.RESET))
-                validators.rake(rakefile, **kwargs)
+                validators.rake(rakefile, **serverspec_kwargs)
                 print()
             else:
                 msg = '{}No serverspec tests found in {}/.\n{}'

--- a/molecule/provisioners.py
+++ b/molecule/provisioners.py
@@ -193,7 +193,15 @@ class BaseProvisioner(object):
     @abc.abstractmethod
     def testinfra_args(self):
         """
-        Returns the kwards used when invoking the testinfra validator
+        Returns the kwargs used when invoking the testinfra validator
+        :return:
+        """
+        return
+
+    @abc.abstractmethod
+    def serverspec_args(self):
+        """
+        Returns the kwargs used when invoking the serverspec validator
         :return:
         """
         return
@@ -326,7 +334,6 @@ class VagrantProvisioner(BaseProvisioner):
     @property
     def testinfra_args(self):
         kwargs = {
-            'env': self.m._env,
             'sudo': True,
             'ansible-inventory':
             self.m._config.config['ansible']['inventory_file'],
@@ -335,6 +342,10 @@ class VagrantProvisioner(BaseProvisioner):
         }
 
         return kwargs
+
+    @property
+    def serverspec_args(self):
+        return dict()
 
     @property
     def ansible_connection_params(self):
@@ -469,6 +480,7 @@ class DockerProvisioner(BaseProvisioner):
             RUN bash -c 'if [ -x "$(command -v yum)" ]; then  yum update && yum install -y python sudo; fi'
 
             '''
+
             dockerfile = dockerfile.format(
                 container['registry'] + container['image'],
                 container['image_version'])
@@ -602,7 +614,6 @@ class DockerProvisioner(BaseProvisioner):
             hosts_string += container['name'] + ','
 
         kwargs = {
-            'env': self.m._env,
             'sudo': True,
             'connection': 'docker',
             'hosts': hosts_string.rstrip(','),
@@ -610,3 +621,7 @@ class DockerProvisioner(BaseProvisioner):
         }
 
         return kwargs
+
+    @property
+    def serverspec_args(self):
+        return dict()


### PR DESCRIPTION
* Gave rubocop/rake its own kwargs since it takes different options than testinfra
* Removed superfluous addition of env to testinfra kwargs since it's now set by ansible-playbook

At some point we should probably consider using a base class for validators to avoid inconsistent args between them.