### PR TITLE
Prep work before a potential 1.9 release

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,10 +47,9 @@ virtual machines/containers, with support for multiple Vagrant providers
 Ansible Support
 ---------------
 
-* 1.9.6 - Limited (`Docker`_ and `OpenStack`_ provisioners not-supported)
+* 1.9.6 - Limited (`Docker`_ provisioner not-supported by `Ansible`_)
 * 2.0.2.0 - Supported
-* 2.1.0.0 - Supported
-* 2.1.1.0 - In progress (#297)
+* 2.1.1.0 - Supported
 
 Quick Start
 -----------

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -363,11 +363,11 @@ order to test this particular role.
 Override Configuration
 ----------------------
 
-1. local config (``~/.config/molecule/config.yml``)
-2. project config
+1. project config
+2. local config (``~/.config/molecule/config.yml``)
 3. default config (``molecule.yml``)
 
-The merge order is default -> project -> local, meaning that elements at
+The merge order is default -> local -> project, meaning that elements at
 the top of the above list will be merged last, and have greater precedence
 than elements at the bottom of the list.
 

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -31,7 +31,7 @@ LOCAL_CONFIG = '~/.config/molecule/config.yml'
 
 
 class Config(object):
-    def __init__(self, configs=[DEFAULT_CONFIG, PROJECT_CONFIG, LOCAL_CONFIG]):
+    def __init__(self, configs=[DEFAULT_CONFIG, LOCAL_CONFIG, PROJECT_CONFIG]):
         self.config = self._get_config(configs)
         self._build_config_paths()
 

--- a/tests/unit/commands/test_init.py
+++ b/tests/unit/commands/test_init.py
@@ -19,13 +19,10 @@
 #  THE SOFTWARE.
 
 import os
-import logging
 
 import pytest
 
 from molecule.commands.init import Init
-
-logging.getLogger("sh").setLevel(logging.WARNING)
 
 
 @pytest.fixture()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -18,11 +18,14 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
+import logging
 import os
 import os.path
 import shutil
 
 import pytest
+
+logging.getLogger("sh").setLevel(logging.WARNING)
 
 
 @pytest.fixture()

--- a/tests/unit/provisioner/test_dockerprovisioner.py
+++ b/tests/unit/provisioner/test_dockerprovisioner.py
@@ -20,7 +20,6 @@
 
 import distutils.spawn
 import distutils.version
-import logging
 import pytest
 
 import ansible
@@ -29,8 +28,6 @@ from molecule import ansible_playbook
 from molecule import config
 from molecule import core
 from molecule.provisioners import dockerprovisioner
-
-logging.getLogger("sh").setLevel(logging.WARNING)
 
 
 def ansible_v1():

--- a/tests/unit/provisioner/test_vagrantprovisioner.py
+++ b/tests/unit/provisioner/test_vagrantprovisioner.py
@@ -18,7 +18,6 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-import logging
 import os
 import shutil
 
@@ -29,8 +28,6 @@ import yaml
 from molecule.commands import converge
 from molecule.commands import create
 from molecule.commands import destroy
-
-logging.getLogger("sh").setLevel(logging.WARNING)
 
 pytestmark = pytest.mark.skipif(
     vagrant.get_vagrant_executable() is None,


### PR DESCRIPTION
* Change the config merging order to the existing strategy
   used in molecule stable/1.x series.  The merge order is
   default -> local -> project.
* Moved unit test logging into conftest.