### PR TITLE
#273: Add support for Docker port bindings

### DIFF
--- a/docs/source/provisioners.rst
+++ b/docs/source/provisioners.rst
@@ -32,6 +32,9 @@ The available params for docker containers are:
 * ``privileged`` - **(OPTIONAL)** whether or not to run the container in privileged mode (boolean)
 * ``registry`` - **(OPTIONAL)** the registry to obtain the image
 * ``install_python`` - **(default=yes)** install python onto the image being used
+* ``port_bindings`` - **(OPTIONAL)** the port mapping between the Docker host and the container.
+  This is passed to docker-py as the [port_bindings host config](https://github.com/docker/docker-py/blob/master/docs/port-bindings.md).
+
 
 The available param for the docker provisioner itself is:
 * ``install_python`` - **(default=yes)** install python onto all images for all containers
@@ -47,15 +50,17 @@ Docker Example
         - name: foo-01
           ansible_groups:
           - group1
-            image: ubuntu
-            image_version: latest
-            privileged: True
-          - name: foo-02
-            ansible_groups:
-              - group2
-            image: ubuntu
-            image_version: latest
-            registry: testhost:5323
+          image: ubuntu
+          image_version: latest
+          privileged: True
+          port_bindings:
+            80: 80
+        - name: foo-02
+          ansible_groups:
+            - group2
+          image: ubuntu
+          image_version: latest
+          registry: testhost:5323
 
 Vagrant Provisioner
 -------------------
@@ -141,5 +146,3 @@ Openstack instance example
 
 Implementing Provisioners
 -------------------------
-
-

--- a/tests/provisioner/test_dockerprovisioner.py
+++ b/tests/provisioner/test_dockerprovisioner.py
@@ -40,6 +40,10 @@ def docker_data():
                 {'name': 'test1',
                  'image': 'ubuntu',
                  'image_version': 'latest',
+                 'port_bindings': {
+                     80: 80,
+                     443: 443
+                 },
                  'ansible_groups': ['group1']}, {'name': 'test2',
                                                  'image': 'ubuntu',
                                                  'image_version': 'latest',
@@ -98,6 +102,27 @@ def test_status(docker_instance):
 
     assert 'docker' in docker_instance.status()[0].provider
     assert 'docker' in docker_instance.status()[1].provider
+
+    docker_instance.destroy()
+
+
+def test_port_bindings(docker_instance):
+    docker_instance.up()
+
+    assert docker_instance.status()[0].ports == []
+    assert docker_instance.status()[1].ports == [
+        {
+            'PublicPort': 443,
+            'PrivatePort': 443,
+            'IP': '0.0.0.0',
+            'Type': 'tcp'
+        }, {
+            'PublicPort': 80,
+            'PrivatePort': 80,
+            'IP': '0.0.0.0',
+            'Type': 'tcp'
+        }
+    ]
 
     docker_instance.destroy()
 


### PR DESCRIPTION
This addresses #273 by passing `port_bindings` from `molecule.yml` to the docker-py `create_container()` method.

More information about the supported datatype can be found in the [docker-py docs](https://github.com/docker/docker-py/blob/master/docs/port-bindings.md)