### PR TITLE
Changed molecule status to display hosts by default.

### DIFF
--- a/assets/bash_completion/molecule.bash-completion.sh
+++ b/assets/bash_completion/molecule.bash-completion.sh
@@ -34,7 +34,7 @@ _molecule(){
   INIT_OPTIONS="--docker"
   LIST_OPTIONS="--debug -m"
   LOGIN_OPTIONS=""
-  STATUS_OPTIONS="-a --debug --hosts --platforms --porcelain --providers"
+  STATUS_OPTIONS="--debug --hosts --platforms --porcelain --providers"
   TEST_OPTIONS="--debug --platform --provider --tags --sudo"
   VERIFY_OPTIONS="--debug --platform --provider --tags --sudo"
 

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -519,10 +519,10 @@ class Status(AbstractCommand):
     Prints status of configured instances.
 
     Usage:
-        status [--debug][--porcelain] ([-a] [--platforms][--providers])
+        status [--debug][--porcelain] ([--hosts] [--platforms][--providers])
 
     Options:
-        -a              display all available items
+        --hosts         display the available hosts
         --debug         get more detail
         --platforms     display the available platforms
         --providers     display the available providers
@@ -532,6 +532,8 @@ class Status(AbstractCommand):
     def execute(self):
         if self.static:
             self.disabled('status')
+
+        display_all = True if len(sys.argv) < 3 else False
 
         # Check that an instance is created.
         if not self.molecule._state.get('created'):
@@ -550,29 +552,31 @@ class Status(AbstractCommand):
         # Display the results in procelain mode.
         porcelain = self.molecule._args['--porcelain']
 
-        # Prepare the table for the results.
-        headers = [] if porcelain else ['Name', 'State', 'Provider']
-        data = []
-
-        for item in status:
-            if item.state != 'not_created':
-                state = colorama.Fore.GREEN + item.state + colorama.Fore.RESET
-            else:
-                state = item.state
-
-            data.append([item.name, state, item.provider])
-
         # Display hosts information.
-        self.molecule._display_tabulate_data(data, headers=headers)
-        print()
+        if display_all or self.molecule._args['--hosts']:
+
+            # Prepare the table for the results.
+            headers = [] if porcelain else ['Name', 'State', 'Provider']
+            data = []
+
+            for item in status:
+                if item.state != 'not_created':
+                    state = colorama.Fore.GREEN + item.state + colorama.Fore.RESET
+                else:
+                    state = item.state
+
+                data.append([item.name, state, item.provider])
+
+            self.molecule._display_tabulate_data(data, headers=headers)
+            print()
 
         # Display the platforms.
-        if self.molecule._args['-a'] or self.molecule._args['--platforms']:
+        if display_all or self.molecule._args['--platforms']:
             self.molecule._print_valid_platforms(porcelain=porcelain)
             print()
 
         # Display the providers.
-        if self.molecule._args['-a'] or self.molecule._args['--providers']:
+        if display_all or self.molecule._args['--providers']:
             self.molecule._print_valid_providers(porcelain=porcelain)
 
         return None, None

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -522,18 +522,19 @@ class Status(AbstractCommand):
         status [--debug][--porcelain] ([--hosts] [--platforms][--providers])
 
     Options:
-        --hosts         display the available hosts
         --debug         get more detail
+        --porcelain     machine readable output
+        --hosts         display the available hosts
         --platforms     display the available platforms
         --providers     display the available providers
-        --porcelain     machine readable output
     """
 
     def execute(self):
         if self.static:
             self.disabled('status')
 
-        display_all = True if len(sys.argv) < 3 else False
+        display_all = not any([self.args['--hosts'], self.args['--platforms'],
+                               self.args['--providers']])
 
         # Check that an instance is created.
         if not self.molecule._state.get('created'):

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -519,12 +519,11 @@ class Status(AbstractCommand):
     Prints status of configured instances.
 
     Usage:
-        status [--debug][--porcelain] ([-a] | [--hosts][--platforms][--providers])
+        status [--debug][--porcelain] ([-a] [--platforms][--providers])
 
     Options:
         -a              display all available items
         --debug         get more detail
-        --hosts         display the available hosts
         --platforms     display the available platforms
         --providers     display the available providers
         --porcelain     machine readable output
@@ -551,24 +550,21 @@ class Status(AbstractCommand):
         # Display the results in procelain mode.
         porcelain = self.molecule._args['--porcelain']
 
+        # Prepare the table for the results.
+        headers = [] if porcelain else ['Name', 'State', 'Provider']
+        data = []
+
+        for item in status:
+            if item.state != 'not_created':
+                state = colorama.Fore.GREEN + item.state + colorama.Fore.RESET
+            else:
+                state = item.state
+
+            data.append([item.name, state, item.provider])
+
         # Display hosts information.
-        if self.molecule._args['-a'] or self.molecule._args['--hosts']:
-
-            # Prepare the table for the results.
-            headers = [] if porcelain else ['Name', 'State', 'Provider']
-            data = []
-
-            for item in status:
-                if item.state != 'not_created':
-                    state = colorama.Fore.GREEN + item.state + colorama.Fore.RESET
-                else:
-                    state = item.state
-
-                data.append([item.name, state, item.provider])
-
-            # Print the results.
-            self.molecule._display_tabulate_data(data, headers=headers)
-            print()
+        self.molecule._display_tabulate_data(data, headers=headers)
+        print()
 
         # Display the platforms.
         if self.molecule._args['-a'] or self.molecule._args['--platforms']:


### PR DESCRIPTION
Currently, if you try running ```molecule status``` you get nothing unless you pass in any flag. It seems more logical to at least display the hosts by default instead of having to pass in anything for that. 

This PR:
* removes ```--hosts``` flag in ```Status```
* Prints the status of hosts by default