### PR TITLE
Make all testinfra args configurable

### DIFF
--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -417,12 +417,12 @@ class Verify(AbstractCommand):
         serverspec_kwargs = self.molecule._provisioner.serverspec_args
         testinfra_kwargs['env'] = ansible.env
         testinfra_kwargs['env']['PYTHONDONTWRITEBYTECODE'] = '1'
-        testinfra_kwargs['debug'] = True if self.molecule._args.get(
-            '--debug') else False
-        testinfra_kwargs['sudo'] = True if self.molecule._args.get(
-            '--sudo') else False
+        if self.molecule._args.get('--debug'):
+            testinfra_kwargs['debug'] = True
+        if self.molecule._args.get('--sudo'):
+            testinfra_kwargs['sudo'] = True
         serverspec_kwargs['env'] = testinfra_kwargs['env']
-        serverspec_kwargs['debug'] = testinfra_kwargs['debug']
+        serverspec_kwargs['debug'] = testinfra_kwargs.get('debug')
 
         try:
             # testinfra


### PR DESCRIPTION
The sudo and debug options for testinfra could optionally be set as CLI args, however the way this was done prevented them from also being set as options in the testinra config block. This change allows support for both methods.