### PR TITLE
Remove vagrant triggers

### DIFF
--- a/docs/source/providers.rst
+++ b/docs/source/providers.rst
@@ -59,10 +59,6 @@ This example is far more extensive than you likely need and it demonstrates lots
             box_url: https://vagrantcloud.com/ubuntu/boxes/trusty64/versions/14.04/providers/virtualbox.box
           - name: rhel-7
             box: rhel/rhel-7
-            triggers:
-              - trigger: before
-                action: destroy
-                cmd: run_remote 'subscription-manager unregister'
 
         providers:
           - name: virtualbox
@@ -74,8 +70,6 @@ Other Notes
 ^^^^^^^^^^^
 
 * `box_version`, defaults to '=', can include an constraints like '<, >, >=, <=, ~.' as listed in the `Versioning`_ docs.
-
-* `triggers` enables very basic support for the vagrant-triggers plugin. During `molecule create`, if the plugin is not found it will be automatically installed.
 
 Libvirt
 ---------

--- a/molecule/templates/molecule.yml.j2
+++ b/molecule/templates/molecule.yml.j2
@@ -103,11 +103,6 @@ vagrant:
       box_url: {{ config.molecule.init.platform.box_url }}
       # Optional: box_version - support for vagrant versioning
       # box_version: {{ config.molecule.init.platform.box_version }}
-      # Optional: very basic support for vagrant-triggers plugin
-      # triggers:
-      #  - trigger: before
-      #    action: destroy
-      #    cmd: run_remote 'subscription-manager unregister'
 
   providers:
     - name: virtualbox

--- a/molecule/templates/vagrantfile.j2
+++ b/molecule/templates/vagrantfile.j2
@@ -1,13 +1,3 @@
-{%- for platform in config.vagrant.platforms %}
-  {%- if platform.name == current_platform %}
-    {%- if 'triggers' in platform %}
-unless Vagrant.has_plugin?('vagrant-triggers')
-  system "vagrant plugin install vagrant-triggers"
-  exec "vagrant #{ARGV.join' '}"
-end
-    {%- endif %}
-  {%- endif %}
-{%- endfor %}
 Vagrant.configure('2') do |config|
   config.cache.scope = 'machine' if Vagrant.has_plugin?('vagrant-cachier')
   {%- for platform in config.vagrant.platforms %}
@@ -18,13 +8,6 @@ Vagrant.configure('2') do |config|
       {%- endif %}
       {%- if 'box_url' in platform and 'box_version' not in platform %}
   config.vm.box_url = '{{ platform.box_url }}'
-      {%- endif %}
-      {%- if 'triggers' in platform %}
-        {%- for trigger in platform.triggers %}
-  config.trigger.{{ trigger.trigger }} :{{ trigger.action }}, :force => true do
-    {{ trigger.cmd }}
-  end
-        {%- endfor %}
       {%- endif %}
     {%- endif %}
   {%- endfor %}


### PR DESCRIPTION
In an effort to move away from provider specific features, we're removing vagrant triggers support. If this feature is needed or being used by anybody, we can implement it in a better way using playbooks.