### PR TITLE
[Docker Driver] Added install_python flag to allow skipping of python installation

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -28,7 +28,7 @@ From the root for the project, run:
 .. code-block:: bash
 
   $ tox -r yapf
-  $ source .tox/py27/bin/activate
+  $ source .tox/yapf/bin/activate
   $ yapf -i -r molecule/ tests/
 
 .. _`YAPF`: https://github.com/google/yapf

--- a/docs/source/provisioners.rst
+++ b/docs/source/provisioners.rst
@@ -29,8 +29,12 @@ The available params for docker containers are:
 * ``ansible_groups`` - groups the container belongs to in Ansible
 * ``image`` - name of the image
 * ``image_version`` - version of the image
-* ``privileged`` - whether or not to run the container in privileged mode (boolean)
+* ``privileged`` - **(OPTIONAL)** whether or not to run the container in privileged mode (boolean)
 * ``registry`` - **(OPTIONAL)** the registry to obtain the image
+* ``install_python`` - **(default=yes)** install python onto the image being used
+
+The available param for the docker provisioner itself is:
+* ``install_python`` - **(default=yes)** install python onto all images for all containers
 
 Docker Example
 --------------

--- a/molecule/provisioners/dockerprovisioner.py
+++ b/molecule/provisioners/dockerprovisioner.py
@@ -39,7 +39,7 @@ class DockerProvisioner(BaseProvisioner):
 
         self.image_tag = 'molecule_local/{}:{}'
 
-        if not 'install_python' in self.m._config.config['docker']:
+        if 'install_python' not in self.m._config.config['docker']:
             self.m._config.config['docker']['install_python'] = True
 
     def _get_platform(self):
@@ -98,10 +98,13 @@ class DockerProvisioner(BaseProvisioner):
 
         for container in self.instances:
 
-            if 'install_python' in container and container['install_python'] is False:
+            if 'install_python' in container and container[
+                    'install_python'] is False:
                 continue
             else:
-                molecule.utilities.print_info("Creating Ansible compatible image of {}:{} ...".format(container['image'], container['image_version']))
+                molecule.utilities.print_info(
+                    "Creating Ansible compatible image of {}:{} ...".format(
+                        container['image'], container['image_version']))
 
             if 'registry' in container:
                 container['registry'] += '/'

--- a/molecule/provisioners/dockerprovisioner.py
+++ b/molecule/provisioners/dockerprovisioner.py
@@ -39,6 +39,9 @@ class DockerProvisioner(BaseProvisioner):
 
         self.image_tag = 'molecule_local/{}:{}'
 
+        if not 'install_python' in self.m._config.config['docker']:
+            self.m._config.config['docker']['install_python'] = True
+
     def _get_platform(self):
         self.m._env['MOLECULE_PLATFORM'] = 'Docker'
         return self.m._env['MOLECULE_PLATFORM']
@@ -94,6 +97,11 @@ class DockerProvisioner(BaseProvisioner):
                             for tag in image.get('RepoTags')]
 
         for container in self.instances:
+
+            if 'install_python' in container and container['install_python'] is False:
+                continue
+            else:
+                molecule.utilities.print_info("Creating Ansible compatible image of {}:{} ...".format(container['image'], container['image_version']))
 
             if 'registry' in container:
                 container['registry'] += '/'
@@ -151,7 +159,11 @@ class DockerProvisioner(BaseProvisioner):
                         'Finished building {}'.format(tag_string))
 
     def up(self, no_provision=True):
-        self.build_image()
+
+        if self.m._config.config['docker']['install_python']:
+            self.build_image()
+        else:
+            self.image_tag = '{}:{}'
 
         for container in self.instances:
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,4 +4,3 @@ pytest
 pytest-mock
 tox
 wheel
-yapf==0.10.0

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -113,8 +113,9 @@ def test_merge_deep_deep_01(deep_dict_a, deep_dict_b):
                            "position": "python master"}}
     }
     with pytest.raises(LookupError):
-        actual = utilities.merge_dicts(
-            deep_dict_a, deep_dict_b, raise_conflicts=True)
+        actual = utilities.merge_dicts(deep_dict_a,
+                                       deep_dict_b,
+                                       raise_conflicts=True)
         assert expected == actual
 
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -113,9 +113,8 @@ def test_merge_deep_deep_01(deep_dict_a, deep_dict_b):
                            "position": "python master"}}
     }
     with pytest.raises(LookupError):
-        actual = utilities.merge_dicts(deep_dict_a,
-                                       deep_dict_b,
-                                       raise_conflicts=True)
+        actual = utilities.merge_dicts(
+            deep_dict_a, deep_dict_b, raise_conflicts=True)
         assert expected == actual
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps = flake8
 commands = flake8
 
 [testenv:yapf]
-deps = yapf
+deps = yapf==0.10.0
 commands =
     yapf -d -r molecule/ tests/
 


### PR DESCRIPTION
This PR addresses the issue #245 to allow the user to skip the installation of python on a docker image. 
By default, the docker driver will build an image on top of the user specified image with python guaranteed to be installed. If the user passes in the flag ```install_python: no``` into either the docker driver config or container, it will be skipped. 

## Example
To skip the installation for all instances...
``` yaml
---
docker:
  install_python: no
  containers:
    - name: test1
      image: ubuntu
      image_version: latest
```

To skip the installation on only one instance
``` yaml
---
docker:
  containers:
  - name: test1-01
    ansible_groups:
      - group1
    image: ubuntu
    image_version: latest
    install_python: no
  - name: test1-02
    ansible_groups:
      - group2
    image: ubuntu
    image_version: latest