### PR TITLE
Corrected `molecule init`

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -371,25 +371,6 @@ The merge order is default -> project -> local, meaning that elements at
 the top of the above list will be merged last, and have greater precedence
 than elements at the bottom of the list.
 
-Using Molecule For Deployment
------------------------------
-
-In some cases, it may be desirable to use molecule to manage existing inventory, such as a lab.
-Molecule has limited support for this concept by allowing a user to omit the ``vagrant`` block
-in molecule.yml, and then specifying a path to ansible.cfg and inventory files. Molecule will
-skip instance management in this scenario and only call ansible-playbook. Currently, only
-molecule's ``converge`` command works in this configuration.
-
-A molecule.yml such as this will trigger the described behavior:
-
-.. code-block:: yaml
-
-    ansible:
-      playbook: playbook.yml
-      config_file: /path/to/ansible.cfg
-      inventory_file: /path/to/ansible_inventory
-      extra_vars: my_var1=var1 my_var2=var2
-
 Using Molecule In Travis
 ------------------------
 

--- a/molecule/commands/converge.py
+++ b/molecule/commands/converge.py
@@ -70,10 +70,6 @@ class Converge(base.BaseCommand):
                 create_instances = True
                 create_inventory = True
 
-        if self.static:
-            create_instances = False
-            create_inventory = False
-
         if create_instances and not idempotent:
             command_args, args = utilities.remove_args(self.command_args,
                                                        self.args, ['--tags'])

--- a/molecule/commands/create.py
+++ b/molecule/commands/create.py
@@ -38,9 +38,6 @@ class Create(base.BaseCommand):
     """
 
     def execute(self, exit=True):
-        if self.static:
-            self.disabled('create')
-
         self.molecule._remove_inventory_file()
         self.molecule._create_templates()
         try:

--- a/molecule/commands/destroy.py
+++ b/molecule/commands/destroy.py
@@ -44,9 +44,6 @@ class Destroy(base.BaseCommand):
 
         :return: None
         """
-        if self.static:
-            self.disabled('destroy')
-
         self.molecule._create_templates()
         try:
             utilities.print_info("Destroying instances ...")

--- a/molecule/commands/idempotence.py
+++ b/molecule/commands/idempotence.py
@@ -37,9 +37,6 @@ class Idempotence(base.BaseCommand):
     """
 
     def execute(self, exit=True):
-        if self.static:
-            self.disabled('idempotence')
-
         utilities.print_info(
             'Idempotence test in progress (can take a few minutes)...')
 

--- a/molecule/commands/init.py
+++ b/molecule/commands/init.py
@@ -37,6 +37,9 @@ class Init(base.BaseCommand):
         init [<role>] [--docker | --openstack] [--offline]
     """
 
+    def main(self):
+        pass
+
     def clean_meta_main(self, role_path):
         main_path = os.path.join(role_path, 'meta', 'main.yml')
         temp_path = os.path.join(role_path, 'meta', 'main.yml.tmp')

--- a/molecule/commands/list.py
+++ b/molecule/commands/list.py
@@ -35,9 +35,6 @@ class List(base.BaseCommand):
     """
 
     def execute(self):
-        if self.static:
-            self.disabled('list')
-
         porcelain = self.molecule._args['-m'] or self.molecule._args[
             '--porcelain']
         self.molecule._print_valid_platforms(porcelain=porcelain)

--- a/molecule/commands/login.py
+++ b/molecule/commands/login.py
@@ -36,9 +36,6 @@ class Login(base.BaseCommand):
     """
 
     def execute(self):
-        if self.static:
-            self.disabled('login')
-
         # Collect the list of running hosts.
         try:
             status = self.molecule._provisioner.status()

--- a/molecule/commands/status.py
+++ b/molecule/commands/status.py
@@ -42,9 +42,6 @@ class Status(base.BaseCommand):
     """
 
     def execute(self):
-        if self.static:
-            self.disabled('status')
-
         display_all = not any([self.args['--hosts'], self.args['--platforms'],
                                self.args['--providers']])
 

--- a/molecule/commands/test.py
+++ b/molecule/commands/test.py
@@ -39,9 +39,6 @@ class Test(base.BaseCommand):
     """
 
     def execute(self):
-        if self.static:
-            self.disabled('test')
-
         command_args, args = utilities.remove_args(
             self.command_args, self.args, self.command_args)
 

--- a/molecule/commands/verify.py
+++ b/molecule/commands/verify.py
@@ -44,9 +44,6 @@ class Verify(base.BaseCommand):
     """
 
     def execute(self, exit=True):
-        if self.static:
-            self.disabled('verify')
-
         serverspec_dir = self.molecule._config.config['molecule'][
             'serverspec_dir']
         testinfra_dir = self.molecule._config.config['molecule'][

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -25,18 +25,18 @@ import anyconfig
 
 from molecule import utilities
 
-CONFIG_PATHS = [os.path.join(
-    os.path.dirname(__file__), 'conf/defaults.yml'), 'molecule.yml',
-                '~/.config/molecule/config.yml']
+DEFAULT_CONFIG = os.path.join(os.path.dirname(__file__), 'conf/defaults.yml')
+PROJECT_CONFIG = 'molecule.yml'
+LOCAL_CONFIG = '~/.config/molecule/config.yml'
 
 
 class Config(object):
-    def __init__(self, configs=CONFIG_PATHS):
+    def __init__(self, configs=[DEFAULT_CONFIG, PROJECT_CONFIG, LOCAL_CONFIG]):
         self.config = self._get_config(configs)
 
     @property
     def molecule_file(self):
-        return 'molecule.yml'
+        return PROJECT_CONFIG
 
     def build_easy_paths(self):
         """
@@ -75,29 +75,16 @@ class Config(object):
         :param platform: platform name to pass to underlying format_instance_name call
         :return: None
         """
-        # assume static inventory if there's no vagrant section
-        if self.config.get('vagrant') is None:
-            return
-
-        # assume static inventory if no instances are listed
-        if self.config['vagrant'].get('instances') is None:
-            return
-
         for instance in self.config['vagrant']['instances']:
             instance['vm_name'] = utilities.format_instance_name(
                 instance['name'], platform,
                 self.config['vagrant']['instances'])
 
-    def _get_config(self, configs):
-        if not self._has_molecule_file():
-            error = '\nUnable to find {}. Exiting.'
-            utilities.logger.error(error.format(self.molecule_file))
-            utilities.sysexit()
-
-        return self._combine(configs)
-
-    def _has_molecule_file(self):
+    def molecule_file_exists(self):
         return os.path.isfile(self.molecule_file)
+
+    def _get_config(self, configs):
+        return self._combine(configs)
 
     def _combine(self, configs):
         """ Perform a prioritized recursive merge of serveral source files,

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -48,14 +48,8 @@ class Molecule(object):
         self._provisioner = None
 
     def main(self):
-        if self._args.get('<command>') == 'init':
-            return  # exits program
-
-        # ensure the .molecule directory exists
-        if not os.path.isdir(os.path.join(os.curdir, self._config.config[
-                'molecule']['molecule_dir'])):
-            os.mkdir(os.path.join(os.curdir, self._config.config['molecule'][
-                'molecule_dir']))
+        if not os.path.exists(self._config.config['molecule']['molecule_dir']):
+            os.makedirs(self._config.config['molecule']['molecule_dir'])
 
         # concatentate file names and paths within config so they're more convenient to use
         self._config.build_easy_paths()
@@ -85,9 +79,6 @@ class Molecule(object):
             self._print_valid_platforms()
             utilities.sysexit()
 
-        if not os.path.exists(self._config.config['molecule']['molecule_dir']):
-            os.makedirs(self._config.config['molecule']['molecule_dir'])
-
         # updates instances config with full machine names
         self._config.populate_instance_names(self._env['MOLECULE_PLATFORM'])
 
@@ -96,6 +87,9 @@ class Molecule(object):
                             yaml.dump(self._config.config,
                                       default_flow_style=False,
                                       indent=2))
+        self._add_or_update_vars('group_vars')
+        self._add_or_update_vars('host_vars')
+        self._symlink_vars()
 
     def get_provisioner(self):
         if 'vagrant' in self._config.config:

--- a/molecule/provisioners/vagrantprovisioner.py
+++ b/molecule/provisioners/vagrantprovisioner.py
@@ -89,14 +89,6 @@ class VagrantProvisioner(baseprovisioner.BaseProvisioner):
 
     @property
     def default_provider(self):
-        # assume static inventory if there's no vagrant section
-        if self.m._config.config.get('vagrant') is None:
-            return 'static'
-
-        # assume static inventory if no providers are listed
-        if self.m._config.config['vagrant'].get('providers') is None:
-            return 'static'
-
         # take config's default_provider if specified, otherwise use the first in the provider list
         default_provider = self.m._config.config['molecule'].get(
             'default_provider')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,12 +44,3 @@ def temp_files(tmpdir, request):
         return confs
 
     return wrapper
-
-
-@pytest.fixture()
-def mock_molecule_file_exists(monkeypatch):
-    def mockreturn(m):
-        return True
-
-    return monkeypatch.setattr('molecule.config.Config._has_molecule_file',
-                               mockreturn)

--- a/tests/provisioner/test_dockerprovisioner.py
+++ b/tests/provisioner/test_dockerprovisioner.py
@@ -51,7 +51,7 @@ def docker_data():
 
 
 @pytest.fixture()
-def molecule_instance(temp_files, docker_data, mock_molecule_file_exists):
+def molecule_instance(temp_files, docker_data):
     c = temp_files(content=[docker_data])
     m = core.Molecule(dict())
     m._config = config.Config(configs=c)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -24,7 +24,7 @@ from molecule import core
 
 
 @pytest.fixture()
-def molecule(mock_molecule_file_exists):
+def molecule():
     return core.Molecule(dict())
 
 


### PR DESCRIPTION
Corrected bug introduced in #268.  Removed duplicate "are we running
the init command" logic from both the core and command base class.

The `init` sub command is unique to other commands.  It doesn't require
a `molecule.yml`.  Moved this logic into a method, in the parent class,
so the children can change the behavior.

Also disabled static inventory introduced in #40.  We never used this,
and the core needs refactored before we attempt to reintroduce it.

Fixes: #275