### PR TITLE
[Docker Provisioner] Added privileged flag

### DIFF
--- a/docs/source/provisioners.rst
+++ b/docs/source/provisioners.rst
@@ -29,6 +29,7 @@ The available params for docker containers are:
 * ``ansible_groups`` - groups the container belongs to in Ansible
 * ``image`` - name of the image
 * ``image_version`` - version of the image
+# ``privileged`` - whether or not to run the container in privileged mode
 * ``registry`` - **(OPTIONAL)** the registry to obtain the image
 
 Docker Example
@@ -44,6 +45,7 @@ Docker Example
           - group1
             image: ubuntu
             image_version: latest
+            privileged: True
           - name: foo-02
             ansible_groups:
               - group2

--- a/docs/source/provisioners.rst
+++ b/docs/source/provisioners.rst
@@ -29,7 +29,7 @@ The available params for docker containers are:
 * ``ansible_groups`` - groups the container belongs to in Ansible
 * ``image`` - name of the image
 * ``image_version`` - version of the image
-# ``privileged`` - whether or not to run the container in privileged mode
+# ``privileged`` - whether or not to run the container in privileged mode (boolean)
 * ``registry`` - **(OPTIONAL)** the registry to obtain the image
 
 Docker Example

--- a/molecule/provisioners.py
+++ b/molecule/provisioners.py
@@ -532,6 +532,13 @@ class DockerProvisioner(BaseProvisioner):
         self.build_image()
 
         for container in self.instances:
+
+            if 'privileged' not in container:
+                container['privileged'] = False
+
+            docker_host_config = self._docker.create_host_config(
+                privileged=container['privileged'])
+
             if (container['Created'] is not True):
                 print '{} Creating container {} with base image {}:{} ...'.format(
                     colorama.Fore.YELLOW, container['name'],
@@ -541,7 +548,8 @@ class DockerProvisioner(BaseProvisioner):
                                                 container['image_version']),
                     tty=True,
                     detach=False,
-                    name=container['name'])
+                    name=container['name'],
+                    host_config=docker_host_config)
                 self._docker.start(container=container.get('Id'))
                 container['Created'] = True
 


### PR DESCRIPTION
This PR simply adds the ability to run a specified container in privileged mode. 

In response to Issue #184 

To run a container in privileged mode, simply add the privileged flag. 

``` yaml
---
docker:
  containers:
    - name: foo-01
      ansible_groups:
        - group1
      image: ubuntu
      image_version: latest
      privileged: True
```