### PR TITLE
Adds testinfra parameters through molecule configuration

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -299,6 +299,27 @@ A specific registry can also be defined with the ``registry`` option in the cont
 When accessing a private registry, ensure your docker client is logged into whichever
 registry you are trying to access.
 
+Testinfra
+---------
+
+In the testinfra section, you can configure flags exactly as they're
+passed to `testinfra`. Some flags, such as ``ansible-inventory``,
+``connection`` and ``hosts``, are already set by Molecule. Any flag
+set in this section will override the defaults. See more details on
+using `testinfra's command line arguments`_.
+
+.. code-block:: yaml
+
+    testinfra:
+      n: 1
+
+
+Note: Testinfra is based on pytest, so additional `pytest arguments`_ can be
+passed through it.
+
+.. _`testinfra's command line arguments`: http://testinfra.readthedocs.io/en/latest/invocation.html
+.. _`PyTest arguments`: http://pytest.org/latest/usage.html#usage
+
 playbook.yml
 ------------
 

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -390,7 +390,9 @@ class Verify(AbstractCommand):
         ansible = AnsiblePlaybook(self.molecule._config.config['ansible'],
                                   _env=self.molecule._env)
 
-        testinfra_kwargs = self.molecule._provisioner.testinfra_args
+        testinfra_kwargs = utilities.merge_dicts(
+            self.molecule._provisioner.testinfra_args,
+            self.molecule._config.config['testinfra'])
         serverspec_kwargs = self.molecule._provisioner.serverspec_args
         testinfra_kwargs['env'] = ansible.env
         testinfra_kwargs['env']['PYTHONDONTWRITEBYTECODE'] = '1'

--- a/molecule/conf/defaults.yml
+++ b/molecule/conf/defaults.yml
@@ -92,3 +92,6 @@ ansible:
     - -o IdentitiesOnly=yes
     - -o ControlMaster=auto
     - -o ControlPersist=60s
+
+testinfra:
+  n: 3

--- a/molecule/provisioners.py
+++ b/molecule/provisioners.py
@@ -338,8 +338,7 @@ class VagrantProvisioner(BaseProvisioner):
         kwargs = {
             'ansible-inventory':
             self.m._config.config['ansible']['inventory_file'],
-            'connection': 'ansible',
-            'n': 3
+            'connection': 'ansible'
         }
 
         return kwargs
@@ -622,11 +621,7 @@ class DockerProvisioner(BaseProvisioner):
         for container in self.instances:
             hosts_string += container['name'] + ','
 
-        kwargs = {
-            'connection': 'docker',
-            'hosts': hosts_string.rstrip(','),
-            'n': 3
-        }
+        kwargs = {'connection': 'docker', 'hosts': hosts_string.rstrip(',')}
 
         return kwargs
 


### PR DESCRIPTION
This PR addresses issue #193 and passes arguments to testinfra from molecule configuration.  Parameters merge with provisioner-specific arguments and override defaults.

Example molecule.yml:

```yaml
...

testinfra:
  n: 1

...
```