### PR TITLE
Added dependency resolution to Syntax check

### DIFF
--- a/molecule/ansible_galaxy_install.py
+++ b/molecule/ansible_galaxy_install.py
@@ -91,3 +91,9 @@ class AnsibleGalaxyInstall:
         except sh.ErrorReturnCode as e:
             LOG.error('ERROR: {}'.format(e))
             utilities.sysexit(e.exit_code)
+
+    def download(self, config_file):
+        utilities.print_info('Installing role dependencies ...')
+        self.add_env_arg('ANSIBLE_CONFIG', config_file)
+        self.bake()
+        self.execute()

--- a/molecule/commands/converge.py
+++ b/molecule/commands/converge.py
@@ -23,7 +23,6 @@ import sys
 
 import yaml
 
-from molecule import ansible_galaxy_install
 from molecule import ansible_playbook
 from molecule import utilities
 from molecule.commands import base
@@ -82,14 +81,8 @@ class Converge(base.BaseCommand):
         # install role dependencies only during `molecule converge`
         if not idempotent and 'requirements_file' in self.molecule.config.config[
                 'ansible']:
-            utilities.print_info('Installing role dependencies ...')
-            galaxy_install = ansible_galaxy_install.AnsibleGalaxyInstall(
-                self.molecule.config.config['ansible']['requirements_file'])
-            galaxy_install.add_env_arg(
-                'ANSIBLE_CONFIG',
-                self.molecule.config.config['ansible']['config_file'])
-            galaxy_install.bake()
-            output = galaxy_install.execute()
+            self.molecule.download_dependencies(self.molecule.config.config[
+                'ansible']['requirements_file'])
 
         ansible = ansible_playbook.AnsiblePlaybook(self.molecule.config.config[
             'ansible'])

--- a/molecule/commands/converge.py
+++ b/molecule/commands/converge.py
@@ -25,6 +25,7 @@ import yaml
 
 from molecule import ansible_playbook
 from molecule import utilities
+from molecule.ansible_galaxy_install import AnsibleGalaxyInstall
 from molecule.commands import base
 from molecule.commands import create
 
@@ -80,9 +81,12 @@ class Converge(base.BaseCommand):
 
         # install role dependencies only during `molecule converge`
         if not idempotent and 'requirements_file' in self.molecule.config.config[
-                'ansible']:
-            self.molecule.download_dependencies(self.molecule.config.config[
+                'ansible'] and not self.molecule._state.installed_deps:
+            galaxy = AnsibleGalaxyInstall(self.molecule.config.config[
                 'ansible']['requirements_file'])
+            galaxy.download(self.molecule.config.config['ansible'][
+                'config_file'])
+            self.molecule._state.change_state('installed_deps', True)
 
         ansible = ansible_playbook.AnsiblePlaybook(self.molecule.config.config[
             'ansible'])

--- a/molecule/commands/syntax.py
+++ b/molecule/commands/syntax.py
@@ -34,6 +34,10 @@ class Syntax(base.BaseCommand):
     def execute(self, exit=True):
         self.molecule._create_templates()
 
+        if 'requirements_file' in self.molecule.config.config['ansible']:
+            self.molecule.download_dependencies(self.molecule.config.config[
+                'ansible']['requirements_file'])
+
         ansible = ansible_playbook.AnsiblePlaybook(self.molecule.config.config[
             'ansible'])
         ansible.add_cli_arg('syntax-check', True)

--- a/molecule/commands/syntax.py
+++ b/molecule/commands/syntax.py
@@ -19,6 +19,7 @@
 #  THE SOFTWARE.
 
 from molecule import ansible_playbook
+from molecule.ansible_galaxy_install import AnsibleGalaxyInstall
 from molecule import utilities
 from molecule.commands import base
 
@@ -34,9 +35,13 @@ class Syntax(base.BaseCommand):
     def execute(self, exit=True):
         self.molecule._create_templates()
 
-        if 'requirements_file' in self.molecule.config.config['ansible']:
-            self.molecule.download_dependencies(self.molecule.config.config[
+        if 'requirements_file' in self.molecule.config.config[
+                'ansible'] and not self.molecule._state.installed_deps:
+            galaxy = AnsibleGalaxyInstall(self.molecule.config.config[
                 'ansible']['requirements_file'])
+            galaxy.download(self.molecule.config.config['ansible'][
+                'config_file'])
+            self.molecule._state.change_state('installed_deps', True)
 
         ansible = ansible_playbook.AnsiblePlaybook(self.molecule.config.config[
             'ansible'])

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -33,7 +33,6 @@ import yaml
 from molecule import config
 from molecule import state
 from molecule import utilities
-from molecule import ansible_galaxy_install
 from molecule.provisioners import baseprovisioner
 from molecule.provisioners import dockerprovisioner
 from molecule.provisioners import openstackprovisioner
@@ -235,18 +234,6 @@ class Molecule(object):
 
     def _write_instances_state(self):
         self._state.change_state('hosts', self._instances_state())
-
-    def download_dependencies(self, requirements_file):
-
-        if not self._state.installed_deps:
-            utilities.print_info('Installing role dependencies ...')
-            galaxy_install = ansible_galaxy_install.AnsibleGalaxyInstall(
-                requirements_file)
-            galaxy_install.add_env_arg(
-                'ANSIBLE_CONFIG', self.config.config['ansible']['config_file'])
-            galaxy_install.bake()
-            galaxy_install.execute()
-            self._state.change_state('installed_deps', True)
 
     def _create_inventory_file(self):
         """

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -33,6 +33,7 @@ import yaml
 from molecule import config
 from molecule import state
 from molecule import utilities
+from molecule import ansible_galaxy_install
 from molecule.provisioners import baseprovisioner
 from molecule.provisioners import dockerprovisioner
 from molecule.provisioners import openstackprovisioner
@@ -234,6 +235,18 @@ class Molecule(object):
 
     def _write_instances_state(self):
         self._state.change_state('hosts', self._instances_state())
+
+    def download_dependencies(self, requirements_file):
+
+        if not self._state.installed_deps:
+            utilities.print_info('Installing role dependencies ...')
+            galaxy_install = ansible_galaxy_install.AnsibleGalaxyInstall(
+                requirements_file)
+            galaxy_install.add_env_arg(
+                'ANSIBLE_CONFIG', self.config.config['ansible']['config_file'])
+            galaxy_install.bake()
+            galaxy_install.execute()
+            self._state.change_state('installed_deps', True)
 
     def _create_inventory_file(self):
         """

--- a/molecule/state.py
+++ b/molecule/state.py
@@ -31,7 +31,8 @@ import yaml
 from molecule import utilities
 
 VALID_KEYS = ['converged', 'created', 'customconf', 'default_platform',
-              'default_provider', 'hosts', 'multiple_platforms']
+              'default_provider', 'hosts', 'multiple_platforms',
+              'installed_deps']
 
 
 class InvalidState(Exception):
@@ -78,6 +79,10 @@ class State(object):
     @property
     def customconf(self):
         return self._data.get('customconf')
+
+    @property
+    def installed_deps(self):
+        return self._data.get('installed_deps')
 
     @marshal
     def reset(self):

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -118,6 +118,16 @@ def test_change_state_persists(state_instance):
 
         assert d.get('created')
 
+def test_change_state_deps_installed(state_instance):
+    assert not state_instance.created
+
+    state_instance.change_state('installed_deps', True)
+    assert state_instance.created
+
+    with open(state_instance._state_file) as stream:
+        d = yaml.safe_load(stream)
+
+        assert d.get('installed_deps')
 
 def test_get_data():
     # Already tested through the property tests


### PR DESCRIPTION
This PR addresses #332. 

It adds the state ```installed_deps``` to prevent molecule from repeatedly downloading dependencies when they have already been installed. 

This has not been run with the unit tests. I'm currently only able to test it with the docker driver. It seemed to pass on my travis instance. But please feel free to double check this PR with a full tox suite test. 