### PR TITLE
Added fallback status for vagrant driver

### DIFF
--- a/molecule/provisioners/openstackprovisioner.py
+++ b/molecule/provisioners/openstackprovisioner.py
@@ -145,7 +145,6 @@ class OpenstackProvisioner(baseprovisioner.BaseProvisioner):
         Status = collections.namedtuple('Status', ['name', 'state',
                                                    'provider'])
         status_list = []
-
         for instance in self.instances:
             if self._instance_is_accessible(instance):
                 status_list.append(Status(name=instance['name'],


### PR DESCRIPTION
If vagrant was never converged a `.vagrant` and `.molecule` directory
will not exist.  Under these circumstances `molecule status` fails
to render status.

Fixes: #355