### PR TITLE
Initialize ansible roles in offline mode

### DIFF
--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -665,7 +665,7 @@ class Init(AbstractCommand):
     Creates the scaffolding for a new role intended for use with molecule.
 
     Usage:
-        init <role> [--docker]
+        init <role> [--docker] [--offline]
     """
 
     def clean_meta_main(self, role_path):
@@ -695,7 +695,10 @@ class Init(AbstractCommand):
             sys.exit(1)
 
         try:
-            sh.ansible_galaxy('init', role)
+            if self.molecule._args['--offline']:
+                sh.ansible_galaxy('init', '--offline', role)
+            else:
+                sh.ansible_galaxy('init', role)
         except (CalledProcessError, sh.ErrorReturnCode_1) as e:
             print('ERROR: {}'.format(e))
             sys.exit(e.returncode)

--- a/tox.ini
+++ b/tox.ini
@@ -16,11 +16,13 @@ commands =
     yapf -d -r molecule
 
 [testenv:docs]
+passenv = *
 deps=-rdocs-requirements.txt
 commands=
     python setup.py build_sphinx
 
 [testenv:py27]
+passenv = *
 deps =
     -rrequirements.txt
     -rtest-requirements.txt


### PR DESCRIPTION
At the moment, `molecule init` requires internet connection to create the scaffolding of an Ansible role.
I find it inconvenient. `ansible-galaxy` supports `--offline` option so we could make use of it.
This PR addresses this.

There are two changes in tox.ini which fixes some of the build failure issues(https://github.com/metacloud/molecule/issues/192)