### PR TITLE
Implements support for "libvirt" provider

### DIFF
--- a/docs/source/providers.rst
+++ b/docs/source/providers.rst
@@ -169,18 +169,17 @@ There is an example:
             options:
               memory: 1024
               cpus: 2
-              driver: kvm #Note that the two available drivers are kvm and qemu (refer to the vagrant-libvirt doc).
+              # There are two available drivers: kvm and qemu.
+              # Refer to the vagrant-libvirt docs for more info.
+              driver: kvm
               video_type: vga
 
         instances:
           - name: ansible-role
             raw_config_args:
-              - "ssh.pty = true"
               - "vm.synced_folder './', '/vagrant', disabled: true"
-              - "vm.network :private_network, :libvirt__dhcp_enabled=> false ,:libvirt__tunnel_type => 'server', :libvirt__tunnel_port => '11111'"
             options:
               append_platform_to_hostname: no
-
             ansible_groups:
               - group_1
 

--- a/docs/source/providers.rst
+++ b/docs/source/providers.rst
@@ -149,37 +149,40 @@ There is an example:
 
 .. code-block:: yaml
 
-    ---
-    vagrant:
+      ---
+      vagrant:
+        raw_config_args:
+          - "ssh.pty = true"
+          - "vm.network :private_network, :libvirt__dhcp_enabled=> false ,:libvirt__tunnel_type => 'server', :libvirt__tunnel_port => '11111'"
 
-      platforms:
-        - name: rhel6
-          box: rhel/rhel-6
-        - name: rhel7
-          box: rhel/rhel-7
-        - name: centos7
-          box: centos/7
+        platforms:
+          - name: rhel6
+            box: rhel/rhel-6
+          - name: rhel7
+            box: rhel/rhel-7
+          - name: centos7
+            box: centos/7
 
-      providers:
-        - name: libvirt
-          type: libvirt
-          options:
-        memory: 1024
-        cpus: 2
-        driver: kvm #Note that the two available drivers are kvm and qemu(refer to the vagrant-libvirt doc).
-        video_type: vga
+        providers:
+          - name: libvirt
+            type: libvirt
+            options:
+              memory: 1024
+              cpus: 2
+              driver: kvm #Note that the two available drivers are kvm and qemu (refer to the vagrant-libvirt doc).
+              video_type: vga
 
-      instances:
-        - name: ansible-role
-          raw_config_args:
-        - "ssh.pty = true"
-        - "vm.synced_folder './', '/vagrant', disabled: true"
-        - "vm.network :private_network, :libvirt__dhcp_enabled=> false ,:libvirt__tunnel_type => 'server', :libvirt__tunnel_port => '11111'"
-          options:
-        append_platform_to_hostname: no
+        instances:
+          - name: ansible-role
+            raw_config_args:
+              - "ssh.pty = true"
+              - "vm.synced_folder './', '/vagrant', disabled: true"
+              - "vm.network :private_network, :libvirt__dhcp_enabled=> false ,:libvirt__tunnel_type => 'server', :libvirt__tunnel_port => '11111'"
+            options:
+              append_platform_to_hostname: no
 
-          ansible_groups:
-        - group_1
+            ansible_groups:
+              - group_1
 
 .. _`VirtualBox`: http://docs.vagrantup.com/v2/virtualbox/index.html
 .. _`Versioning`: https://docs.vagrantup.com/v2/boxes/versioning.html

--- a/docs/source/providers.rst
+++ b/docs/source/providers.rst
@@ -77,6 +77,110 @@ Other Notes
 
 * `triggers` enables very basic support for the vagrant-triggers plugin. During `molecule create`, if the plugin is not found it will be automatically installed.
 
+Libvirt
+---------
+
+The libvirt toolkit is known to work with the `vagrant-libvirt`_ provider plugin. But before installing this plugin you need to have libvirt installed(if you plan to run the tests on your local machine). Some users have reported dependency issues while installing vagrant-libvirt, so it is highly recommended to check `this section`_. You also need a vagrant compatible version installed on your machine(note that, not all versions are supported. Check the vagrant-libvirt documentation).
+
+
+You can install the vagrant-libvirt plugin with::
+
+      $ vagrant plugin install vagrant-libvirt
+
+.. _`vagrant-libvirt`: https://github.com/pradels/vagrant-libvirt
+
+
+.. _`this section`: https://github.com/pradels/vagrant-libvirt#possible-problems-with-plugin-installation-on-linux
+
+Molecule allows to specify `provider options`_ and `domain specific options`_  within the molecule.yml file, in the providers section.
+
+.. _`domain specific options`: https://github.com/pradels/vagrant-libvirt#domain-specific-options
+
+Provider options
+^^^^^^^^^^^^^^^^
+These options are described in the `provider options`_ section of the vagrant-libvirt project site:
+
+Although it should work without any configuration for most people, this provider exposes quite a few provider-specific configuration options. The following options allow you to configure how vagrant-libvirt connects to libvirt, and are used to generate the `libvirt connection URI`_:
+
+* `driver` - A hypervisor name to access. For now only kvm and qemu are supported.
+* `host` - The name of the server, where libvirtd is running. You want to use this option when creating the VM in a remote host.
+* `connect_via_ssh` - If use ssh tunnel to connect to Libvirt. Absolutely needed to access libvirt on remote host. It will not be able to get the IP address of a started VM otherwise.
+* `username` - Username and password to access Libvirt.
+* `password` - Password to access Libvirt.
+* `id_ssh_key_file` - If not nil, uses this ssh private key to access Libvirt. Default is $HOME/.ssh/id_rsa. Prepends $HOME/.ssh/ if no directory.
+* `socket` - Path to the libvirt unix socket (eg: /var/run/libvirt/libvirt-sock)
+* `uri` - For advanced usage. Directly specifies what libvirt connection URI vagrant-libvirt should use. Overrides all other connection configuration options.
+
+Connection-independent options:
+
+* `storage_pool_name` - Libvirt storage pool name, where box image and instance snapshots will be stored.
+
+.. _`provider options`: https://github.com/pradels/vagrant-libvirt#provider-options
+.. _`libvirt connection URI`: http://libvirt.org/uri.html
+
+Here is an example of how could look like your molecule.yml file:
+
+.. code-block:: yaml
+
+Domain Specific Options
+^^^^^^^^^^^^^^^^^^^^^^^
+
+* `disk_bus` - The type of `disk device`_ to emulate. Defaults to virtio if not set.
+* `nic_model_type` - parameter specifies the model of the network adapter when you create a domain value by default virtio KVM believe possible values, see the `nics documentation`_.
+* `memory` - Amount of memory in MBytes. Defaults to 512 if not set.
+* `cpus` - Number of virtual cpus. Defaults to 2 if not set.
+* `nested` - `Enable nested virtualization`_. Default is false.
+* `cpu_mode` - `CPU emulation mode`_. Defaults to 'host-model' if not set. Allowed values: host-model, host-passthrough.
+* `Other options` - Such as graphics_port, suspend_mode, boot, etc. Please, take a look at the `vagrant-libvirt`_ documentation for seeing all available options.
+
+.. _`disk device`: http://libvirt.org/formatdomain.html#elementsDisks
+.. _`nics documentation`: https://libvirt.org/formatdomain.html#elementsNICSModel
+.. _`Enable nested virtualization`: https://github.com/torvalds/linux/blob/master/Documentation/virtual/kvm/nested-vmx.txt
+.. _`CPU emulation mode`: https://libvirt.org/formatdomain.html#elementsCPU
+
+Usage
+^^^^^
+
+All libvirt specific options(such as the one above, provider specific and domain options) must be specified in the providers section. Nevertheless, other options such as synced or network settings should be added to the raw_config_args, as they are vagrant generic parameters. Note that you can use special libvirt parameters such as "libvirt__tunnel_type", as it is shown in the example below.
+
+Please, refer to the `vagrant-libvirt`_ documentation for getting a better understanding of all available options.
+
+There is an example:
+
+.. code-block:: yaml
+
+    ---
+    vagrant:
+
+      platforms:
+        - name: rhel6
+          box: rhel/rhel-6
+        - name: rhel7
+          box: rhel/rhel-7
+        - name: centos7
+          box: centos/7
+
+      providers:
+        - name: libvirt
+          type: libvirt
+          options:
+        memory: 1024
+        cpus: 2
+        driver: kvm #Note that the two available drivers are kvm and qemu(refer to the vagrant-libvirt doc).
+        video_type: vga
+
+      instances:
+        - name: ansible-role
+          raw_config_args:
+        - "ssh.pty = true"
+        - "vm.synced_folder './', '/vagrant', disabled: true"
+        - "vm.network :private_network, :libvirt__dhcp_enabled=> false ,:libvirt__tunnel_type => 'server', :libvirt__tunnel_port => '11111'"
+          options:
+        append_platform_to_hostname: no
+
+          ansible_groups:
+        - group_1
+
 .. _`VirtualBox`: http://docs.vagrantup.com/v2/virtualbox/index.html
 .. _`Versioning`: https://docs.vagrantup.com/v2/boxes/versioning.html
 .. _`provider plugins`: https://www.vagrantup.com/docs/providers/

--- a/molecule/templates/vagrantfile.j2
+++ b/molecule/templates/vagrantfile.j2
@@ -133,7 +133,9 @@ Vagrant.configure('2') do |config|
 
   {% for instance in config.vagrant.instances -%}
   config.vm.define '{{ instance.vm_name }}' do |c|
+    {%- if 'libvirt' not in config.vagrant.providers|map(attribute='type')|list %}
     c.vm.hostname = '{{ instance.vm_name }}'
+    {%- endif %}
     {%- for interface in instance.interfaces %}
     c.vm.network '{{ interface.network_name }}', type: '{{ interface.type }}', auto_config: {{ interface.auto_config|lower }}
     {%- if interface.type == 'static' %}, ip: '{{ interface.ip }}' {%- endif -%}

--- a/molecule/templates/vagrantfile.j2
+++ b/molecule/templates/vagrantfile.j2
@@ -66,6 +66,29 @@ Vagrant.configure('2') do |config|
   {%- endif %}
     {%- endif %}
 
+    {%- if provider.type is defined and provider.type == 'libvirt' and provider.name == current_provider %}
+  config.vm.provider :libvirt do |libvirt|
+    {%- if provider.options %}
+      {%- for k, v in provider.options.iteritems()|sort %}
+      {%- if  v  is number %}
+    libvirt.{{ k }} = {{ v }}
+      {%- else %}
+    libvirt.{{ k }} = "{{ v }}"
+      {%- endif %}
+      {%- endfor %}
+      {%- if not provider.options.memory %}
+    libvirt.memory = 512
+      {%- endif %}
+      {%- if not provider.options.cpus %}
+    libvirt.cpus = 2
+      {%- endif %}
+    {%- else %}
+    libvirt.memory = 512
+    libvirt.cpus = 2
+    {%- endif %}
+  end
+    {%- endif %}
+
     {# --- parallels --- #}
     {%- if provider.type is defined and provider.type == 'parallels' and provider.name == current_provider %}
   config.vm.provider 'parallels' do |prl|


### PR DESCRIPTION
Tip of the hat to @oserde. A straightforward rebase of #119 on top of the latest master wasn't possible, so I manually added the relevant provider blocks and docs, then amended the commits to credit @oserde. 

Supersedes and therefore closes #119. 