### PR TITLE
Do not specify command to run

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,7 +11,6 @@ and `Serverspec`_ or `Testinfra`_ to run tests.  Molecule uses an `Ansible`_
 
 Some of the UI was inspired by `Test Kitchen`_.
 
-
 Contents:
 
 .. toctree::

--- a/docs/source/provisioners.rst
+++ b/docs/source/provisioners.rst
@@ -7,14 +7,17 @@ Currently, Molecule supports two provisioners: Vagrant and Docker.
 The provisioner can set when using ``init`` command or through the
 ``molecule.yml`` file.
 
-
 Docker Provisioner
 ------------------
+
 The docker provisioner is compatible with any image
 that has python installed. Molecule will automatically install
 python for images with the yum or apt-get package tools. A new
 docker image will be built with the prefix molecule_local to separate it
 from the other images on your system.
+
+The image being used is responsible for implementing the command to execute
+on ``docker run``.
 
 Below is an example of a ``molecule.yml`` file using two containers ``foo-01`` and
 ``foo-02``. ``foo-01`` is running the latest image of ubuntu and ``foo-02`` is running
@@ -48,8 +51,6 @@ Docker Example
             image_version: latest
             registry: testhost:5323
 
-
-
 Vagrant Provisioner
 -------------------
 
@@ -68,6 +69,7 @@ The available parameters for vagrant instances are:
 
 Vagrant Instance Example
 ------------------------
+
 This is an example of a set of vagrant instance - for information on specifying the platform/
 provider, see :ref:`providers`.
 

--- a/molecule/provisioners.py
+++ b/molecule/provisioners.py
@@ -540,7 +540,6 @@ class DockerProvisioner(BaseProvisioner):
                     image=self.image_tag.format(container['image'],
                                                 container['image_version']),
                     tty=True,
-                    command='bash -c "sleep infinity"',
                     detach=False,
                     name=container['name'])
                 self._docker.start(container=container.get('Id'))


### PR DESCRIPTION
Require the container to supply the command to execute.
Nearly all Dockerfiles supply a command to execute, we shouldn't
supply our own.  This is particularly useful for images which
need to start an init daemon.

Fixes: #185