### PR TITLE
Would never update RHEL based images

### DIFF
--- a/molecule/provisioners.py
+++ b/molecule/provisioners.py
@@ -476,8 +476,8 @@ class DockerProvisioner(BaseProvisioner):
 
             dockerfile = '''
             FROM {}:{}
-            RUN bash -c 'if [ -x "$(command -v apt-get)" ]; then  apt-get update && apt-get install -y python sudo; fi'
-            RUN bash -c 'if [ -x "$(command -v yum)" ]; then  yum update && yum install -y python sudo; fi'
+            RUN bash -c 'if [ -x "$(command -v apt-get)" ]; then apt-get update && apt-get install -y python sudo; fi'
+            RUN bash -c 'if [ -x "$(command -v yum)" ]; then yum makecache fast && yum update -y && yum install -y python sudo; fi'
 
             '''
 


### PR DESCRIPTION
Required a `-y` flag to `yum update`.  Also, added `yum makecache` prior
to upgrade.