### PR TITLE
Passing 'ROLES_PATH' directly to `galaxy-install`

### DIFF
--- a/molecule/ansible_galaxy.py
+++ b/molecule/ansible_galaxy.py
@@ -55,13 +55,19 @@ class AnsibleGalaxy(object):
         :return: None
         """
         requirements_file = self._config['ansible']['requirements_file']
+        roles_path = os.path.join(self._config['molecule']['molecule_dir'],
+                                  'roles')
+        galaxy_options = {
+            'force': True,
+            'role-file': requirements_file,
+            'roles-path': roles_path
+        }
+
         self.galaxy = sh.ansible_galaxy.bake('install',
-                                             '-f',
-                                             '-r',
-                                             requirements_file,
                                              _env=self.env,
                                              _out=self.out,
-                                             _err=self.err)
+                                             _err=self.err,
+                                             **galaxy_options)
 
     def add_env_arg(self, name, value):
         """
@@ -90,8 +96,6 @@ class AnsibleGalaxy(object):
             utilities.sysexit(e.exit_code)
 
     def install(self):
-        config_file = self._config['ansible']['config_file']
         utilities.print_info('Installing role dependencies ...')
-        self.add_env_arg('ANSIBLE_CONFIG', config_file)
         self.bake()
         self.execute()

--- a/tests/unit/test_ansible_galaxy.py
+++ b/tests/unit/test_ansible_galaxy.py
@@ -46,5 +46,15 @@ def test_install(mocker, galaxy_instance):
     galaxy_instance.install()
 
     mocked.assert_called_once
-    assert re.search(r'ansible-galaxy install -f -r requirements.yml',
-                     str(galaxy_instance.galaxy))
+
+    # NOTE(retr0h): The following is a somewhat gross test, but need to
+    # handle **kwargs expansion being unordered.
+    pieces = str(galaxy_instance.galaxy).split()
+    cmd = pieces.pop(0)
+    subcmd = pieces.pop(0)
+    expected = ['--force', '--role-file=requirements.yml',
+                '--roles-path=test/roles']
+
+    assert re.search(r'ansible-galaxy', cmd)
+    assert 'install' == subcmd
+    assert expected == sorted(pieces)

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     ansible20: ansible==2.0.2.0
     ansible21: ansible==2.1.1.0
 commands =
-    unit: py.test --cov={envsitepackagesdir}/molecule/ tests/unit/
+    unit: py.test --cov={envsitepackagesdir}/molecule/ tests/unit/ {posargs}
     functional: {toxinidir}/tests/functional/test.bash
 
 [flake8]


### PR DESCRIPTION
Install the roles into .molecule/roles/.  Under certain circumstances
`ansible-galaxy` will use the roles path defined through env vars or
from ansible.cfg.  We should be explicit.  This is prep work for #333.

Fixes: #341