### PR TITLE
Add `molecule status` functional test

### DIFF
--- a/molecule/provisioners/openstackprovisioner.py
+++ b/molecule/provisioners/openstackprovisioner.py
@@ -19,6 +19,7 @@
 #  THE SOFTWARE.
 
 import collections
+import os
 
 import shade
 
@@ -174,22 +175,24 @@ class OpenstackProvisioner(baseprovisioner.BaseProvisioner):
             if self.instance_is_accessible(instance):
                 status_list.append(Status(name=instance['name'],
                                           state='UP',
-                                          provider='Openstack'))
+                                          provider='openstack'))
             else:
                 status_list.append(Status(name=instance['name'],
                                           state='not_created',
-                                          provider='Openstack'))
+                                          provider='openstack'))
 
         return status_list
 
     def conf(self, name=None, ssh_config=False):
-        with open(self.molecule.config.config['ansible'][
-                'inventory_file']) as instance:
-            for line in instance:
-                if len(line.split()) > 0 and line.split()[0] == name:
-                    ansible_host = line.split()[1]
-                    host_address = ansible_host.split('=')[1]
-                    return host_address
+        inventory_file = self.molecule.config.config['ansible'][
+            'inventory_file']
+        if os.path.exists(inventory_file):
+            with open(inventory_file) as stream:
+                for line in stream:
+                    if len(line.split()) > 0 and line.split()[0] == name:
+                        ansible_host = line.split()[1]
+                        host_address = ansible_host.split('=')[1]
+                        return host_address
         return None
 
     def instance_is_accessible(self, instance):

--- a/tests/functional/openstack/scenarios/full/molecule.yml
+++ b/tests/functional/openstack/scenarios/full/molecule.yml
@@ -1,0 +1,23 @@
+---
+ansible:
+  raw_env_vars:
+    ANSIBLE_ROLES_PATH: ../../../roles:../../../../roles
+
+openstack:
+  keypair: KeyName
+  keyfile: ~/.ssh/id_rsa
+  instances:
+    - name: full-01
+      image: 'CentOS 7'
+      flavor: m1.xlarge
+      sshuser: centos
+      ansible_groups:
+        - example-group
+        - example-group1
+    - name: full-02
+      image: 'CentOS 7'
+      flavor: m1.xlarge
+      sshuser: centos
+      ansible_groups:
+        - example-group
+        - example-group2

--- a/tests/functional/openstack/scenarios/full/playbook.yml
+++ b/tests/functional/openstack/scenarios/full/playbook.yml
@@ -1,0 +1,15 @@
+---
+- hosts: example-group
+  roles:
+    - role: molecule
+      molecule_targeted_group: example-group
+
+- hosts: example-group1
+  roles:
+    - role: molecule
+      molecule_targeted_group: example-group1
+
+- hosts: example-group2
+  roles:
+    - role: molecule
+      molecule_targeted_group: example-group2

--- a/tests/functional/openstack/test_command_status.bash
+++ b/tests/functional/openstack/test_command_status.bash
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+#  Copyright (c) 2015-2016 Cisco Systems
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
+(
+	cd ${OPENSTACK_FUNCTIONAL_TEST_BASE_DIR}/scenarios/full
+	molecule status --porcelain | grep 'full-01 .*not_created .*openstack'
+	molecule status --porcelain | grep 'full-02 .*not_created .*openstack'
+)

--- a/tests/functional/test.bash
+++ b/tests/functional/test.bash
@@ -27,6 +27,7 @@ set -e
 export FUNCTIONAL_TEST_BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export VAGRANT_FUNCTIONAL_TEST_BASE_DIR="${FUNCTIONAL_TEST_BASE_DIR}/vagrant"
 export DOCKER_FUNCTIONAL_TEST_BASE_DIR="${FUNCTIONAL_TEST_BASE_DIR}/docker"
+export OPENSTACK_FUNCTIONAL_TEST_BASE_DIR="${FUNCTIONAL_TEST_BASE_DIR}/openstack"
 ANSIBLE_MAJOR_VERSION=$(ansible --version|head -1|awk '{print $NF}'|cut -d\. -f1)
 
 source ${VIRTUAL_ENV}/bin/activate
@@ -66,3 +67,9 @@ if [ $(which vagrant) ]; then
 else
 	echo_warn "Vagrant executable not found -- skipping!"
 fi
+
+echo_info "OpenStack driver"
+for test in ${OPENSTACK_FUNCTIONAL_TEST_BASE_DIR}/test_*.bash; do
+	echo_info "Testing -> ${test}"
+	source ${test}
+done


### PR DESCRIPTION
Added a `status` functional test for the openstack driver.  This
test caught a bug, where the `inventory_file` was attempting to be
read, when it did not yet exist.