### PR TITLE
Fixed parse error in openstack driver

### DIFF
--- a/molecule/commands/verify.py
+++ b/molecule/commands/verify.py
@@ -44,6 +44,7 @@ class Verify(base.BaseCommand):
     """
 
     def execute(self, exit=True):
+
         serverspec_dir = self.molecule._config.config['molecule'][
             'serverspec_dir']
         testinfra_dir = self.molecule._config.config['molecule'][

--- a/molecule/provisioners/openstackprovisioner.py
+++ b/molecule/provisioners/openstackprovisioner.py
@@ -116,6 +116,7 @@ class OpenstackProvisioner(baseprovisioner.BaseProvisioner):
         active_instances = self._openstack.list_servers()
         active_instance_names = {instance['name']: instance['status']
                                  for instance in active_instances}
+
         utilities.logger.warning("Creating openstack instances ...")
         for instance in self.instances:
             if instance['name'] not in active_instance_names:
@@ -128,7 +129,8 @@ class OpenstackProvisioner(baseprovisioner.BaseProvisioner):
                     auto_ip=True,
                     wait=True,
                     key_name=self.m._config.config['openstack']['keypair'],
-                    security_groups=instance['security_groups'])
+                    security_groups=instance['security_groups']
+                    if 'security_groups' in instance else None)
                 utilities.reset_known_host_key(server['interface_ip'])
                 instance['created'] = True
                 num_retries = 0
@@ -178,10 +180,11 @@ class OpenstackProvisioner(baseprovisioner.BaseProvisioner):
         return status_list
 
     def conf(self, name=None, ssh_config=False):
-        with open(self.m._config.config['molecule'][
+
+        with open(self.m._config.config['ansible'][
                 'inventory_file']) as instance:
             for line in instance:
-                if line.split()[0] == name:
+                if len(line.split()) > 0 and line.split()[0] == name:
                     ansible_host = line.split()[1]
                     host_address = ansible_host.split('=')[1]
                     return host_address


### PR DESCRIPTION
This PR fixes some parsing issues the openstack driver had when trying to grab the proper SSH information. Also, it no longer requires a security_group for specifying an openstack instance. 