### PR TITLE
[Feature Implementation] Molecule Check

### DIFF
--- a/assets/bash_completion/molecule.bash-completion.sh
+++ b/assets/bash_completion/molecule.bash-completion.sh
@@ -24,9 +24,9 @@ _molecule(){
 	prev=${COMP_WORDS[COMP_CWORD-1]}
 	firstword=$(_get_firstword)
 
-  GLOBAL_COMMANDS="create converge destroy idempotence init list login status test verify"
+  GLOBAL_COMMANDS="check create converge destroy idempotence init list login status test verify"
   GLOBAL_OPTIONS="-h -v"
-
+  CHECK_OPTIONS=""
   CREATE_OPTIONS="--debug --platform --provider --tags"
   CONVERGE_OPTIONS="--debug --platform --provider --tags"
   DESTROY_OPTIONS="--debug --platform --provider --tags"

--- a/molecule/cli.py
+++ b/molecule/cli.py
@@ -22,6 +22,7 @@ Usage:
     molecule [-hv] <command> [<args>...]
 
 Commands:
+    check         check playbook syntax
     create        create instances
     converge      create and provision instances
     idempotence   converge and check the output for changes

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -98,6 +98,24 @@ class AbstractCommand:
         raise NotImplementedError
 
 
+class Check(AbstractCommand):
+    """
+    Performs a syntax check on the current role.
+
+    Usage:
+        check
+    """
+
+    def execute(self, exit=True):
+
+        self.molecule._create_templates()
+
+        ansible = AnsiblePlaybook(self.molecule._config.config['ansible'])
+        ansible.add_cli_arg('syntax-check', True)
+
+        return ansible.execute(hide_errors=True)
+
+
 class Create(AbstractCommand):
     """
     Creates all instances defined in molecule.yml.

--- a/molecule/conf/defaults.yml
+++ b/molecule/conf/defaults.yml
@@ -54,6 +54,7 @@ molecule:
     # sequence of commands to run when performing `molecule test`
     sequence:
       - destroy
+      - check
       - create
       - converge
       - idempotence


### PR DESCRIPTION
This PR implements feature described in #110. This feature is small yet can save some time because the playbook syntax isn't checked until the molecule test instances have been created. 

The test sequence has been modified to fit the check sequence. Now, the ```check``` action follows directly before ```create```. 