### PR TITLE
[Bug Fix] Added inventory flag to check command. 

### DIFF
--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -112,6 +112,7 @@ class Check(AbstractCommand):
 
         ansible = AnsiblePlaybook(self.molecule._config.config['ansible'])
         ansible.add_cli_arg('syntax-check', True)
+        ansible.add_cli_arg('inventory-file', 'localhost,')
 
         return ansible.execute(hide_errors=True)
 


### PR DESCRIPTION
Addresses issue #217 

Turns out ansible 1.9 needs the ```--inventory-file``` passed in with the syntax-check flag. In ansible 2.1 it does not need it. 
