### PR TITLE
Implemented a new config class

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -363,22 +363,13 @@ order to test this particular role.
 Override Configuration
 ----------------------
 
-You can specify a configuration file in the following places, in this order:
+1. local config (``~/.config/molecule/config.yml``)
+2. project config
+3. default config (``molecule.yml``)
 
-1. MOLECULE\_CONFIG environment variable
-2. ~/.config/molecule/config.yml
-3. /etc/molecule/config.yml
-
-Molecule looks for configuration file and will stop looking for files once one of these is found,
-so you *cannot* load settings from more than one of these locations.
-
-Options specified in the (first found) configuration file will merge with (and
-override) the defaults. Options not specified in the file will fall back
-to defaults.
-
-However, you can also specify settings in the `molecule.yml` file for a role under
-the *ansible* section. These will be the most specific settings and will
-override settings from all other files.
+The merge order is default -> project -> local, meaning that elements at
+the top of the above list will be merged last, and have greater precedence
+than elements at the bottom of the list.
 
 Using Molecule For Deployment
 -----------------------------

--- a/molecule/ansible_galaxy_install.py
+++ b/molecule/ansible_galaxy_install.py
@@ -19,7 +19,6 @@
 #  THE SOFTWARE.
 
 import os
-import sys
 
 import sh
 
@@ -89,4 +88,4 @@ class AnsibleGalaxyInstall:
             return self.galaxy().stdout
         except sh.ErrorReturnCode as e:
             utilities.logger.error('ERROR: {}'.format(e))
-            sys.exit(e.exit_code)
+            utilities.sysexit(e.exit_code)

--- a/molecule/commands/init.py
+++ b/molecule/commands/init.py
@@ -100,9 +100,7 @@ class Init(base.BaseCommand):
 
         sanitized_role = re.sub('[._]', '-', role)
         with open(
-                os.path.join(
-                    role_path,
-                    self.molecule._config.config['molecule']['molecule_file']),
+                os.path.join(role_path, self.molecule._config.molecule_file),
                 'w') as f:
             f.write(t_molecule.render(config=self.molecule._config.config,
                                       role=sanitized_role))

--- a/molecule/conf/defaults.yml
+++ b/molecule/conf/defaults.yml
@@ -1,8 +1,5 @@
 ---
 molecule:
-  # file to look for in CWD when using ansible-playbook directly
-  molecule_file: molecule.yml
-
   # directories to ignore when doing trailing whitespace checks on files during verify command
   ignore_paths:
     - .git

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -48,18 +48,8 @@ class Molecule(object):
         self._provisioner = None
 
     def main(self):
-        # load molecule defaults
-        self._config.load_defaults_file()
-
-        # merge in any molecule config files found (eg: ~/.configs/molecule/config.yml)
-        self._config.merge_molecule_config_files()
-
-        # init command doesn't need to load molecule.yml
         if self._args.get('<command>') == 'init':
             return  # exits program
-
-        # merge in molecule.yml
-        self._config.merge_molecule_file()
 
         # ensure the .molecule directory exists
         if not os.path.isdir(os.path.join(os.curdir, self._config.config[
@@ -85,7 +75,7 @@ class Molecule(object):
             self._args['--platform'] = None
             self._provisioner = self.get_provisioner()
             self._print_valid_providers()
-            sys.exit(1)
+            utilities.sysexit()
         except baseprovisioner.InvalidPlatformSpecified:
             utilities.logger.error("\nInvalid platform '{}'\n".format(
                 self._args['--platform']))
@@ -93,7 +83,7 @@ class Molecule(object):
             self._args['--platform'] = None
             self._provisioner = self.get_provisioner()
             self._print_valid_platforms()
-            sys.exit(1)
+            utilities.sysexit()
 
         if not os.path.exists(self._config.config['molecule']['molecule_dir']):
             os.makedirs(self._config.config['molecule']['molecule_dir'])
@@ -128,7 +118,7 @@ class Molecule(object):
         except subprocess.CalledProcessError as e:
             utilities.logger.error('ERROR: {}'.format(e))
             utilities.logger.error("Does your vagrant VM exist?")
-            sys.exit(e.returncode)
+            utilities.sysexit(e.returncode)
         utilities.write_file(ssh_config, out)
 
     def _print_valid_platforms(self, porcelain=False):
@@ -220,7 +210,7 @@ class Molecule(object):
 
         # rakefile
         kwargs = {
-            'molecule_file': self._config.config['molecule']['molecule_file'],
+            'molecule_file': self._config.molecule_file,
             'current_platform': self._env['MOLECULE_PLATFORM'],
             'serverspec_dir': self._config.config['molecule']['serverspec_dir']
         }
@@ -317,7 +307,7 @@ class Molecule(object):
                 'ERROR: the group_vars path {} does not exist. Check your configuration file'.format(
                     group_vars_target))
 
-            sys.exit(1)
+            utilities.sysexit()
         os.symlink(group_vars_target, group_vars_link_path)
 
     def _display_tabulate_data(self, data, headers=None):

--- a/molecule/validators.py
+++ b/molecule/validators.py
@@ -20,7 +20,6 @@
 
 import os
 import re
-import sys
 
 import sh
 
@@ -82,7 +81,7 @@ def check_trailing_cruft(ignore_paths=[], exit=True):
             found_error = True
 
     if exit and found_error:
-        sys.exit(1)
+        utilities.sysexit()
 
 
 def trailing_newline(source):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 ansible
+anyconfig
 colorama==0.3.7
 docopt==0.6.2
 docker-py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,3 +17,39 @@
 #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
+
+import os
+import os.path
+
+import pytest
+
+
+@pytest.fixture()
+def temp_files(tmpdir, request):
+    def wrapper(content=[]):
+        d = tmpdir.mkdir('molecule')
+        confs = []
+        for index, item in enumerate(content):
+            c = d.join(os.extsep.join((str(index), 'yml')))
+            c.write(item)
+            confs.append(c.strpath)
+
+        def cleanup():
+            for c in confs:
+                os.remove(c)
+            os.rmdir(d.strpath)
+
+        request.addfinalizer(cleanup)
+
+        return confs
+
+    return wrapper
+
+
+@pytest.fixture()
+def mock_molecule_file_exists(monkeypatch):
+    def mockreturn(m):
+        return True
+
+    return monkeypatch.setattr('molecule.config.Config._has_molecule_file',
+                               mockreturn)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,20 +18,36 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-import os
-
 import pytest
 
 from molecule import config
 
 
 @pytest.fixture()
-def molecule_file(tmpdir, request):
-    d = tmpdir.mkdir('molecule')
-    c = d.join(os.extsep.join(('molecule', 'yml')))
-    data = {
+def default_config_data():
+    return {'foo': 'bar', 'baz': 'qux'}
+
+
+@pytest.fixture()
+def project_config_data():
+    return {'foo': 'bar', 'baz': 'project-override'}
+
+
+@pytest.fixture()
+def local_config_data():
+    return {'foo': 'local-override', 'baz': 'local-override'}
+
+
+@pytest.fixture()
+def config_data():
+    return {
         'molecule': {
-            'molecule_dir': '.test_molecule'
+            'state_file': 'state_file.yml',
+            'vagrantfile_file': 'vagrantfile_file',
+            'rakefile_file': 'rakefile_file',
+            'config_file': 'config_file',
+            'inventory_file': 'inventory_file',
+            'molecule_dir': 'test',
         },
         'vagrant': {
             'instances': [
@@ -40,77 +56,87 @@ def molecule_file(tmpdir, request):
             ]
         },
         'ansible': {
-            'config_file': 'test_config',
-            'inventory_file': 'test_inventory'
         }
     }
-    c.write(data)
-
-    def cleanup():
-        os.remove(c.strpath)
-        os.rmdir(d.strpath)
-
-    request.addfinalizer(cleanup)
-
-    return c.strpath
 
 
-def test_load_defaults_file():
-    c = config.Config()
-    c.load_defaults_file()
+@pytest.fixture()
+def config_instance(temp_files, config_data, mock_molecule_file_exists):
+    c = temp_files(content=[config_data])
 
-    assert '.molecule' == c.config['molecule']['molecule_dir']
-
-
-def test_load_defaults_external_file(molecule_file):
-    c = config.Config()
-    c.load_defaults_file(defaults_file=molecule_file)
-
-    assert '.test_molecule' == c.config['molecule']['molecule_dir']
+    return config.Config(configs=c)
 
 
-def test_merge_molecule_config_files(molecule_file):
-    c = config.Config()
-    c.load_defaults_file()
-    c.merge_molecule_config_files(paths=[molecule_file])
-
-    assert '.test_molecule' == c.config['molecule']['molecule_dir']
+def test_molecule_file(config_instance):
+    assert 'molecule.yml' == config_instance.molecule_file
 
 
-def test_merge_molecule_file(molecule_file):
-    c = config.Config()
-    c.load_defaults_file()
-    c.merge_molecule_file(molecule_file=molecule_file)
+def test_build_easy_paths(config_instance):
+    config_instance.build_easy_paths()
 
-    assert '.test_molecule' == c.config['molecule']['molecule_dir']
-
-
-def test_build_easy_paths():
-    c = config.Config()
-    c.load_defaults_file()
-    c.build_easy_paths()
-
-    assert '.molecule/state.yml' == c.config['molecule']['state_file']
-    assert '.molecule/vagrantfile' == c.config['molecule']['vagrantfile_file']
-    assert '.molecule/rakefile' == c.config['molecule']['rakefile_file']
-    assert '.molecule/ansible.cfg' == c.config['molecule']['config_file']
-    assert '.molecule/ansible_inventory' == c.config['molecule'][
+    assert 'test/state_file.yml' == config_instance.config['molecule'][
+        'state_file']
+    assert 'test/vagrantfile_file' == config_instance.config['molecule'][
+        'vagrantfile_file']
+    assert 'test/rakefile_file' == config_instance.config['molecule'][
+        'rakefile_file']
+    assert 'test/config_file' == config_instance.config['molecule'][
+        'config_file']
+    assert 'test/inventory_file' == config_instance.config['molecule'][
         'inventory_file']
 
 
-def test_update_ansible_defaults(molecule_file):
-    c = config.Config()
-    c.load_defaults_file()
-    c.merge_molecule_file(molecule_file=molecule_file)
+def test_update_ansible_defaults(config_instance):
+    config_instance.build_easy_paths()
+    config_instance.update_ansible_defaults()
 
-    assert 'test_inventory' == c.config['ansible']['inventory_file']
-    assert 'test_config' == c.config['ansible']['config_file']
+    assert 'test/inventory_file' == config_instance.config['molecule'][
+        'inventory_file']
+    assert 'test/config_file' == config_instance.config['molecule'][
+        'config_file']
 
 
-def test_populate_instance_names(molecule_file):
-    c = config.Config()
-    c.load_defaults_file()
-    c.merge_molecule_file(molecule_file=molecule_file)
-    c.populate_instance_names('rhel-7')
+def test_populate_instance_names(config_instance):
+    config_instance.populate_instance_names('rhel-7')
 
-    assert 'aio-01-rhel-7' == c.config['vagrant']['instances'][0]['vm_name']
+    assert 'aio-01-rhel-7' == config_instance.config['vagrant']['instances'][
+        0]['vm_name']
+
+
+def test_get_config(config_instance):
+    assert isinstance(config_instance.config, dict)
+
+
+def test_get_config_raises_when_missing_molecule_file():
+    with pytest.raises(SystemExit):
+        config.Config()
+
+
+def test_combine_default_config(temp_files, default_config_data,
+                                mock_molecule_file_exists):
+    c = temp_files(content=[default_config_data])
+    config_instance = config.Config(configs=c).config
+
+    assert 'bar' == config_instance['foo']
+    assert 'qux' == config_instance['baz']
+
+
+def test_combine_project_config_overrides_default_config(
+        temp_files, default_config_data, project_config_data,
+        mock_molecule_file_exists):
+    c = temp_files(content=[default_config_data, project_config_data])
+    config_instance = config.Config(configs=c).config
+
+    assert 'bar' == config_instance['foo']
+    assert 'project-override' == config_instance['baz']
+
+
+def test_combine_local_config_overrides_default_and_project_config(
+        temp_files, default_config_data, project_config_data,
+        local_config_data, mock_molecule_file_exists):
+    c = temp_files(
+        content=[default_config_data, project_config_data, local_config_data])
+    config_instance = config.Config(configs=c).config
+
+    assert 'local-override' == config_instance['foo']
+    assert 'local-override' == config_instance['baz']

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -24,7 +24,7 @@ from molecule import core
 
 
 @pytest.fixture()
-def molecule():
+def molecule(mock_molecule_file_exists):
     return core.Molecule(dict())
 
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -27,22 +27,15 @@ from molecule import state
 
 
 @pytest.fixture()
-def state_file(tmpdir, request):
-    d = tmpdir.mkdir('molecule')
-    c = d.join(os.extsep.join(('state', 'yml')))
-
-    def cleanup():
-        os.remove(c.strpath)
-        os.rmdir(d.strpath)
-
-    request.addfinalizer(cleanup)
-
-    return c.strpath
+def state_data():
+    return {}
 
 
 @pytest.fixture()
-def state_instance(state_file):
-    return state.State(state_file=state_file)
+def state_instance(temp_files, state_data):
+    c = temp_files(content=[state_data])[0]
+
+    return state.State(state_file=c)
 
 
 def test_converged(state_instance):

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -27,32 +27,6 @@ import pytest
 from molecule import utilities
 
 
-@pytest.fixture()
-def simple_dict_a():
-    return {"name": "remy", "city": "Berkeley", "age": 21}
-
-
-@pytest.fixture()
-def simple_dict_b():
-    return {"name": "remy", "city": "Austin"}
-
-
-@pytest.fixture()
-def deep_dict_a():
-    return {"users": {"remy": {"email": "remy@cisco.com",
-                               "office": "San Jose",
-                               "age": 21}}}
-
-
-@pytest.fixture()
-def deep_dict_b():
-    return {
-        "users": {"remy": {"email": "remy@cisco.com",
-                           "office": "Austin",
-                           "position": "python master"}}
-    }
-
-
 def test_print_success(capsys):
     utilities.print_success('test')
     result, _ = capsys.readouterr()
@@ -71,86 +45,6 @@ def test_print_info(capsys):
     expected, _ = capsys.readouterr()
 
     assert expected == result
-
-
-def test_merge_simple_simple_00(simple_dict_a, simple_dict_b):
-    expected = {"name": "remy", "city": "Austin", "age": 21}
-    actual = utilities.merge_dicts(simple_dict_a, simple_dict_b)
-
-    expected == actual
-
-
-def test_merge_simple_simple_01(simple_dict_b, simple_dict_a):
-    expected = {"name": "remy", "city": "Berkeley", "age": 21}
-    actual = utilities.merge_dicts(simple_dict_b, simple_dict_a)
-
-    assert expected == actual
-
-
-def test_merge_simple_deep_00(simple_dict_a, deep_dict_a):
-    expected = {
-        "name": "remy",
-        "city": "Berkeley",
-        "age": 21,
-        "users": {"remy": {"email": "remy@cisco.com",
-                           "office": "San Jose",
-                           "age": 21}}
-    }
-    actual = utilities.merge_dicts(simple_dict_a, deep_dict_a)
-
-    assert expected == actual
-
-
-def test_merge_simple_deep_01(deep_dict_a, simple_dict_a):
-    expected = {
-        "name": "remy",
-        "city": "Berkeley",
-        "age": 21,
-        "users": {"remy": {"email": "remy@cisco.com",
-                           "office": "San Jose",
-                           "age": 21}}
-    }
-    actual = utilities.merge_dicts(deep_dict_a, simple_dict_a)
-
-    assert expected == actual
-
-
-def test_merge_deep_deep_00(deep_dict_a, deep_dict_b):
-    expected = {
-        "users": {"remy": {"age": 21,
-                           "email": "remy@cisco.com",
-                           "office": "Austin",
-                           "position": "python master"}}
-    }
-    actual = utilities.merge_dicts(deep_dict_a, deep_dict_b)
-
-    assert expected == actual
-
-
-def test_merge_deep_deep_01(deep_dict_a, deep_dict_b):
-    expected = {
-        "users": {"remy": {"age": 21,
-                           "email": "remy@cisco.com",
-                           "office": "Austin",
-                           "position": "python master"}}
-    }
-    with pytest.raises(LookupError):
-        actual = utilities.merge_dicts(deep_dict_a,
-                                       deep_dict_b,
-                                       raise_conflicts=True)
-        assert expected == actual
-
-
-def test_merge_deep_deep_02(deep_dict_b, deep_dict_a):
-    expected = {
-        "users": {"remy": {"age": 21,
-                           "email": "remy@cisco.com",
-                           "office": "San Jose",
-                           "position": "python master"}}
-    }
-    actual = utilities.merge_dicts(deep_dict_b, deep_dict_a)
-
-    assert expected == actual
 
 
 # TODO(retr0h): Cleanup how we deal with temp files
@@ -259,3 +153,16 @@ def test_sysexit_with_custom_code():
         utilities.sysexit(2)
 
     assert 2 == e.value.code
+
+
+def test_merge_dicts():
+    # Example taken from python-anyconfig/anyconfig/__init__.py
+    a = {'b': [{'c': 0}, {'c': 2}], 'd': {'e': 'aaa', 'f': 3}}
+    b = {'a': 1, 'b': [{'c': 3}], 'd': {'e': 'bbb'}}
+    expected = {'a': 1,
+                'b': [{'c': 0}, {'c': 2}, {'c': 3}],
+                'd': {'e': "bbb",
+                      'f': 3}}
+    result = utilities.merge_dicts(a, b)
+
+    assert expected == result


### PR DESCRIPTION
#Integrated a config class that doesn't involve having to maintain
custom dictionary merging code.  `Anyconfig`[0] is a great tool, with
far more sweat and tears invested in it.

* Molecule config is hard coded to simply `molecule.yml` in the current
  directory.  It no longer allows various locations to find a config.
* The config loading is default -> project -> local.  This means a local
  config can override anything else.
* Implemented tests which utilize a tmpdir config fixture.
* Updated documentation

[0] https://github.com/ssato/python-anyconfig

Fixes: #260