### PR TITLE
Turn parallel tests off by default

### DIFF
--- a/molecule/conf/defaults.yml
+++ b/molecule/conf/defaults.yml
@@ -94,5 +94,4 @@ ansible:
     - -o ControlMaster=auto
     - -o ControlPersist=60s
 
-testinfra:
-  n: 3
+testinfra: {}


### PR DESCRIPTION
We are now able to pass params to testinfra through molecule's config
file #198.  However, running in parallel by default has caused us
more issues than good.  It doesn't seem to improve speeds, especially
when leveraging the Ansible fixture.  It also seems to block ssh muxing
sockets when using ControlPersist, with numerous converge/test/destroy
sequences.

Speed should not be an issue, as it appears to be fixed soon[0].

[0] https://github.com/philpep/testinfra/issues/56