### PR TITLE
Preserve custom paths

### DIFF
--- a/molecule/config.py
+++ b/molecule/config.py
@@ -84,14 +84,15 @@ class Config(object):
 
         :return: None
         """
+        md = self.config.get('molecule')
+        ad = self.config.get('ansible')
         for item in ['state_file', 'vagrantfile_file', 'rakefile_file']:
-            d = self.config.get('molecule')
-            if d:
-                d[item] = os.path.join(self.config['molecule']['molecule_dir'],
-                                       self.config['molecule'][item])
+            if md and not self._is_path(md[item]):
+                md[item] = os.path.join(md['molecule_dir'], md[item])
 
         for item in ['config_file', 'inventory_file']:
-            d = self.config.get('ansible')
-            if d:
-                d[item] = os.path.join(self.config['molecule']['molecule_dir'],
-                                       self.config['ansible'][item])
+            if ad and not self._is_path(ad[item]):
+                ad[item] = os.path.join(md['molecule_dir'], ad[item])
+
+    def _is_path(self, pathname):
+        return os.path.sep in pathname

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -62,7 +62,8 @@ def test_molecule_file(config_instance):
 
 
 def test_build_config_paths(config_instance):
-    # Full path provided to ``state_file``
+    # Full path provided to ``state_file``.  Tested further in subsequent
+    # tests.
     assert 'state_data.yml' == config_instance.config['molecule'][
         'state_file'].split('/')[-1]
     assert 'test/vagrantfile_file' == config_instance.config['molecule'][
@@ -73,6 +74,40 @@ def test_build_config_paths(config_instance):
         'config_file']
     assert 'test/inventory_file' == config_instance.config['ansible'][
         'inventory_file']
+
+
+@pytest.fixture()
+def build_config_paths_molecule_data():
+    return {
+        'molecule': {
+            'state_file': 'state_path',
+            'vagrantfile_file': '/full/path/vagrantfile_file',
+            'rakefile_file': 'relative/path/rakefile_file',
+            'molecule_dir': 'test'
+        },
+        'ansible': {
+            'config_file': 'config_file',
+            'inventory_file': 'inventory_file',
+            'playbook': 'playbook.yml'
+        }
+    }
+
+
+# NOTE(retr0h): ``os.path.join`` does this for us.
+def test_build_config_paths_preserves_full_path(temp_files):
+    confs = temp_files(fixtures=['build_config_paths_molecule_data'])
+    c = config.Config(configs=confs)
+
+    assert '/full/path/vagrantfile_file' == c.config['molecule'][
+        'vagrantfile_file']
+
+
+def test_build_config_paths_preserves_relative_path(temp_files):
+    confs = temp_files(fixtures=['build_config_paths_molecule_data'])
+    c = config.Config(configs=confs)
+
+    assert 'relative/path/rakefile_file' == c.config['molecule'][
+        'rakefile_file']
 
 
 def test_populate_instance_names(config_instance):


### PR DESCRIPTION
When initializing a config object, it will append the
`molecule_dir` to certain elements.  We only want this
to happen when we do not specify a full or relative
path.

Fixes: #284