### PR TITLE
Test sequence will now 'fail fast' (#183 fix) 

### DIFF
--- a/molecule/ansible_galaxy_install.py
+++ b/molecule/ansible_galaxy_install.py
@@ -22,19 +22,18 @@ from __future__ import print_function
 
 import os
 import sys
-
 import sh
 
-from utilities import print_stderr
-from utilities import print_stdout
+from utilities import print_error
+from utilities import print_warning
 
 
 class AnsibleGalaxyInstall:
     def __init__(self,
                  requirements_file,
                  _env=None,
-                 _out=print_stdout,
-                 _err=print_stderr):
+                 _out=print_warning,
+                 _err=print_error):
         """
         Sets up requirements for ansible-galaxy
 
@@ -91,5 +90,5 @@ class AnsibleGalaxyInstall:
         try:
             return self.galaxy().stdout
         except sh.ErrorReturnCode as e:
-            print('ERROR: {}'.format(e))
+            print_error('ERROR: {}'.format(e))
             sys.exit(e.exit_code)

--- a/molecule/ansible_galaxy_install.py
+++ b/molecule/ansible_galaxy_install.py
@@ -24,16 +24,15 @@ import os
 import sys
 import sh
 
-from utilities import print_error
-from utilities import print_warning
+from utilities import logger
 
 
 class AnsibleGalaxyInstall:
     def __init__(self,
                  requirements_file,
                  _env=None,
-                 _out=print_warning,
-                 _err=print_error):
+                 _out=logger.warning,
+                 _err=logger.error):
         """
         Sets up requirements for ansible-galaxy
 
@@ -90,5 +89,5 @@ class AnsibleGalaxyInstall:
         try:
             return self.galaxy().stdout
         except sh.ErrorReturnCode as e:
-            print_error('ERROR: {}'.format(e))
+            logger.error('ERROR: {}'.format(e))
             sys.exit(e.exit_code)

--- a/molecule/ansible_playbook.py
+++ b/molecule/ansible_playbook.py
@@ -23,12 +23,15 @@ from __future__ import print_function
 import os
 import sh
 
-from utilities import print_error
-from utilities import print_warning
+from utilities import logger
 
 
 class AnsiblePlaybook:
-    def __init__(self, args, _env=None, _out=print_warning, _err=print_error):
+    def __init__(self,
+                 args,
+                 _env=None,
+                 _out=logger.warning,
+                 _err=logger.error):
         """
         Sets up requirements for ansible-playbook
 
@@ -162,6 +165,6 @@ class AnsiblePlaybook:
             return None, self.ansible().stdout
         except (sh.ErrorReturnCode, sh.ErrorReturnCode_2) as e:
             if not hide_errors:
-                print_error('ERROR: {}'.format(e))
+                logger.error('ERROR: {}'.format(e))
 
             return e.exit_code, None

--- a/molecule/ansible_playbook.py
+++ b/molecule/ansible_playbook.py
@@ -21,15 +21,14 @@
 from __future__ import print_function
 
 import os
-
 import sh
 
-from utilities import print_stderr
-from utilities import print_stdout
+from utilities import print_error
+from utilities import print_warning
 
 
 class AnsiblePlaybook:
-    def __init__(self, args, _env=None, _out=print_stdout, _err=print_stderr):
+    def __init__(self, args, _env=None, _out=print_warning, _err=print_error):
         """
         Sets up requirements for ansible-playbook
 
@@ -163,6 +162,6 @@ class AnsiblePlaybook:
             return None, self.ansible().stdout
         except (sh.ErrorReturnCode, sh.ErrorReturnCode_2) as e:
             if not hide_errors:
-                print('ERROR: {}'.format(e))
+                print_error('ERROR: {}'.format(e))
 
             return e.exit_code, None

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -22,7 +22,6 @@ from __future__ import print_function
 
 import os
 import sys
-
 import colorama
 import yaml
 
@@ -79,8 +78,8 @@ class Config(object):
 
         if not os.path.isfile(molecule_file):
             error = '\n{}Unable to find {}. Exiting.{}'
-            print(error.format(colorama.Fore.RED, self.config['molecule'][
-                'molecule_file'], colorama.Fore.RESET))
+            utilities.print_error(error.format(colorama.Fore.RED, self.config[
+                'molecule']['molecule_file'], colorama.Fore.RESET))
             sys.exit(1)
 
         with open(molecule_file, 'r') as env:
@@ -88,8 +87,8 @@ class Config(object):
                 molecule_yml = yaml.safe_load(env)
             except Exception as e:
                 error = "\n{}{} isn't properly formatted: {}{}"
-                print(error.format(colorama.Fore.RED, molecule_file, e,
-                                   colorama.Fore.RESET))
+                utilities.print_error(error.format(
+                    colorama.Fore.RED, molecule_file, e, colorama.Fore.RESET))
                 sys.exit(1)
 
             interim = utilities.merge_dicts(self.config, molecule_yml)

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -78,7 +78,7 @@ class Config(object):
 
         if not os.path.isfile(molecule_file):
             error = '\n{}Unable to find {}. Exiting.{}'
-            utilities.print_error(error.format(colorama.Fore.RED, self.config[
+            utilities.logger.error(error.format(colorama.Fore.RED, self.config[
                 'molecule']['molecule_file'], colorama.Fore.RESET))
             sys.exit(1)
 
@@ -87,7 +87,7 @@ class Config(object):
                 molecule_yml = yaml.safe_load(env)
             except Exception as e:
                 error = "\n{}{} isn't properly formatted: {}{}"
-                utilities.print_error(error.format(
+                utilities.logger.error(error.format(
                     colorama.Fore.RED, molecule_file, e, colorama.Fore.RESET))
                 sys.exit(1)
 

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -125,8 +125,8 @@ class Molecule(object):
             if ssh_config is None:
                 return
         except CalledProcessError as e:
-            utilities.print_error('ERROR: {}'.format(e))
-            utilities.print_error("Does your vagrant VM exist?")
+            utilities.logger.error('ERROR: {}'.format(e))
+            utilities.logger.error("Does your vagrant VM exist?")
             sys.exit(e.returncode)
         utilities.write_file(ssh_config, out)
 
@@ -260,7 +260,7 @@ class Molecule(object):
         try:
             utilities.write_file(inventory_file, inventory)
         except IOError:
-            utilities.print_warning(
+            utilities.logger.warning(
                 '{}WARNING: could not write inventory file {}{}'.format(
                     colorama.Fore.YELLOW, inventory_file, colorama.Fore.RESET))
 
@@ -284,7 +284,7 @@ class Molecule(object):
         symlink = os.path.join(
             os.path.abspath(molecule_dir), group_vars_target)
         if not os.path.exists(symlink):
-            utilities.print_error(
+            utilities.logger.error(
                 'ERROR: the group_vars path {} does not exist. Check your configuration file'.format(
                     group_vars_target))
 

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -125,8 +125,8 @@ class Molecule(object):
             if ssh_config is None:
                 return
         except CalledProcessError as e:
-            print('ERROR: {}'.format(e))
-            print("Does your vagrant VM exist?")
+            utilities.print_error('ERROR: {}'.format(e))
+            utilities.print_error("Does your vagrant VM exist?")
             sys.exit(e.returncode)
         utilities.write_file(ssh_config, out)
 
@@ -260,8 +260,9 @@ class Molecule(object):
         try:
             utilities.write_file(inventory_file, inventory)
         except IOError:
-            print('{}WARNING: could not write inventory file {}{}'.format(
-                colorama.Fore.YELLOW, inventory_file, colorama.Fore.RESET))
+            utilities.print_warning(
+                '{}WARNING: could not write inventory file {}{}'.format(
+                    colorama.Fore.YELLOW, inventory_file, colorama.Fore.RESET))
 
     def _add_or_update_group_vars(self):
         """Creates or updates the symlink to group_vars if needed."""
@@ -283,9 +284,10 @@ class Molecule(object):
         symlink = os.path.join(
             os.path.abspath(molecule_dir), group_vars_target)
         if not os.path.exists(symlink):
-            print(
+            utilities.print_error(
                 'ERROR: the group_vars path {} does not exist. Check your configuration file'.format(
                     group_vars_target))
+
             sys.exit(1)
         os.symlink(group_vars_target, group_vars_link_path)
 

--- a/molecule/provisioners.py
+++ b/molecule/provisioners.py
@@ -496,7 +496,7 @@ class DockerProvisioner(BaseProvisioner):
             errors = False
 
             if tag_string not in available_images:
-                utilities.print_warning(
+                utilities.logger.warning(
                     '{} Building ansible compatible image ...'.format(
                         colorama.Fore.YELLOW))
                 previous_line = ''
@@ -505,18 +505,18 @@ class DockerProvisioner(BaseProvisioner):
                         if len(line_split) > 0:
                             line = json.loads(line_split)
                             if 'stream' in line:
-                                utilities.print_warning('{} {} {}'.format(
+                                utilities.logger.warning('{} {} {}'.format(
                                     colorama.Fore.LIGHTBLUE_EX, line['stream'],
                                     colorama.Fore.RESET))
                             if 'errorDetail' in line:
-                                utilities.print_warning('{} {} {}'.format(
+                                utilities.logger.warning('{} {} {}'.format(
                                     colorama.Fore.LIGHTRED_EX, line[
                                         'errorDetail']['message'],
                                     colorama.Fore.RESET))
                                 errors = True
                             if 'status' in line:
                                 if previous_line not in line['status']:
-                                    utilities.print_warning(
+                                    utilities.logger.warning(
                                         '{} {} ... {}'.format(
                                             colorama.Fore.LIGHTYELLOW_EX, line[
                                                 'status'],
@@ -524,11 +524,11 @@ class DockerProvisioner(BaseProvisioner):
                                 previous_line = line['status']
 
                 if errors:
-                    utilities.print_error('{} Build failed for {}'.format(
+                    utilities.logger.error('{} Build failed for {}'.format(
                         colorama.Fore.RED, tag_string))
                     return
                 else:
-                    utilities.print_warning('{} Finished building {}'.format(
+                    utilities.logger.warning('{} Finished building {}'.format(
                         colorama.Fore.GREEN, tag_string))
 
     def up(self, no_provision=True):
@@ -543,7 +543,7 @@ class DockerProvisioner(BaseProvisioner):
                 privileged=container['privileged'])
 
             if (container['Created'] is not True):
-                utilities.print_warning(
+                utilities.logger.warning(
                     '{} Creating container {} with base image {}:{} ...'.format(
                         colorama.Fore.YELLOW, container['name'],
                         container['image'], container['image_version']), )
@@ -557,22 +557,22 @@ class DockerProvisioner(BaseProvisioner):
                 self._docker.start(container=container.get('Id'))
                 container['Created'] = True
 
-                utilities.print_warning('{} Container created.\n{}'.format(
+                utilities.logger.warning('{} Container created.\n{}'.format(
                     colorama.Fore.GREEN, colorama.Fore.RESET))
             else:
                 self._docker.start(container['name'])
-                utilities.print_warning('{} Starting container {} ...'.format(
+                utilities.logger.warning('{} Starting container {} ...'.format(
                     colorama.Fore.GREEN, colorama.Fore.RESET))
 
     def destroy(self):
 
         for container in self.instances:
             if (container['Created']):
-                utilities.print_warning('{} Stopping container {} ...'.format(
+                utilities.logger.warning('{} Stopping container {} ...'.format(
                     colorama.Fore.YELLOW, container['name']), )
                 self._docker.stop(container['name'], timeout=0)
                 self._docker.remove_container(container['name'])
-                utilities.print_warning('{} Removed container {}.\n'.format(
+                utilities.logger.warning('{} Removed container {}.\n'.format(
                     colorama.Fore.GREEN, container['name']))
                 container['Created'] = False
 

--- a/molecule/provisioners.py
+++ b/molecule/provisioners.py
@@ -496,28 +496,31 @@ class DockerProvisioner(BaseProvisioner):
             errors = False
 
             if tag_string not in available_images:
-                print '{} Building ansible compatible image ...'.format(
-                    colorama.Fore.YELLOW)
+                utilities.print_warning(
+                    '{} Building ansible compatible image ...'.format(
+                        colorama.Fore.YELLOW))
                 previous_line = ''
                 for line in self._docker.build(fileobj=f, tag=tag_string):
                     for line_split in line.split('\n'):
                         if len(line_split) > 0:
                             line = json.loads(line_split)
                             if 'stream' in line:
-                                print('{} {} {}'.format(
+                                utilities.print_warning('{} {} {}'.format(
                                     colorama.Fore.LIGHTBLUE_EX, line['stream'],
                                     colorama.Fore.RESET))
                             if 'errorDetail' in line:
-                                print('{} {} {}'.format(
-                                    colorama.Fore.LIGHTRED_EX,
-                                    line['errorDetail']['message'],
+                                utilities.print_warning('{} {} {}'.format(
+                                    colorama.Fore.LIGHTRED_EX, line[
+                                        'errorDetail']['message'],
                                     colorama.Fore.RESET))
                                 errors = True
                             if 'status' in line:
                                 if previous_line not in line['status']:
-                                    print('{} {} ... {}'.format(
-                                        colorama.Fore.LIGHTYELLOW_EX,
-                                        line['status'], colorama.Fore.RESET))
+                                    utilities.print_warning(
+                                        '{} {} ... {}'.format(
+                                            colorama.Fore.LIGHTYELLOW_EX, line[
+                                                'status'],
+                                            colorama.Fore.RESET))
                                 previous_line = line['status']
 
                 if errors:
@@ -525,8 +528,8 @@ class DockerProvisioner(BaseProvisioner):
                         colorama.Fore.RED, tag_string))
                     return
                 else:
-                    print '{} Finished building {}'.format(colorama.Fore.GREEN,
-                                                           tag_string)
+                    utilities.print_warning('{} Finished building {}'.format(
+                        colorama.Fore.GREEN, tag_string))
 
     def up(self, no_provision=True):
         self.build_image()
@@ -540,9 +543,10 @@ class DockerProvisioner(BaseProvisioner):
                 privileged=container['privileged'])
 
             if (container['Created'] is not True):
-                print '{} Creating container {} with base image {}:{} ...'.format(
-                    colorama.Fore.YELLOW, container['name'],
-                    container['image'], container['image_version']),
+                utilities.print_warning(
+                    '{} Creating container {} with base image {}:{} ...'.format(
+                        colorama.Fore.YELLOW, container['name'],
+                        container['image'], container['image_version']), )
                 container = self._docker.create_container(
                     image=self.image_tag.format(container['image'],
                                                 container['image_version']),
@@ -553,23 +557,23 @@ class DockerProvisioner(BaseProvisioner):
                 self._docker.start(container=container.get('Id'))
                 container['Created'] = True
 
-                print '{} Container created.\n{}'.format(colorama.Fore.GREEN,
-                                                         colorama.Fore.RESET)
+                utilities.print_warning('{} Container created.\n{}'.format(
+                    colorama.Fore.GREEN, colorama.Fore.RESET))
             else:
                 self._docker.start(container['name'])
-                print '{} Starting container {} ...'.format(
-                    colorama.Fore.GREEN, colorama.Fore.RESET)
+                utilities.print_warning('{} Starting container {} ...'.format(
+                    colorama.Fore.GREEN, colorama.Fore.RESET))
 
     def destroy(self):
 
         for container in self.instances:
             if (container['Created']):
-                print '{} Stopping container {} ...'.format(
-                    colorama.Fore.YELLOW, container['name']),
+                utilities.print_warning('{} Stopping container {} ...'.format(
+                    colorama.Fore.YELLOW, container['name']), )
                 self._docker.stop(container['name'], timeout=0)
                 self._docker.remove_container(container['name'])
-                print '{} Removed container {}.\n'.format(colorama.Fore.GREEN,
-                                                          container['name'])
+                utilities.print_warning('{} Removed container {}.\n'.format(
+                    colorama.Fore.GREEN, container['name']))
                 container['Created'] = False
 
     def status(self):

--- a/molecule/provisioners.py
+++ b/molecule/provisioners.py
@@ -521,8 +521,8 @@ class DockerProvisioner(BaseProvisioner):
                                 previous_line = line['status']
 
                 if errors:
-                    print '{} Build failed for {}'.format(colorama.Fore.RED,
-                                                          tag_string)
+                    utilities.print_error('{} Build failed for {}'.format(
+                        colorama.Fore.RED, tag_string))
                     return
                 else:
                     print '{} Finished building {}'.format(colorama.Fore.GREEN,

--- a/molecule/utilities.py
+++ b/molecule/utilities.py
@@ -29,8 +29,30 @@ import logging
 import colorama
 import jinja2
 
-log = logging.getLogger()
-log.addHandler(logging.NullHandler())
+
+class LogFilter(object):
+    def __init__(self, level):
+        self.__level = level
+
+    def filter(self, logRecord):
+        return logRecord.levelno <= self.__level
+
+
+logger = logging.getLogger(__name__)
+warn = logging.StreamHandler()
+warn.setLevel(logging.WARN)
+warn.addFilter(LogFilter(logging.WARN))
+warn.setFormatter(logging.Formatter('{}{} --> {}{} %(message)s'.format(
+    colorama.Style.BRIGHT, colorama.Fore.BLUE, colorama.Fore.RESET,
+    colorama.Style.RESET_ALL)))
+
+error = logging.StreamHandler()
+error.setLevel(logging.ERROR)
+error.setFormatter(logging.Formatter('{}{} --> {}{} %(message)s'.format(
+    colorama.Style.BRIGHT, colorama.Fore.RED, colorama.Fore.RESET,
+    colorama.Style.RESET_ALL)))
+logger.addHandler(error)
+logger.addHandler(warn)
 
 
 def merge_dicts(a, b, raise_conflicts=False, path=None):
@@ -93,7 +115,7 @@ def write_template(src, dest, kwargs={}, _module='molecule', _dir='templates'):
 
     # template file doesn't exist
     if path and not os.path.isfile(src):
-        log.error('\n{}Unable to locate template file: {}{}'.format(
+        logger.error('\n{}Unable to locate template file: {}{}'.format(
             colorama.Fore.RED, src, colorama.Fore.RESET))
         sys.exit(1)
 
@@ -189,7 +211,7 @@ def print_warning(line):
     :param line: what gets printed
     :return: None
     """
-    log.warning(line)
+    logger.warning(line)
 
 
 def print_error(line):
@@ -198,7 +220,7 @@ def print_error(line):
     :param line: what gets printed
     :return: None
     """
-    log.error(line)
+    logger.error(line)
 
 
 def debug(title, data):

--- a/molecule/utilities.py
+++ b/molecule/utilities.py
@@ -24,8 +24,13 @@ import copy
 import os
 import sys
 
+import logging
+
 import colorama
 import jinja2
+
+log = logging.getLogger()
+log.addHandler(logging.NullHandler())
 
 
 def merge_dicts(a, b, raise_conflicts=False, path=None):
@@ -88,7 +93,7 @@ def write_template(src, dest, kwargs={}, _module='molecule', _dir='templates'):
 
     # template file doesn't exist
     if path and not os.path.isfile(src):
-        print('\n{}Unable to locate template file: {}{}'.format(
+        log.error('\n{}Unable to locate template file: {}{}'.format(
             colorama.Fore.RED, src, colorama.Fore.RESET))
         sys.exit(1)
 
@@ -178,24 +183,22 @@ def remove_args(command_args, args, kill):
     return new_command_args, new_args
 
 
-def print_stdout(line):
+def print_warning(line):
     """
     Prints a line to stdout without a \n at the end.
     :param line: what gets printed
     :return: None
     """
-    print(line, file=sys.stdout, end='')
-    sys.stdout.flush()
+    log.warning(line)
 
 
-def print_stderr(line):
+def print_error(line):
     """
     Prints a line to stderr without a \n at the end.
     :param line: what gets printed
     :return: None
     """
-    print(line, file=sys.stderr, end='')
-    sys.stderr.flush()
+    log.error(line)
 
 
 def debug(title, data):

--- a/molecule/utilities.py
+++ b/molecule/utilities.py
@@ -205,24 +205,6 @@ def remove_args(command_args, args, kill):
     return new_command_args, new_args
 
 
-def print_warning(line):
-    """
-    Prints a line to stdout without a \n at the end.
-    :param line: what gets printed
-    :return: None
-    """
-    logger.warning(line)
-
-
-def print_error(line):
-    """
-    Prints a line to stderr without a \n at the end.
-    :param line: what gets printed
-    :return: None
-    """
-    logger.error(line)
-
-
 def debug(title, data):
     """
     Prints colorized output for use when debugging portions of molecule.

--- a/molecule/validators.py
+++ b/molecule/validators.py
@@ -185,8 +185,6 @@ def testinfra(testinfra_dir, env=None, debug=False, **kwargs):
     """
     kwargs['debug'] = debug
     kwargs['_env'] = env
-    kwargs['_out'] = print_stdout
-    kwargs['_err'] = print_stderr
 
     if 'HOME' not in kwargs['_env']:
         kwargs['_env']['HOME'] = os.path.expanduser('~')

--- a/molecule/validators.py
+++ b/molecule/validators.py
@@ -27,8 +27,8 @@ import re
 import colorama
 import sh
 
-from utilities import print_stderr
-from utilities import print_stdout
+from utilities import print_error
+from utilities import print_warning
 
 
 def check_trailing_cruft(ignore_paths=[], exit=True):
@@ -122,8 +122,8 @@ def rubocop(serverspec_dir,
             debug=False,
             env=os.environ.copy(),
             pattern='/**/*.rb',
-            out=print_stdout,
-            err=print_stderr):
+            out=print_warning,
+            err=print_error):
     """
     Runs rubocop against specified directory with specified pattern
 
@@ -147,8 +147,8 @@ def rubocop(serverspec_dir,
 def rake(rakefile,
          debug=False,
          env=os.environ.copy(),
-         out=print_stdout,
-         err=print_stderr):
+         out=print_warning,
+         err=print_error):
     """
     Runs rake with specified rakefile
 

--- a/molecule/validators.py
+++ b/molecule/validators.py
@@ -27,8 +27,7 @@ import re
 import colorama
 import sh
 
-from utilities import print_error
-from utilities import print_warning
+from utilities import logger
 
 
 def check_trailing_cruft(ignore_paths=[], exit=True):
@@ -75,15 +74,15 @@ def check_trailing_cruft(ignore_paths=[], exit=True):
 
         if newline:
             error = '{}Trailing newline found at the end of {}{}\n'
-            print(error.format(colorama.Fore.RED, filename,
-                               colorama.Fore.RESET))
+            logger.error(error.format(colorama.Fore.RED, filename,
+                                      colorama.Fore.RESET))
             found_error = True
 
         if whitespace:
             error = '{}Trailing whitespace found in {} on lines: {}{}\n'
             lines = ', '.join(str(x) for x in whitespace)
-            print(error.format(colorama.Fore.RED, filename, lines,
-                               colorama.Fore.RESET))
+            logger.error(error.format(colorama.Fore.RED, filename, lines,
+                                      colorama.Fore.RESET))
             found_error = True
 
     if exit and found_error:
@@ -122,8 +121,8 @@ def rubocop(serverspec_dir,
             debug=False,
             env=os.environ.copy(),
             pattern='/**/*.rb',
-            out=print_warning,
-            err=print_error):
+            out=logger.warning,
+            err=logger.error):
     """
     Runs rubocop against specified directory with specified pattern
 
@@ -147,8 +146,8 @@ def rubocop(serverspec_dir,
 def rake(rakefile,
          debug=False,
          env=os.environ.copy(),
-         out=print_warning,
-         err=print_error):
+         out=logger.warning,
+         err=logger.error):
     """
     Runs rake with specified rakefile
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -22,7 +22,6 @@ import binascii
 import os
 
 import testtools
-from mock import patch
 import molecule.utilities as utilities
 
 
@@ -128,16 +127,6 @@ class TestUtilities(testtools.TestCase):
         os.remove(tmp_file)
 
         self.assertEqual(data, contents)
-
-    def test_print_warning(self):
-        with patch('molecule.utilities.logger') as log_mock:
-            utilities.print_warning('test warning')
-            log_mock.warning.assert_called_with('test warning')
-
-    def test_print_error(self):
-        with patch('molecule.utilities.logger') as log_mock:
-            utilities.print_error('test error')
-            log_mock.error.assert_called_with('test error')
 
     def test_format_instance_name_00(self):
         instances = [{'name': 'test-01'}]

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -24,7 +24,6 @@ import StringIO
 
 import testtools
 from mock import patch
-
 import molecule.utilities as utilities
 
 
@@ -133,14 +132,14 @@ class TestUtilities(testtools.TestCase):
 
     def test_print_stdout(self):
         with patch('sys.stdout', StringIO.StringIO()) as mocked_stdout:
-            utilities.print_stdout('test stdout')
+            utilities.print_warning('test stdout')
             stdout = mocked_stdout.getvalue()
 
             self.assertEqual(stdout, 'test stdout')
 
     def test_print_stderr(self):
         with patch('sys.stderr', StringIO.StringIO()) as mocked_stderr:
-            utilities.print_stderr('test stderr')
+            utilities.print_error('test stderr')
             stderr = mocked_stderr.getvalue()
 
             self.assertEqual(stderr, 'test stderr')

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -20,7 +20,6 @@
 
 import binascii
 import os
-import StringIO
 
 import testtools
 from mock import patch
@@ -130,19 +129,15 @@ class TestUtilities(testtools.TestCase):
 
         self.assertEqual(data, contents)
 
-    def test_print_stdout(self):
-        with patch('sys.stdout', StringIO.StringIO()) as mocked_stdout:
-            utilities.print_warning('test stdout')
-            stdout = mocked_stdout.getvalue()
+    def test_print_warning(self):
+        with patch('molecule.utilities.logger') as log_mock:
+            utilities.print_warning('test warning')
+            log_mock.warning.assert_called_with('test warning')
 
-            self.assertEqual(stdout, 'test stdout')
-
-    def test_print_stderr(self):
-        with patch('sys.stderr', StringIO.StringIO()) as mocked_stderr:
-            utilities.print_error('test stderr')
-            stderr = mocked_stderr.getvalue()
-
-            self.assertEqual(stderr, 'test stderr')
+    def test_print_error(self):
+        with patch('molecule.utilities.logger') as log_mock:
+            utilities.print_error('test error')
+            log_mock.error.assert_called_with('test error')
 
     def test_format_instance_name_00(self):
         instances = [{'name': 'test-01'}]


### PR DESCRIPTION
This PR addresses #183 . If a step in the ```molecule test``` sequence failed that was not the ending step, the command could still return code ```0```. 

Simply put - this PR causes ```molecule test``` to abort if any sequence fails.  Also, I changed the error printing to go to stderr instead of std out in light of #180.