### PR TITLE
Debug cleanup

### DIFF
--- a/molecule/commands/converge.py
+++ b/molecule/commands/converge.py
@@ -136,14 +136,15 @@ class Converge(base.BaseCommand):
                          for (k, v) in ansible.env.items()
                          if 'ANSIBLE' not in k}
             utilities.debug('OTHER ENVIRONMENT',
-                            yaml.dump(other_env,
-                                      default_flow_style=False,
-                                      indent=2))
+                            yaml.safe_dump(other_env,
+                                           default_flow_style=False,
+                                           indent=2))
             utilities.debug('ANSIBLE ENVIRONMENT',
-                            yaml.dump(ansible_env,
-                                      default_flow_style=False,
-                                      indent=2))
+                            yaml.safe_dump(ansible_env,
+                                           default_flow_style=False,
+                                           indent=2))
             utilities.debug('ANSIBLE PLAYBOOK', str(ansible.ansible))
+            utilities.debug('CURRENT STATE', str(self.molecule._state))
 
         utilities.print_info("Starting Ansible Run ...")
         status, output = ansible.execute(hide_errors=hide_errors)

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -103,9 +103,9 @@ class Molecule(object):
 
         if self._args.get('--debug'):
             utilities.debug('RUNNING CONFIG',
-                            yaml.dump(self._config.config,
-                                      default_flow_style=False,
-                                      indent=2))
+                            yaml.safe_dump(self._config.config,
+                                           default_flow_style=False,
+                                           indent=2))
 
     def get_provisioner(self):
         if 'vagrant' in self._config.config:

--- a/molecule/state.py
+++ b/molecule/state.py
@@ -51,6 +51,9 @@ class State(object):
 
         return wrapper
 
+    def __str__(self):
+        return yaml.safe_dump(self._data, default_flow_style=False, indent=2)
+
     @property
     def converged(self):
         return self._data.get('converged')

--- a/molecule/utilities.py
+++ b/molecule/utilities.py
@@ -256,8 +256,9 @@ def debug(title, data):
     print(''.join([colorama.Back.WHITE, colorama.Style.BRIGHT,
                    colorama.Fore.BLACK, 'DEBUG: ' + title, colorama.Fore.RESET,
                    colorama.Back.RESET, colorama.Style.RESET_ALL]))
-    print(''.join([colorama.Fore.BLACK, colorama.Style.BRIGHT, data,
+    print(''.join([colorama.Fore.BLACK, colorama.Style.BRIGHT, data.strip(),
                    colorama.Style.RESET_ALL, colorama.Fore.RESET]))
+    print('')
 
 
 def sysexit(code=1):


### PR DESCRIPTION
* Debug of running configs now uses safe_dump so it doesn't print more info than we need
* Made spacing between debug blocks more consistent
* Added \__str\__ to state class for easy printing of object contents
* Added state debugging info to `molecule converge`