### PR TITLE
Added a spec_helper which supports docker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'docker-api', '~> 1.29'
 gem 'rake', '~> 11.2'
-gem 'serverspec', '~> 2.36'
 gem 'rubocop', '~> 0.42'
+gem 'serverspec', '~> 2.36'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,11 @@ GEM
   specs:
     ast (2.3.0)
     diff-lcs (1.2.5)
+    docker-api (1.29.2)
+      excon (>= 0.38.0)
+      json
+    excon (0.51.0)
+    json (2.0.2)
     multi_json (1.12.1)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -53,6 +58,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  docker-api (~> 1.29)
   rake (~> 11.2)
   rubocop (~> 0.42)
   serverspec (~> 2.36)

--- a/tests/functional/docker/scenarios/full/spec/README.md
+++ b/tests/functional/docker/scenarios/full/spec/README.md
@@ -1,3 +1,0 @@
-# Not Implemented
-
-https://github.com/metacloud/molecule/issues/272 

--- a/tests/functional/docker/scenarios/full/spec/default_spec.rb
+++ b/tests/functional/docker/scenarios/full/spec/default_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe file('/etc/molecule') do
+  it { should be_a_directory }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
+  it { should be_mode 755 }
+end
+
+describe file('/etc/molecule/example-group') do
+  it { should be_a_file }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
+  it { should be_mode 644 }
+  it { should contain 'molecule example-group file' }
+end

--- a/tests/functional/docker/scenarios/full/spec/groups/example-group1/default_spec.rb
+++ b/tests/functional/docker/scenarios/full/spec/groups/example-group1/default_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe file('/etc/molecule/example-group1') do
+  it { should be_a_file }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
+  it { should be_mode 644 }
+  it { should contain 'molecule example-group1 file' }
+end
+
+describe file('/etc/molecule/example-group2') do
+  it { should_not exist }
+end

--- a/tests/functional/docker/scenarios/full/spec/groups/example-group2/default_spec.rb
+++ b/tests/functional/docker/scenarios/full/spec/groups/example-group2/default_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe file('/etc/molecule/example-group2') do
+  it { should be_a_file }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
+  it { should be_mode 644 }
+  it { should contain 'molecule example-group2 file' }
+end
+
+describe file('/etc/molecule/example-group1') do
+  it { should_not exist }
+end

--- a/tests/functional/docker/scenarios/full/spec/spec_helper.rb
+++ b/tests/functional/docker/scenarios/full/spec/spec_helper.rb
@@ -1,0 +1,16 @@
+require 'docker'
+require 'serverspec'
+
+host = ENV['TARGET_HOST']
+
+set :backend, :docker
+set :host, host
+
+RSpec.configure do |config|
+  config.color = true
+  config.tty = true
+  config.formatter = :documentation
+  config.before(:suite) do
+    set :docker_container, host
+  end
+end


### PR DESCRIPTION
Since serverspec is not the default test framework, we do not supply
helper files.  We simply use rake to act as an executer.  This will
serve as an example implementation for others.

Special thanks to @kireledan, who actually figured this out, but I sent
him on a wild goose hunt, thinking we needed to change the Rakefile.

Fixes: #272