### PR TITLE
A custom `testinfra_dir` was not being handled

### DIFF
--- a/molecule/commands.py
+++ b/molecule/commands.py
@@ -410,13 +410,6 @@ class Verify(AbstractCommand):
         # whitespace & trailing newline check
         validators.check_trailing_cruft(ignore_paths=ignore_paths, exit=exit)
 
-        # no serverspec or testinfra
-        if not os.path.isdir(serverspec_dir) and not os.path.isdir(
-                testinfra_dir):
-            msg = 'Skipping tests, could not find {}/ or {}/.'
-            utilities.logger.warning(msg.format(serverspec_dir, testinfra_dir))
-            return None, None
-
         self.molecule._write_ssh_config()
 
         # testinfra's Ansible calls get same env vars as ansible-playbook
@@ -438,10 +431,12 @@ class Verify(AbstractCommand):
 
         try:
             # testinfra
-            if len(glob.glob1(testinfra_dir, "test_*.py")) > 0:
+            tests = '{}/test_*.py'.format(testinfra_dir)
+            tests_glob = glob.glob(tests)
+            if len(tests_glob) > 0:
                 msg = 'Executing testinfra tests found in {}/.'
                 utilities.print_info(msg.format(testinfra_dir))
-                validators.testinfra(testinfra_dir, **testinfra_kwargs)
+                validators.testinfra(tests_glob, **testinfra_kwargs)
             else:
                 msg = 'No testinfra tests found in {}/.\n'
                 utilities.logger.warning(msg.format(testinfra_dir))

--- a/molecule/validators.py
+++ b/molecule/validators.py
@@ -166,7 +166,7 @@ def rake(rakefile,
     return sh.rake(**kwargs)
 
 
-def testinfra(testinfra_dir,
+def testinfra(tests,
               debug=False,
               env=os.environ.copy(),
               out=logger.warning,
@@ -176,7 +176,7 @@ def testinfra(testinfra_dir,
     Runs testinfra against specified ansible inventory file
 
     :param inventory: Path to ansible inventory file
-    :param testinfra_dir: Path to the testinfra tests
+    :param tests: List of testinfra tests
     :param debug: Pass debug flag to testinfra
     :param env: Environment to pass to underlying sh call
     :param out: Function to process STDOUT for underlying sh call
@@ -191,7 +191,4 @@ def testinfra(testinfra_dir,
     if 'HOME' not in kwargs['_env']:
         kwargs['_env']['HOME'] = os.path.expanduser('~')
 
-    tests = '{}/test_*.py'.format(testinfra_dir)
-    tests_glob = sh.glob(tests)
-
-    return sh.testinfra(tests_glob, **kwargs)
+    return sh.testinfra(tests, **kwargs)

--- a/tests/provisioner/test_dockerprovisioner.py
+++ b/tests/provisioner/test_dockerprovisioner.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2015 Cisco Systems
+#  Copyright (c) 2015-2016 Cisco Systems
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
We were performing validation around the spec/ and tests/ dirs
in two different ways/places.  Also, we were not handling the
passing of the `testinfra_dir` correctly to the validator.

Fixes: #148