### PR TITLE
Update and fix serverspec for all platforms

### DIFF
--- a/demo/molecule/molecule.yml
+++ b/demo/molecule/molecule.yml
@@ -17,6 +17,15 @@ vagrant:
     - name: demo-01
       ansible_groups:
         - demo
+        - demo1
+      interfaces:
+        - network_name: private_network
+          type: dhcp
+          auto_config: true
+    - name: demo-02
+      ansible_groups:
+        - demo
+        - demo2
       interfaces:
         - network_name: private_network
           type: dhcp

--- a/demo/molecule/playbook.yml
+++ b/demo/molecule/playbook.yml
@@ -2,3 +2,30 @@
 - hosts: all
   roles:
     - role: molecule
+
+- hosts: demo
+  tasks:
+    - name: Create /etc/molecule/demo to test tasks targeting demo group
+      copy: dest=/etc/molecule/demo
+            group=root
+            owner=root
+            mode=0644
+            content="molecule demo file should appear on all instances in demo group"
+
+- hosts: demo1
+  tasks:
+    - name: Create /etc/molecule/demo1 to test tasks targeting demo1 group
+      copy: dest=/etc/molecule/demo1
+            group=root
+            owner=root
+            mode=0644
+            content="molecule demo1 file should appear on instances in demo1 group"
+
+- hosts: demo2
+  tasks:
+    - name: Create /etc/molecule/demo2 to test tasks targeting demo2 group
+      copy: dest=/etc/molecule/demo2
+            group=root
+            owner=root
+            mode=0644
+            content="molecule demo2 file should appear on instances in demo2 group"

--- a/demo/molecule/spec/default_spec.rb
+++ b/demo/molecule/spec/default_spec.rb
@@ -1,9 +1,16 @@
 require 'spec_helper'
 
 describe file('/etc/molecule') do
+  it { should be_a_directory }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
+  it { should be_mode 755 }
+end
+
+describe file('/etc/molecule/demo') do
   it { should be_a_file }
   it { should be_owned_by 'root' }
   it { should be_grouped_into 'root' }
   it { should be_mode 644 }
-  it { should contain 'molecule test file' }
+  it { should contain 'molecule demo file' }
 end

--- a/demo/molecule/spec/groups/aio/default_spec.rb
+++ b/demo/molecule/spec/groups/aio/default_spec.rb
@@ -1,8 +1,0 @@
-require 'spec_helper'
-
-describe file('/etc/hosts') do
-  it { should be_a_file }
-  it { should be_owned_by 'root' }
-  it { should be_grouped_into 'root' }
-  it { should be_mode 644 }
-end

--- a/demo/molecule/spec/groups/demo1/default_spec.rb
+++ b/demo/molecule/spec/groups/demo1/default_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe file('/etc/molecule/demo1') do
+  it { should be_a_file }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
+  it { should be_mode 644 }
+  it { should contain 'molecule demo1 file' }
+end
+
+describe file('/etc/molecule/demo2') do
+  it { should_not exist }
+end

--- a/demo/molecule/spec/groups/demo2/default_spec.rb
+++ b/demo/molecule/spec/groups/demo2/default_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe file('/etc/molecule/demo2') do
+  it { should be_a_file }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
+  it { should be_mode 644 }
+  it { should contain 'molecule demo2 file' }
+end
+
+describe file('/etc/molecule/demo1') do
+  it { should_not exist }
+end

--- a/demo/molecule/tasks/main.yml
+++ b/demo/molecule/tasks/main.yml
@@ -5,12 +5,12 @@
 - include: debian.yml
   when: ansible_os_family == 'Debian'
 
-- name: Create a file so we can test something with serverspec
-  copy: dest=/etc/molecule
+- name: Create /etc/molecule on all hosts
+  file: dest=/etc/molecule
         group=root
         owner=root
-        mode=0644
-        content="molecule test file"
+        mode=0755
+        state=directory
 
 - name: Test ability to target ansible tags (molecule1)
   shell: /bin/true

--- a/demo/molecule/tests/test_default.py
+++ b/demo/molecule/tests/test_default.py
@@ -6,6 +6,7 @@ def test_etc_molecule(File):
     assert f.group == 'root'
     assert f.mode == 0o755
 
+
 def test_etc_molecule_demo(File):
     f = File('/etc/molecule/demo')
 

--- a/demo/molecule/tests/test_default.py
+++ b/demo/molecule/tests/test_default.py
@@ -1,5 +1,16 @@
-def test_hosts_file(File):
-    hosts = File('/etc/hosts')
+def test_etc_molecule(File):
+    f = File('/etc/molecule')
 
-    assert hosts.user == 'root'
-    assert hosts.group == 'root'
+    assert f.is_directory
+    assert f.user == 'root'
+    assert f.group == 'root'
+    assert f.mode == 0o755
+
+def test_etc_molecule_demo(File):
+    f = File('/etc/molecule/demo')
+
+    assert f.is_file
+    assert f.user == 'root'
+    assert f.group == 'root'
+    assert f.mode == 0o644
+    assert f.contains('molecule demo file')

--- a/demo/molecule/tests/test_demo1.py
+++ b/demo/molecule/tests/test_demo1.py
@@ -1,0 +1,16 @@
+testinfra_hosts = ['demo1']
+
+def test_etc_molecule_demo1(File):
+    f = File('/etc/molecule/demo1')
+
+    assert f.is_file
+    assert f.user == 'root'
+    assert f.group == 'root'
+    assert f.mode == 0o644
+    assert f.contains('molecule demo1 file')
+
+
+def test_etc_molecule_demo2(File):
+    f = File('/etc/molecule/demo2')
+
+    assert not f.exists

--- a/demo/molecule/tests/test_demo1.py
+++ b/demo/molecule/tests/test_demo1.py
@@ -1,5 +1,6 @@
 testinfra_hosts = ['demo1']
 
+
 def test_etc_molecule_demo1(File):
     f = File('/etc/molecule/demo1')
 

--- a/demo/molecule/tests/test_demo2.py
+++ b/demo/molecule/tests/test_demo2.py
@@ -1,0 +1,15 @@
+testinfra_hosts = ['demo2']
+
+def test_etc_molecule_demo2(File):
+    f = File('/etc/molecule/demo2')
+
+    assert f.is_file
+    assert f.user == 'root'
+    assert f.group == 'root'
+    assert f.mode == 0o644
+    assert f.contains('molecule demo2 file')
+
+def test_etc_molecule_demo1(File):
+    f = File('/etc/molecule/demo1')
+
+    assert not f.exists

--- a/demo/molecule/tests/test_demo2.py
+++ b/demo/molecule/tests/test_demo2.py
@@ -1,5 +1,6 @@
 testinfra_hosts = ['demo2']
 
+
 def test_etc_molecule_demo2(File):
     f = File('/etc/molecule/demo2')
 
@@ -8,6 +9,7 @@ def test_etc_molecule_demo2(File):
     assert f.group == 'root'
     assert f.mode == 0o644
     assert f.contains('molecule demo2 file')
+
 
 def test_etc_molecule_demo1(File):
     f = File('/etc/molecule/demo1')

--- a/molecule/commands/create.py
+++ b/molecule/commands/create.py
@@ -52,4 +52,5 @@ class Create(base.BaseCommand):
                 utilities.sysexit(e.returncode)
             return e.returncode, e.message
         self.molecule._create_inventory_file()
+        self.molecule._write_instances_state()
         return None, None

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -224,10 +224,10 @@ class Molecule(object):
             instance_name = utilities.format_instance_name(
                 instance['name'], self._provisioner._platform,
                 self._provisioner.instances)
-            instances[instance_name] = []
+            instances[instance_name]['ansible_groups'] = []
             if 'ansible_groups' in instance:
                 for group in instance['ansible_groups']:
-                    instances[instance_name].append(group)
+                    instances[instance_name]['ansible_groups'].append(group)
 
         self._state.change_state('instances', instances)
 

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -234,6 +234,9 @@ class Molecule(object):
 
         return dict(instances)
 
+    def _write_instances_state(self):
+        self._state.change_state('hosts', self._instances_state())
+
     def _create_inventory_file(self):
         """
         Creates the inventory file used by molecule and later passed to ansible-playbook.
@@ -266,7 +269,6 @@ class Molecule(object):
                     self._provisioner.instances))
 
         inventory_file = self._config.config['ansible']['inventory_file']
-        self._state.change_state('hosts', self._instances_state())
         try:
             utilities.write_file(inventory_file, inventory)
         except IOError:

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -212,7 +212,6 @@ class Molecule(object):
             self._config.config['molecule']['rakefile_template'],
             self._config.config['molecule']['rakefile_file'], kwargs=kwargs)
 
-    @property
     def _instances_state(self):
         """
         Creates a dict of formatted instances names and the group(s) they're
@@ -267,7 +266,7 @@ class Molecule(object):
                     self._provisioner.instances))
 
         inventory_file = self._config.config['ansible']['inventory_file']
-        self._state.change_state('hosts', self._instances_state)
+        self._state.change_state('hosts', self._instances_state())
         try:
             utilities.write_file(inventory_file, inventory)
         except IOError:

--- a/molecule/provisioners/dockerprovisioner.py
+++ b/molecule/provisioners/dockerprovisioner.py
@@ -113,7 +113,7 @@ class DockerProvisioner(baseprovisioner.BaseProvisioner):
             dockerfile = '''
             FROM {}:{}
             RUN bash -c 'if [ -x "$(command -v apt-get)" ]; then apt-get update && apt-get install -y python sudo; fi'
-            RUN bash -c 'if [ -x "$(command -v yum)" ]; then yum makecache fast && yum update -y && yum install -y python sudo; fi'
+            RUN bash -c 'if [ -x "$(command -v yum)" ]; then yum makecache fast && yum update -y && yum install -y python sudo; fi'  # NOQA
 
             '''  # noqa
 

--- a/molecule/provisioners/dockerprovisioner.py
+++ b/molecule/provisioners/dockerprovisioner.py
@@ -113,7 +113,7 @@ class DockerProvisioner(baseprovisioner.BaseProvisioner):
             dockerfile = '''
             FROM {}:{}
             RUN bash -c 'if [ -x "$(command -v apt-get)" ]; then apt-get update && apt-get install -y python sudo; fi'
-            RUN bash -c 'if [ -x "$(command -v yum)" ]; then yum makecache fast && yum update -y && yum install -y python sudo; fi'  # NOQA
+            RUN bash -c 'if [ -x "$(command -v yum)" ]; then yum makecache fast && yum update -y && yum install -y python sudo; fi'
 
             '''  # noqa
 

--- a/molecule/state.py
+++ b/molecule/state.py
@@ -30,8 +30,7 @@ import yaml
 
 from molecule import utilities
 
-VALID_KEYS = ['converged', 'created', 'default_platform', 'default_provider',
-              'multiple_platforms', 'customconf']
+VALID_KEYS = ['converged', 'created', 'customconf', 'default_platform', 'default_provider', 'instances', 'multiple_platforms']
 
 
 class InvalidState(Exception):
@@ -66,6 +65,10 @@ class State(object):
     @property
     def default_provider(self):
         return self._data.get('default_provider')
+
+    @property
+    def instances(self):
+        return self._data.get('instances')
 
     @property
     def multiple_platforms(self):
@@ -106,6 +109,7 @@ class State(object):
             "created": None,
             "default_platform": None,
             "default_provider": None,
+            "instances": None,
             "multiple_platforms": None
         }
 

--- a/molecule/state.py
+++ b/molecule/state.py
@@ -30,7 +30,8 @@ import yaml
 
 from molecule import utilities
 
-VALID_KEYS = ['converged', 'created', 'customconf', 'default_platform', 'default_provider', 'hosts', 'multiple_platforms']
+VALID_KEYS = ['converged', 'created', 'customconf', 'default_platform',
+              'default_provider', 'hosts', 'multiple_platforms']
 
 
 class InvalidState(Exception):

--- a/molecule/state.py
+++ b/molecule/state.py
@@ -30,7 +30,7 @@ import yaml
 
 from molecule import utilities
 
-VALID_KEYS = ['converged', 'created', 'customconf', 'default_platform', 'default_provider', 'instances', 'multiple_platforms']
+VALID_KEYS = ['converged', 'created', 'customconf', 'default_platform', 'default_provider', 'hosts', 'multiple_platforms']
 
 
 class InvalidState(Exception):
@@ -67,8 +67,8 @@ class State(object):
         return self._data.get('default_provider')
 
     @property
-    def instances(self):
-        return self._data.get('instances')
+    def hosts(self):
+        return self._data.get('hosts')
 
     @property
     def multiple_platforms(self):
@@ -109,7 +109,7 @@ class State(object):
             "created": None,
             "default_platform": None,
             "default_provider": None,
-            "instances": None,
+            "hosts": None,
             "multiple_platforms": None
         }
 

--- a/molecule/templates/rakefile.j2
+++ b/molecule/templates/rakefile.j2
@@ -12,11 +12,11 @@ instances = YAML.load_file('{{ state_file }}')['instances']
 
 namespace :serverspec do
   task all: instances.keys
-  instances.each do |name, groups|
+  instances.each do |name, instance|
     desc "Run serverspec on #{name}"
     pattern = ['{{ serverspec_dir }}/*_spec.rb', "{{ serverspec_dir }}/#{name}/*_spec.rb", "{{ serverspec_dir }}/hosts/#{name}/*_spec.rb"]
 
-    groups.each do |group|
+    instance['ansible_groups'].each do |group|
       pattern << "{{ serverspec_dir }}/#{group}/*_spec.rb"
       pattern << "{{ serverspec_dir }}/groups/#{group}/*_spec.rb"
     end

--- a/molecule/templates/rakefile.j2
+++ b/molecule/templates/rakefile.j2
@@ -8,44 +8,22 @@ require 'fileutils'
 task spec: 'serverspec:all'
 task default: :spec
 
-env = YAML.load_file('{{ molecule_file }}')['vagrant']
-
-if env.nil?
-	puts "No vagrant instances defined. "
-	instances = {}
-else
-	instances = env['instances']
-end
-instances_to_test = {}
-instances.each do |instance|
-  instance_name = instance['name']
-  if instance.key?('options')
-    if instance['options'].key?('append_platform_to_hostname')
-      if instance['options']['append_platform_to_hostname']
-        instance_name = instance['name'] + '-{{ current_platform }}'
-      end
-    end
-  end
-  instances_to_test[instance_name] = instance
-end
+instances = YAML.load_file('{{ state_file }}')['instances']
 
 namespace :serverspec do
-  task all: instances_to_test.keys.map { |h| h }
-  instances_to_test.each do |vm_name, instance|
-    desc "Run serverspec on #{vm_name}"
-    pattern = ['{{ serverspec_dir }}/*_spec.rb', "{{ serverspec_dir }}/#{instance['name']}/*_spec.rb", "{{ serverspec_dir }}/hosts/#{instance['name']}/*_spec.rb"]
+  task all: instances.keys
+  instances.each do |name, groups|
+    desc "Run serverspec on #{name}"
+    pattern = ['{{ serverspec_dir }}/*_spec.rb', "{{ serverspec_dir }}/#{name}/*_spec.rb", "{{ serverspec_dir }}/hosts/#{name}/*_spec.rb"]
 
-    if instance.key?('ansible_groups') && instance['ansible_groups'].nil? == false
-      instance['ansible_groups'].each do |group|
-        pattern << "{{ serverspec_dir }}/#{group}/*_spec.rb"
-        pattern << "{{ serverspec_dir }}/groups/#{group}/*_spec.rb"
+    groups.each do |group|
+      pattern << "{{ serverspec_dir }}/#{group}/*_spec.rb"
+      pattern << "{{ serverspec_dir }}/groups/#{group}/*_spec.rb"
     end
 
-    end
-
-    RSpec::Core::RakeTask.new(vm_name.to_sym) do |target|
-      puts "*** Run serverspec on #{vm_name} instance ***"
-      ENV['TARGET_HOST'] = vm_name
+    RSpec::Core::RakeTask.new(name.to_sym) do |target|
+      puts "*** Run serverspec on #{name} instance ***"
+      ENV['TARGET_HOST'] = name
       target.pattern = pattern.join(',')
     end
   end

--- a/molecule/templates/rakefile.j2
+++ b/molecule/templates/rakefile.j2
@@ -8,21 +8,21 @@ require 'fileutils'
 task spec: 'serverspec:all'
 task default: :spec
 
-instances = YAML.load_file('{{ state_file }}')['instances']
+hosts = YAML.load_file('{{ state_file }}')['hosts']
 
 namespace :serverspec do
-  task all: instances.keys
-  instances.each do |name, instance|
+  task all: hosts.keys
+  hosts.each do |name, host|
     desc "Run serverspec on #{name}"
     pattern = ['{{ serverspec_dir }}/*_spec.rb', "{{ serverspec_dir }}/#{name}/*_spec.rb", "{{ serverspec_dir }}/hosts/#{name}/*_spec.rb"]
 
-    instance['ansible_groups'].each do |group|
+    host['groups'].each do |group|
       pattern << "{{ serverspec_dir }}/#{group}/*_spec.rb"
       pattern << "{{ serverspec_dir }}/groups/#{group}/*_spec.rb"
     end
 
     RSpec::Core::RakeTask.new(name.to_sym) do |target|
-      puts "*** Run serverspec on #{name} instance ***"
+      puts "*** Run serverspec on #{name} ***"
       ENV['TARGET_HOST'] = name
       target.pattern = pattern.join(',')
     end

--- a/molecule/validators.py
+++ b/molecule/validators.py
@@ -141,7 +141,7 @@ def rubocop(serverspec_dir,
 def rake(rakefile,
          debug=False,
          env=os.environ.copy(),
-         out=utilities.logger.warning,
+         out=utilities.logger.info,
          err=utilities.logger.error):
     """
     Runs rake with specified rakefile

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -23,9 +23,19 @@ import pytest
 from molecule import core
 
 
+class TestProvisioner():
+    def __init__(self):
+        self.instances = [{'name': 'demo-01',
+                           'ansible_groups': ['demo', 'demo1'],
+                           'options': {'append_platform_to_hostname': True}}]
+        self._platform = 'centos7'
+
+
 @pytest.fixture()
 def molecule():
-    return core.Molecule(dict())
+    m = core.Molecule(dict())
+    m._provisioner = TestProvisioner()
+    return m
 
 
 def test_parse_provisioning_output_failure_00(molecule):
@@ -59,3 +69,8 @@ vagrant-01-ubuntu              : ok=36   changed=0    unreachable=0    failed=0
 
     assert res
     assert [] == changed_tasks
+
+
+def test_instances_state_00(molecule):
+    success_output = {'demo-01-centos7': {'groups': ['demo', 'demo1']}}
+    assert success_output == molecule._instances_state()

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -68,6 +68,16 @@ def test_customconf(state_instance):
     assert not state_instance.customconf
 
 
+def test_hosts(state_instance):
+    assert not state_instance.hosts
+
+    state_instance.change_state('hosts', {'test-01': {'groups': ['group1']}})
+    assert state_instance.hosts
+
+    state_instance.reset()
+    assert not state_instance.hosts
+
+
 def test_reset(state_instance):
     assert not state_instance.created
 


### PR DESCRIPTION
* Updated demo.molecule to have serverspec and testinfra tests that target by ansible group.
* Added method to core to save information about running instances to state. This is used now to pass info to rakefile, but will be useful in future cleanups that try to limit calls to vagrant for info.
* Updated state class to handle new information about running instances (hosts).
* Greatly simplified rakefile, and fixed serverspec so that it works with `molecule test --platform all`.
* Updated rake validator to output at INFO log level to remain consistent.
* Added tests for new core method.
* Fixes #199