### PR TITLE
Update login to use state data

### DIFF
--- a/molecule/commands/login.py
+++ b/molecule/commands/login.py
@@ -43,8 +43,8 @@ class Login(base.BaseCommand):
             hosts =[]
 
         try:
+            # Nowhere to log into if there is no running host.
             if len(hosts) == 0:
-                # Nowhere to log into if there is no running host.
                 raise base.InvalidHost("There are no running hosts.")
 
             # Check whether a host was specified.

--- a/molecule/commands/login.py
+++ b/molecule/commands/login.py
@@ -40,7 +40,7 @@ class Login(base.BaseCommand):
         if self.molecule._state.hosts:
             hosts = [k for k, v in self.molecule._state.hosts.iteritems()]
         else:
-            hosts =[]
+            hosts = []
 
         try:
             # Nowhere to log into if there is no running host.

--- a/molecule/commands/login.py
+++ b/molecule/commands/login.py
@@ -43,14 +43,14 @@ class Login(base.BaseCommand):
             hosts = []
 
         try:
-            # Nowhere to log into if there is no running host.
+            # Nowhere to login to if there is no running host.
             if len(hosts) == 0:
                 raise base.InvalidHost("There are no running hosts.")
 
             # Check whether a host was specified.
             if self.molecule._args['<host>'] is None:
 
-                # One running host is perfect. Log into it.
+                # One running host is perfect. Login to it.
                 if len(hosts) == 1:
                     hostname = hosts[0]
 

--- a/molecule/commands/login.py
+++ b/molecule/commands/login.py
@@ -40,10 +40,13 @@ class Login(base.BaseCommand):
         if self.molecule._state.hosts:
             hosts = [k for k, v in self.molecule._state.hosts.iteritems()]
         else:
-            # Nowhere to log into if there is no running host.
-            raise base.InvalidHost("There are no running hosts.")
+            hosts =[]
 
         try:
+            if len(hosts) == 0:
+                # Nowhere to log into if there is no running host.
+                raise base.InvalidHost("There are no running hosts.")
+
             # Check whether a host was specified.
             if self.molecule._args['<host>'] is None:
 

--- a/molecule/commands/login.py
+++ b/molecule/commands/login.py
@@ -43,7 +43,6 @@ class Login(base.BaseCommand):
             # Nowhere to log into if there is no running host.
             raise base.InvalidHost("There are no running hosts.")
 
-        # make sure vagrant knows about this host
         try:
             # Check whether a host was specified.
             if self.molecule._args['<host>'] is None:
@@ -83,7 +82,6 @@ class Login(base.BaseCommand):
             login_args = self.molecule._provisioner.login_args(hostname)
 
         except subprocess.CalledProcessError:
-            # gets appended to python-vagrant's error message
             conf_errmsg = "\nUnknown host '{}'.\n\nAvailable hosts:\n{}"
             utilities.logger.error(conf_errmsg.format(self.molecule._args[
                 '<host>'], "\n".join(hosts)))


### PR DESCRIPTION
* `molecule login` now leverages state data rather than making a slow call to provisioner.status()
* Error messaging now provides a list of available hosts rather than suggesting the user run `molecule status`

The `molecule login` command is now quite a bit faster and more informative.