### PR TITLE
Display molecule status when not created

### DIFF
--- a/molecule/commands/status.py
+++ b/molecule/commands/status.py
@@ -18,9 +18,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-import os
 import subprocess
-import sys
 
 from molecule import utilities
 from molecule.commands import base
@@ -46,12 +44,6 @@ class Status(base.BaseCommand):
     def execute(self):
         display_all = not any([self.args['--hosts'], self.args['--platforms'],
                                self.args['--providers']])
-
-        # Check that an instance is created.
-        if not self.molecule._state.created:
-            msg = 'ERROR: No instances created. Try `{} create` first.'
-            LOG.error(msg.format(os.path.basename(sys.argv[0])))
-            utilities.sysexit()
 
         # Retrieve the status.
         try:

--- a/molecule/provisioners/openstackprovisioner.py
+++ b/molecule/provisioners/openstackprovisioner.py
@@ -177,7 +177,7 @@ class OpenstackProvisioner(baseprovisioner.BaseProvisioner):
                                           provider='Openstack'))
             else:
                 status_list.append(Status(name=instance['name'],
-                                          state='DOWN',
+                                          state='not_created',
                                           provider='Openstack'))
 
         return status_list

--- a/tests/functional/docker/test_command_status.bash
+++ b/tests/functional/docker/test_command_status.bash
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+#  Copyright (c) 2015-2016 Cisco Systems
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
+(
+	cd ${DOCKER_FUNCTIONAL_TEST_BASE_DIR}/scenarios/full
+	molecule status --porcelain | grep 'full-01 .*not_created .*docker'
+	molecule status --porcelain | grep 'full-02 .*not_created .*docker'
+)

--- a/tests/functional/vagrant/test_command_status.bash
+++ b/tests/functional/vagrant/test_command_status.bash
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+#  Copyright (c) 2015-2016 Cisco Systems
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
+(
+	cd ${VAGRANT_FUNCTIONAL_TEST_BASE_DIR}/scenarios/full
+	molecule status --porcelain | grep 'full-01 .*not_created .*virtualbox'
+	molecule status --porcelain | grep 'full-02 .*not_created .*virtualbox'
+)

--- a/tests/unit/provisioner/test_dockerprovisioner.py
+++ b/tests/unit/provisioner/test_dockerprovisioner.py
@@ -89,11 +89,11 @@ def test_instances(docker_instance):
 def test_status(docker_instance):
     docker_instance.up()
 
-    assert 'test1' == docker_instance.status()[1].name
-    assert 'test2' == docker_instance.status()[0].name
+    assert 'test1' == docker_instance.status()[0].name
+    assert 'test2' == docker_instance.status()[1].name
 
-    assert 'Up' in docker_instance.status()[1].state
     assert 'Up' in docker_instance.status()[0].state
+    assert 'Up' in docker_instance.status()[1].state
 
     assert 'docker' in docker_instance.status()[0].provider
     assert 'docker' in docker_instance.status()[1].provider
@@ -102,8 +102,7 @@ def test_status(docker_instance):
 def test_port_bindings(docker_instance):
     docker_instance.up()
 
-    assert docker_instance.status()[0].ports == []
-    assert docker_instance.status()[1].ports == [
+    assert docker_instance.status()[0].ports == [
         {
             'PublicPort': 443,
             'PrivatePort': 443,
@@ -116,6 +115,7 @@ def test_port_bindings(docker_instance):
             'Type': 'tcp'
         }
     ]
+    assert docker_instance.status()[1].ports == []
 
 
 def test_start_command(docker_instance):
@@ -139,16 +139,16 @@ def test_volume_mounts(docker_instance):
 def test_destroy(docker_instance):
     docker_instance.up()
 
-    assert 'test1' == docker_instance.status()[1].name
-    assert 'test2' == docker_instance.status()[0].name
+    assert 'test1' == docker_instance.status()[0].name
+    assert 'test2' == docker_instance.status()[1].name
 
-    assert 'Up' in docker_instance.status()[1].state
     assert 'Up' in docker_instance.status()[0].state
+    assert 'Up' in docker_instance.status()[1].state
 
     docker_instance.destroy()
 
-    assert 'Not Created' in docker_instance.status()[1].state
-    assert 'Not Created' in docker_instance.status()[0].state
+    assert 'not_created' in docker_instance.status()[0].state
+    assert 'not_created' in docker_instance.status()[1].state
 
 
 def test_provision(docker_instance):


### PR DESCRIPTION
* `status` displays `not_created` when the instance(s) are not created.
* Added offline `status` to functional test suite.
* Also, believe fixed a bug with `molecule status` with docker driver.
  Was displaying status for the wrong hosts.

Fixes: #339