### PR TITLE
Added sudo option for testinfra and some failure handling

### DIFF
--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -33,6 +33,7 @@ import prettytable
 import sh
 import yaml
 from docopt import docopt
+import glob
 
 import molecule.utilities as utilities
 import molecule.validators as validators
@@ -353,12 +354,13 @@ class Verify(AbstractCommand):
     Performs verification steps on running instances.
 
     Usage:
-        verify [--platform=<platform>] [--provider=<provider>] [--debug]
+        verify [--platform=<platform>] [--provider=<provider>] [--debug] [--sudo]
 
     Options:
         --platform=<platform>  specify a platform
         --provider=<provider>  specify a provider
         --debug                get more detail
+        --sudo                 runs tests with sudo
     """
 
     def execute(self, exit=True):
@@ -395,12 +397,14 @@ class Verify(AbstractCommand):
         testinfra_kwargs['env']['PYTHONDONTWRITEBYTECODE'] = '1'
         testinfra_kwargs['debug'] = True if self.molecule._args.get(
             '--debug') else False
+        testinfra_kwargs['sudo'] = True if self.molecule._args.get(
+            '--sudo') else False
         serverspec_kwargs['env'] = testinfra_kwargs['env']
         serverspec_kwargs['debug'] = testinfra_kwargs['debug']
 
         try:
             # testinfra
-            if os.path.isdir(testinfra_dir):
+            if len(glob.glob1(testinfra_dir, "test_*.py")) > 0:
                 msg = '\n{}Executing testinfra tests found in {}/.{}'
                 print(msg.format(colorama.Fore.MAGENTA, testinfra_dir,
                                  colorama.Fore.RESET))

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -442,26 +442,32 @@ class Test(AbstractCommand):
     Runs a series of commands (defined in config) against instances for a full test/verify run.
 
     Usage:
-        test [--platform=<platform>] [--provider=<provider>] [--destroy=<destroy>] [--debug]
+        test [--platform=<platform>] [--provider=<provider>] [--destroy=<destroy>] [--debug] [--sudo]
 
     Options:
         --platform=<platform>  specify a platform
         --provider=<provider>  specify a provider
         --destroy=<destroy>    destroy behavior (passing, always, never)
         --debug                get more detail
+        --sudo                 run tests with sudo
     """
 
     def execute(self):
         if self.static:
             self.disabled('test')
 
-        command_args, args = utilities.remove_args(self.command_args,
-                                                   self.args, ['--destroy'])
+        command_args, args = utilities.remove_args(
+            self.command_args, self.args, self.command_args)
 
         for task in self.molecule._config.config['molecule']['test'][
                 'sequence']:
             command = getattr(sys.modules[__name__], task.capitalize())
             c = command(command_args, args)
+
+            for argument in self.command_args:
+                if argument in c.args:
+                    c.args[argument] = self.args[argument]
+
             status, output = c.execute(exit=False)
 
         if self.args.get('--destroy') == 'always':

--- a/molecule/provisioners.py
+++ b/molecule/provisioners.py
@@ -19,13 +19,15 @@
 #  THE SOFTWARE.
 
 import abc
-import os
-import vagrant
-import docker
 import collections
 import json
+import os
+
+import colorama
+import docker
+import vagrant
 from io import BytesIO
-from colorama import Fore
+
 import utilities
 
 
@@ -495,34 +497,35 @@ class DockerProvisioner(BaseProvisioner):
 
             if tag_string not in available_images:
                 print '{} Building ansible compatible image ...'.format(
-                    Fore.YELLOW)
+                    colorama.Fore.YELLOW)
                 previous_line = ''
                 for line in self._docker.build(fileobj=f, tag=tag_string):
                     for line_split in line.split('\n'):
                         if len(line_split) > 0:
                             line = json.loads(line_split)
                             if 'stream' in line:
-                                print('{} {} {}'.format(Fore.LIGHTBLUE_EX,
-                                                        line['stream'],
-                                                        Fore.RESET))
+                                print('{} {} {}'.format(
+                                    colorama.Fore.LIGHTBLUE_EX, line['stream'],
+                                    colorama.Fore.RESET))
                             if 'errorDetail' in line:
                                 print('{} {} {}'.format(
-                                    Fore.LIGHTRED_EX,
+                                    colorama.Fore.LIGHTRED_EX,
                                     line['errorDetail']['message'],
-                                    Fore.RESET))
+                                    colorama.Fore.RESET))
                                 errors = True
                             if 'status' in line:
                                 if previous_line not in line['status']:
                                     print('{} {} ... {}'.format(
-                                        Fore.LIGHTYELLOW_EX, line['status'],
-                                        Fore.RESET))
+                                        colorama.Fore.LIGHTYELLOW_EX,
+                                        line['status'], colorama.Fore.RESET))
                                 previous_line = line['status']
 
                 if errors:
-                    print '{} Build failed for {}'.format(Fore.RED, tag_string)
+                    print '{} Build failed for {}'.format(colorama.Fore.RED,
+                                                          tag_string)
                     return
                 else:
-                    print '{} Finished building {}'.format(Fore.GREEN,
+                    print '{} Finished building {}'.format(colorama.Fore.GREEN,
                                                            tag_string)
 
     def up(self, no_provision=True):
@@ -531,8 +534,8 @@ class DockerProvisioner(BaseProvisioner):
         for container in self.instances:
             if (container['Created'] is not True):
                 print '{} Creating container {} with base image {}:{} ...'.format(
-                    Fore.YELLOW, container['name'], container['image'],
-                    container['image_version']),
+                    colorama.Fore.YELLOW, container['name'],
+                    container['image'], container['image_version']),
                 container = self._docker.create_container(
                     image=self.image_tag.format(container['image'],
                                                 container['image_version']),
@@ -543,22 +546,22 @@ class DockerProvisioner(BaseProvisioner):
                 self._docker.start(container=container.get('Id'))
                 container['Created'] = True
 
-                print '{} Container created.\n{}'.format(Fore.GREEN,
-                                                         Fore.RESET)
+                print '{} Container created.\n{}'.format(colorama.Fore.GREEN,
+                                                         colorama.Fore.RESET)
             else:
                 self._docker.start(container['name'])
-                print '{} Starting container {} ...'.format(Fore.GREEN,
-                                                            Fore.RESET)
+                print '{} Starting container {} ...'.format(
+                    colorama.Fore.GREEN, colorama.Fore.RESET)
 
     def destroy(self):
 
         for container in self.instances:
             if (container['Created']):
-                print '{} Stopping container {} ...'.format(Fore.YELLOW,
-                                                            container['name']),
+                print '{} Stopping container {} ...'.format(
+                    colorama.Fore.YELLOW, container['name']),
                 self._docker.stop(container['name'], timeout=0)
                 self._docker.remove_container(container['name'])
-                print '{} Removed container {}.\n'.format(Fore.GREEN,
+                print '{} Removed container {}.\n'.format(colorama.Fore.GREEN,
                                                           container['name'])
                 container['Created'] = False
 

--- a/molecule/templates/rakefile.j2
+++ b/molecule/templates/rakefile.j2
@@ -9,8 +9,13 @@ task spec: 'serverspec:all'
 task default: :spec
 
 env = YAML.load_file('{{ molecule_file }}')['vagrant']
-instances = env['instances']
 
+if env.nil?
+	puts "No vagrant instances defined. "
+	instances = {}
+else
+	instances = env['instances']
+end
 instances_to_test = {}
 instances.each do |instance|
   instance_name = instance['name']

--- a/molecule/utilities.py
+++ b/molecule/utilities.py
@@ -93,9 +93,9 @@ def write_template(src, dest, kwargs={}, _module='molecule', _dir='templates'):
         sys.exit(1)
 
     # look for template in filesystem, then molecule package
-    loader = jinja2.ChoiceLoader(
-        [jinja2.FileSystemLoader(path, followlinks=True),
-         jinja2.PackageLoader(_module, _dir)])
+    loader = jinja2.ChoiceLoader([jinja2.FileSystemLoader(path,
+                                                          followlinks=True),
+                                  jinja2.PackageLoader(_module, _dir)])
 
     env = jinja2.Environment(loader=loader)
     template = env.get_template(filename)


### PR DESCRIPTION
This is a small PR to address some small issues I had while working with molecule. 

- By default, testinfra will not run **without** sudo and the ```--sudo``` flag can be passed into ```molecule verify``` or ```molecule test``` to run testinfra with sudo. 

- Testinfra will no longer run if no test files were found (sometimes I didn't need any test and it isn't good for any CI system when it returns a failure code when it didn't actually fail)

- Added a conditional to the rakefile because if no vagrant instances are defined you get a null error. Wanted to give a clearer error message. 

- Moved the ```serverspec_arg``` and ```testinfra_arg``` to be properties in the base class (because they were implemented as properties in the non base classes. 

The reason I wanted to easily be able to toggle sudo is because if you run testinfra on a docker image that has ```Defaults requiretty``` in the ```/etc/sudoers``` file. You're out of luck - testinfra throws a tantrum because it doesn't allocate a pseudo tty. 