### PR TITLE
Reformatted with current YAPF pinning

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -29,7 +29,7 @@ From the root for the project, run:
 
   $ tox -r yapf
   $ source .tox/py27/bin/activate
-  $ yapf -i -r molecule/
+  $ yapf -i -r molecule/ tests/
 
 .. _`YAPF`: https://github.com/google/yapf
 .. _`Tox`: https://tox.readthedocs.org/en/latest

--- a/molecule/provisioners.py
+++ b/molecule/provisioners.py
@@ -479,7 +479,7 @@ class DockerProvisioner(BaseProvisioner):
             RUN bash -c 'if [ -x "$(command -v apt-get)" ]; then apt-get update && apt-get install -y python sudo; fi'
             RUN bash -c 'if [ -x "$(command -v yum)" ]; then yum makecache fast && yum update -y && yum install -y python sudo; fi'
 
-            '''
+            '''  # noqa
 
             dockerfile = dockerfile.format(
                 container['registry'] + container['image'],

--- a/tests/test_dockerprovisioner.py
+++ b/tests/test_dockerprovisioner.py
@@ -38,17 +38,16 @@ class TestDockerProvisioner(testtools.TestCase):
                 'molecule_dir': '.test_molecule',
                 'inventory_file': 'tests/ansible_inventory'
             },
-
             'docker': {
                 'containers': [
                     {'name': 'test1',
                      'image': 'ubuntu',
                      'image_version': 'latest',
-                     'ansible_groups': ['group1']},
-                    {'name': 'test2',
-                     'image': 'ubuntu',
-                     'image_version': 'latest',
-                     'ansible_groups': ['group2']}
+                     'ansible_groups': ['group1']}, {'name': 'test2',
+                                                     'image': 'ubuntu',
+                                                     'image_version': 'latest',
+                                                     'ansible_groups':
+                                                     ['group2']}
                 ]
             },
             'ansible': {
@@ -65,25 +64,30 @@ class TestDockerProvisioner(testtools.TestCase):
         self._mock_molecule._state = dict()
 
     def test_name(self):
-        docker_provisioner = provisioners.DockerProvisioner(self._mock_molecule)
+        docker_provisioner = provisioners.DockerProvisioner(
+            self._mock_molecule)
         # false values don't exist in arg dict at all
         self.assertEqual(docker_provisioner.name, 'docker')
 
     def test_get_provisioner(self):
-        self.assertEqual(provisioners.get_provisioner(self._mock_molecule).name, 'docker')
+        self.assertEqual(
+            provisioners.get_provisioner(self._mock_molecule).name, 'docker')
 
     def test_up(self):
-        docker_provisioner = provisioners.DockerProvisioner(self._mock_molecule)
+        docker_provisioner = provisioners.DockerProvisioner(
+            self._mock_molecule)
         docker_provisioner.up()
         docker_provisioner.destroy()
 
     def test_instances(self):
-        docker_provisioner = provisioners.DockerProvisioner(self._mock_molecule)
+        docker_provisioner = provisioners.DockerProvisioner(
+            self._mock_molecule)
         self.assertEqual(docker_provisioner.instances[0]['name'], 'test1')
         self.assertEqual(docker_provisioner.instances[1]['name'], 'test2')
 
     def test_status(self):
-        docker_provisioner = provisioners.DockerProvisioner(self._mock_molecule)
+        docker_provisioner = provisioners.DockerProvisioner(
+            self._mock_molecule)
 
         docker_provisioner.up()
 
@@ -97,7 +101,8 @@ class TestDockerProvisioner(testtools.TestCase):
         self.assertEqual('docker', docker_provisioner.status()[1].provider)
 
     def test_destroy(self):
-        docker_provisioner = provisioners.DockerProvisioner(self._mock_molecule)
+        docker_provisioner = provisioners.DockerProvisioner(
+            self._mock_molecule)
 
         docker_provisioner.up()
 
@@ -114,7 +119,8 @@ class TestDockerProvisioner(testtools.TestCase):
 
     def test_provision(self):
 
-        docker_provisioner = provisioners.DockerProvisioner(self._mock_molecule)
+        docker_provisioner = provisioners.DockerProvisioner(
+            self._mock_molecule)
         docker_provisioner.destroy()
         docker_provisioner.up()
 
@@ -129,7 +135,8 @@ class TestDockerProvisioner(testtools.TestCase):
         docker_provisioner.destroy()
 
     def test_inventory_generation(self):
-        self._mock_molecule._provisioner = provisioners.get_provisioner(self._mock_molecule)
+        self._mock_molecule._provisioner = provisioners.get_provisioner(
+            self._mock_molecule)
         self._mock_molecule._provisioner.destroy()
         self._mock_molecule._provisioner.up()
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ commands = flake8
 [testenv:yapf]
 deps = yapf
 commands =
-    yapf -d -r molecule
+    yapf -d -r molecule/ tests/
 
 [testenv:docs]
 passenv = *


### PR DESCRIPTION
We brought in YAPF 0.10.0 recently, but didn't reformat.  Updated
documentation and tox to include the `tests/` dir.