### PR TITLE
Test cleanups

### DIFF
--- a/molecule/config.py
+++ b/molecule/config.py
@@ -78,7 +78,9 @@ class Config(object):
 
     def _build_config_paths(self):
         """
-        Convenience function to build up paths from our config values
+        Convenience function to build up paths from our config values.  Path
+        will not be relative to ``molecule_dir``, when a full path was provided
+        in the config.
 
         :return: None
         """

--- a/tests/unit/provisioner/test_dockerprovisioner.py
+++ b/tests/unit/provisioner/test_dockerprovisioner.py
@@ -48,42 +48,8 @@ elif ansible_v1():
 
 
 @pytest.fixture()
-def docker_data():
-    return {
-        'molecule': {
-            'molecule_dir': '.test_molecule',
-            'state_file': 'state_file.yml',
-            'vagrantfile_file': 'vagrantfile_file',
-            'rakefile_file': 'rakefile_file',
-        },
-        'docker': {
-            'containers': [
-                {'name': 'test1',
-                 'image': 'ubuntu',
-                 'image_version': 'latest',
-                 'port_bindings': {
-                     80: 80,
-                     443: 443
-                 },
-                 'volume_mounts': ['/tmp/test1:/inside:rw'],
-                 'ansible_groups': ['group1']}, {'name': 'test2',
-                                                 'image': 'ubuntu',
-                                                 'image_version': 'latest',
-                                                 'ansible_groups':
-                                                 ['group2'],
-                                                 'command': '/bin/sh'}
-            ]
-        },
-        'ansible': {
-            'config_file': 'config_file',
-            'inventory_file': 'inventory_file'
-        }
-    }
-
-
-@pytest.fixture()
-def molecule_instance(temp_files, docker_data):
-    c = temp_files(content=[docker_data])
+def molecule_instance(temp_files):
+    c = temp_files(fixtures=['molecule_docker_config'])
     m = core.Molecule(dict())
     m.config = config.Config(configs=c)
 

--- a/tests/unit/provisioner/test_vagrantprovisioner.py
+++ b/tests/unit/provisioner/test_vagrantprovisioner.py
@@ -35,31 +35,10 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.fixture()
-def molecule_file(tmpdir, request):
+def molecule_file(tmpdir, request, molecule_vagrant_config):
     d = tmpdir.mkdir('molecule')
     c = d.join(os.extsep.join(('molecule', 'yml')))
-    data = {
-        'molecule': {
-            'molecule_dir': '.molecule'
-        },
-        'vagrant': {
-            'platforms': [
-                {'name': 'ubuntu',
-                 'box': 'ubuntu/trusty64'}
-            ],
-            'providers': [
-                {'name': 'virtualbox',
-                 'type': 'virtualbox'}
-            ],
-            'instances': [
-                {'name': 'aio-01'}
-            ]
-        },
-        'ansible': {
-            'config_file': 'test_config',
-            'inventory_file': 'test_inventory',
-        }
-    }
+    data = molecule_vagrant_config
     c.write(data)
 
     pbook = d.join(os.extsep.join(('playbook', 'yml')))

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -27,15 +27,8 @@ from molecule import state
 
 
 @pytest.fixture()
-def state_data():
-    return {}
-
-
-@pytest.fixture()
-def state_instance(temp_files, state_data):
-    c = temp_files(content=[state_data])[0]
-
-    return state.State(state_file=c)
+def state_instance(state_path):
+    return state.State(state_file=state_path)
 
 
 def test_converged(state_instance):


### PR DESCRIPTION
### Rework of temp_files fixture.
* Now renders a file named after the fixture.
* Fixture content is collected via requests fixture, inside the
   `temp_fles` fixtue.
* Create a random directory to place temp files inside.

### Reworked molecule config usage through tests
* Molecule config fixture now contains all molecule defaults.
* Moved the config fixtures into sections.
* Moved those sections into conftest for sharing across tests.
* Provided state file fixture to molecule config fixture.