### PR TITLE
Added host_vars and group_vars specification

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -138,6 +138,7 @@ is where you give molecule role-specific behavior.
         - -o StrictHostKeyChecking=false
         - -o UserKnownHostsFile=/dev/null
 
+
 Ansible
 -------
 
@@ -186,6 +187,32 @@ The `raw_env_vars` section allows you to pass arbitrary environment
 variables to ansible-playbook. This can be useful, for example, if you
 want to do a role level override of a value normally found in
 ansible.cfg.
+
+
+Host/Group Vars
+^^^^^^^^^^^^^^^
+
+Some playbooks require hosts/groups to have certain variables set. If you are in this situation - simply add the
+`host_vars` and/or `group_vars` to the ansible section. For example,
+
+.. code-block:: yaml
+
+    ansible:
+      playbook: playbook.yml
+      group_vars:
+        foo1:
+          - test: key
+            var2: value
+        foo2:
+          - test: key
+            var: value
+      host_vars:
+        foo1-01:
+          - set_this_value: True
+
+This example will set the variables for the ansible groups `foo1` and `foo2`. For hosts `foo1-01` the value `set_this_value`
+will be set to True.
+
 
 Vagrant
 -------

--- a/molecule/ansible_playbook.py
+++ b/molecule/ansible_playbook.py
@@ -103,6 +103,9 @@ class AnsiblePlaybook:
             self.playbook = value
             return
 
+        if name == 'host_vars' or name == 'group_vars':
+            return
+
         # verbose is weird, must be -vvvv not verbose=vvvv
         if name == 'verbose' and value:
             # for cases where someone passes in verbose: True

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -85,6 +85,9 @@ class AbstractCommand:
         # Add or update the host_vars if needed
         self.molecule._add_or_update_vars('host_vars')
 
+        # Update symlinks
+        self.molecule._symlink_vars()
+
     def disabled(self, cmd):
         """
         Prints 'command disabled' message and exits program.

--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -80,7 +80,10 @@ class AbstractCommand:
             self.static = True
 
         # Add or update the group_vars if needed.
-        self.molecule._add_or_update_group_vars()
+        self.molecule._add_or_update_vars('group_vars')
+
+        # Add or update the host_vars if needed
+        self.molecule._add_or_update_vars('host_vars')
 
     def disabled(self, cmd):
         """


### PR DESCRIPTION
This PR adds the ability to specify host variables and group variables. Sometimes playbooks will require host variables being set and this allows you test those playbooks without modifying the tasks to accommodate molecule. 

Here is an example of adding specifying some variables

``` yaml
    ansible:
      playbook: playbook.yml
      group_vars:
        foo1:
          - test: key
            var2: value
        foo2:
          - test: key
            var: value
      host_vars:
        foo1-01:
          - set_this_value: True
```