### PR TITLE
Updated roles path for functional tests

### DIFF
--- a/tests/functional/docker/scenarios/full/molecule.yml
+++ b/tests/functional/docker/scenarios/full/molecule.yml
@@ -1,7 +1,7 @@
 ---
 ansible:
   raw_env_vars:
-    ANSIBLE_ROLES_PATH: ../../../roles
+    ANSIBLE_ROLES_PATH: ../../../roles:../../../../roles
 
 docker:
   containers:

--- a/tests/functional/vagrant/scenarios/full/molecule.yml
+++ b/tests/functional/vagrant/scenarios/full/molecule.yml
@@ -1,7 +1,7 @@
 ---
 ansible:
   raw_env_vars:
-    ANSIBLE_ROLES_PATH: ../../../roles
+    ANSIBLE_ROLES_PATH: ../../../roles:../../../../roles
 
 vagrant:
   platforms:


### PR DESCRIPTION
Roles path need need to come up an extra level under ansible 2.1.1.

```
  syntax: commands succeeded
  py27-ansible19-unit: commands succeeded
  py27-ansible19-functional: commands succeeded
  py27-ansible20-unit: commands succeeded
  py27-ansible20-functional: commands succeeded
  py27-ansible21-unit: commands succeeded
  py27-ansible21-functional: commands succeeded
  docs: commands succeeded
  congratulations :)
```