### PR TITLE
Corrected syntax sub command test failure

### DIFF
--- a/molecule/ansible_galaxy.py
+++ b/molecule/ansible_galaxy.py
@@ -39,10 +39,10 @@ class AnsibleGalaxy(object):
         :return: None
         """
         self._config = config
+        self._galaxy = None
         self.env = _env if _env else os.environ.copy()
         self.out = _out
         self.err = _err
-        self.galaxy = None
 
         # defaults can be redefined with call to add_env_arg() before baking
         self.add_env_arg('PYTHONUNBUFFERED', '1')
@@ -65,11 +65,11 @@ class AnsibleGalaxy(object):
         galaxy_options = utilities.merge_dicts(
             galaxy_default_options, self._config['ansible']['galaxy'])
 
-        self.galaxy = sh.ansible_galaxy.bake('install',
-                                             _env=self.env,
-                                             _out=self.out,
-                                             _err=self.err,
-                                             **galaxy_options)
+        self._galaxy = sh.ansible_galaxy.bake('install',
+                                              _env=self.env,
+                                              _out=self.out,
+                                              _err=self.err,
+                                              **galaxy_options)
 
     def add_env_arg(self, name, value):
         """
@@ -88,11 +88,11 @@ class AnsibleGalaxy(object):
         :return: sh.stdout on success, else None
         :return: None
         """
-        if self.galaxy is None:
+        if self._galaxy is None:
             self.bake()
 
         try:
-            return self.galaxy().stdout
+            return self._galaxy().stdout
         except sh.ErrorReturnCode as e:
             LOG.error('ERROR: {}'.format(e))
             utilities.sysexit(e.exit_code)

--- a/molecule/ansible_playbook.py
+++ b/molecule/ansible_playbook.py
@@ -37,11 +37,11 @@ class AnsiblePlaybook(object):
         :param _err: Function passed to sh for STDERR
         :return: None
         """
-        self.cli = {}
-        self.cli_pos = []
+        self._playbook = None
+        self._ansible = None
+        self._cli = {}
+        self._cli_pos = []
         self.env = _env if _env else os.environ.copy()
-        self.playbook = None
-        self.ansible = None
 
         # process arguments passed in (typically from molecule.yml's ansible block)
         for k, v in args.iteritems():
@@ -61,10 +61,10 @@ class AnsiblePlaybook(object):
 
         :return: None
         """
-        self.ansible = sh.ansible_playbook.bake(self.playbook,
-                                                *self.cli_pos,
-                                                _env=self.env,
-                                                **self.cli)
+        self._ansible = sh.ansible_playbook.bake(self._playbook,
+                                                 *self._cli_pos,
+                                                 _env=self.env,
+                                                 **self._cli)
 
     def parse_arg(self, name, value):
         """
@@ -97,7 +97,7 @@ class AnsiblePlaybook(object):
             return
 
         if name == 'playbook':
-            self.playbook = value
+            self._playbook = value
             return
 
         if name == 'host_vars' or name == 'group_vars':
@@ -108,7 +108,7 @@ class AnsiblePlaybook(object):
             # for cases where someone passes in verbose: True
             if value is True:
                 value = 'vvvv'
-            self.cli_pos.append('-' + value)
+            self._cli_pos.append('-' + value)
             return
 
         self.add_cli_arg(name, value)
@@ -122,7 +122,7 @@ class AnsiblePlaybook(object):
         :return: None
         """
         if value:
-            self.cli[name] = value
+            self._cli[name] = value
 
     def remove_cli_arg(self, name):
         """
@@ -131,7 +131,7 @@ class AnsiblePlaybook(object):
         :param name: Key name of CLI argument to remove
         :return: None
         """
-        self.cli.pop(name, None)
+        self._cli.pop(name, None)
 
     def add_env_arg(self, name, value):
         """
@@ -158,11 +158,11 @@ class AnsiblePlaybook(object):
 
         :returns: exit code if any, output of command as string
         """
-        if self.ansible is None:
+        if self._ansible is None:
             self.bake()
 
         try:
-            return None, self.ansible().stdout
+            return None, self._ansible().stdout
         except (sh.ErrorReturnCode, sh.ErrorReturnCode_2) as e:
             if not hide_errors:
                 LOG.error('ERROR: {}'.format(e))

--- a/molecule/commands/syntax.py
+++ b/molecule/commands/syntax.py
@@ -44,8 +44,7 @@ class Syntax(base.BaseCommand):
         ansible = ansible_playbook.AnsiblePlaybook(self.molecule.config.config[
             'ansible'])
         ansible.add_cli_arg('syntax-check', True)
-        ansible.add_cli_arg('inventory-file', 'localhost,')
-
+        ansible.add_cli_arg('inventory_file', 'localhost,')
         utilities.print_info("Checking playbooks syntax ...")
 
         return ansible.execute(hide_errors=True)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -200,7 +200,7 @@ def ansible_section_data():
             'ask_vault_pass': False,
             'vault_password_file': False,
             'limit': 'all',
-            'verbose': False,
+            'verbose': True,
             'diff': True,
             'tags': False,
             'host_key_checking': False,
@@ -211,7 +211,10 @@ def ansible_section_data():
             'galaxy': {},
             'config_file': 'config_file',
             'inventory_file': 'inventory_file',
-            'playbook': 'playbook.yml'
+            'playbook': 'playbook.yml',
+            'raw_env_vars': {
+                'FOO': 'bar'
+            }
         }
     }
 

--- a/tests/unit/test_ansible_galaxy.py
+++ b/tests/unit/test_ansible_galaxy.py
@@ -27,7 +27,7 @@ from molecule import config
 
 
 @pytest.fixture()
-def galaxy_instance(temp_files):
+def ansible_galaxy_instance(temp_files):
     confs = temp_files(fixtures=['molecule_vagrant_config'])
     c = config.Config(configs=confs)
     c.config['ansible']['requirements_file'] = 'requirements.yml'
@@ -35,21 +35,21 @@ def galaxy_instance(temp_files):
     return ansible_galaxy.AnsibleGalaxy(c.config)
 
 
-def test_add_env_arg(galaxy_instance):
-    galaxy_instance.add_env_arg('MOLECULE_1', 'test')
+def test_add_env_arg(ansible_galaxy_instance):
+    ansible_galaxy_instance.add_env_arg('MOLECULE_1', 'test')
 
-    assert 'test' == galaxy_instance.env['MOLECULE_1']
+    assert 'test' == ansible_galaxy_instance.env['MOLECULE_1']
 
 
-def test_install(mocker, galaxy_instance):
+def test_install(mocker, ansible_galaxy_instance):
     mocked = mocker.patch('molecule.ansible_galaxy.AnsibleGalaxy.execute')
-    galaxy_instance.install()
+    ansible_galaxy_instance.install()
 
     mocked.assert_called_once
 
     # NOTE(retr0h): The following is a somewhat gross test, but need to
     # handle **kwargs expansion being unordered.
-    pieces = str(galaxy_instance.galaxy).split()
+    pieces = str(ansible_galaxy_instance._galaxy).split()
     expected = ['--force', '--role-file=requirements.yml',
                 '--roles-path=test/roles']
 
@@ -58,15 +58,15 @@ def test_install(mocker, galaxy_instance):
     assert expected == sorted(pieces[2:])
 
 
-def test_install_overrides(mocker, galaxy_instance):
-    galaxy_instance._config['ansible']['galaxy'] = {'foo': 'bar',
-                                                    'force': False}
+def test_install_overrides(mocker, ansible_galaxy_instance):
+    ansible_galaxy_instance._config['ansible']['galaxy'] = {'foo': 'bar',
+                                                            'force': False}
     mocked = mocker.patch('molecule.ansible_galaxy.AnsibleGalaxy.execute')
-    galaxy_instance.install()
+    ansible_galaxy_instance.install()
 
     mocked.assert_called_once
 
-    pieces = str(galaxy_instance.galaxy).split()
+    pieces = str(ansible_galaxy_instance._galaxy).split()
     expected = ['--foo=bar', '--role-file=requirements.yml',
                 '--roles-path=test/roles']
 


### PR DESCRIPTION
The `py27-ansible19-functional` tests would fail under certain
circumstances.  Occurs with the `init` command functional test,
when `.molecule/ansible_inventory` does not exist.

Ansible playbook's ansible member is getting an extra `--inventory-file`
arg.  These args are passed to `ansible-playbook` as a dict through
**kwargs expansion.  Since the dict is unordered in python, we encounter
random failures.  The last `--inventory-file` flag wins.

Fixes: #345