### PR TITLE
Implement teardown in vagrant tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,14 @@ virtual machines/containers, with support for multiple Vagrant providers
 .. _`OpenStack`: https://www.openstack.org
 .. _`libvirt`: http://libvirt.org
 
+Ansible Support
+---------------
+
+* 1.9.6 - Limited (`Docker`_ and `OpenStack`_ provisioners not-supported)
+* 2.0.2.0 - Supported
+* 2.1.0.0 - Supported
+* 2.1.1.0 - In progress (#297)
+
 Quick Start
 -----------
 

--- a/tests/unit/provisioner/test_dockerprovisioner.py
+++ b/tests/unit/provisioner/test_dockerprovisioner.py
@@ -18,8 +18,8 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-import pytest
 import logging
+import pytest
 
 from molecule import config
 from molecule import core
@@ -27,8 +27,6 @@ from molecule import ansible_playbook
 from molecule.provisioners import dockerprovisioner
 
 logging.getLogger("sh").setLevel(logging.WARNING)
-
-# TODO(retr0h): Implement finalizer (teardown).
 
 
 @pytest.fixture()


### PR DESCRIPTION
Vagrant tests were not tearing down vms.  Implemented in the pytest
finalizer.

Fixes: #296