### PR TITLE
Directory checks

### DIFF
--- a/molecule/commands/init.py
+++ b/molecule/commands/init.py
@@ -55,8 +55,6 @@ class Init(base.BaseCommand):
             role_path = os.getcwd()
             utilities.print_info(
                 "Initializing molecule in current directory...")
-            if not os.path.isdir(os.path.join(role_path, "tests")):
-                os.mkdir(os.path.join(role_path, "tests"))
 
         else:
 
@@ -117,6 +115,9 @@ class Init(base.BaseCommand):
         testinfra_path = os.path.join(
             role_path,
             self.molecule._config.config['molecule']['testinfra_dir'])
+
+        if not os.path.isdir(testinfra_path):
+            os.mkdir(testinfra_path)
 
         with open(os.path.join(testinfra_path, 'test_default.py'), 'w') as f:
             f.write(t_test_default.render())


### PR DESCRIPTION
This PR address #233 and #259. Although 259 was resolved due to an environment issue, it still doesn't hurt to check if the directory exists. 

For addressing 233, the merge of the state objects seemed to have cause an issue with the creation of the .molecule folder. This has been fixed with a check for the .molecule folder along with a creation of the folder if it is missing. 