### PR TITLE
Added auto docker api version recognition to prevent api mismatch errors

### DIFF
--- a/molecule/driver/dockerdriver.py
+++ b/molecule/driver/dockerdriver.py
@@ -23,7 +23,6 @@ import io
 import json
 
 import docker
-from docker.utils import kwargs_from_env
 
 from molecule import util
 from molecule.driver import basedriver
@@ -34,7 +33,8 @@ LOG = util.get_logger(__name__)
 class DockerDriver(basedriver.BaseDriver):
     def __init__(self, molecule):
         super(DockerDriver, self).__init__(molecule)
-        self._docker = docker.Client(version='auto', **kwargs_from_env())
+        self._docker = docker.Client(version='auto',
+                                     **docker.utils.kwargs_from_env())
         self._containers = self.molecule.config.config['docker']['containers']
         self._provider = self._get_provider()
         self._platform = self._get_platform()

--- a/molecule/driver/dockerdriver.py
+++ b/molecule/driver/dockerdriver.py
@@ -23,6 +23,7 @@ import io
 import json
 
 import docker
+from docker.utils import kwargs_from_env
 
 from molecule import util
 from molecule.driver import basedriver
@@ -33,7 +34,7 @@ LOG = util.get_logger(__name__)
 class DockerDriver(basedriver.BaseDriver):
     def __init__(self, molecule):
         super(DockerDriver, self).__init__(molecule)
-        self._docker = docker.from_env(assert_hostname=False)
+        self._docker = docker.Client(version='auto', **kwargs_from_env())
         self._containers = self.molecule.config.config['docker']['containers']
         self._provider = self._get_provider()
         self._platform = self._get_platform()


### PR DESCRIPTION
This PR alleviates errors that occur when the server and client of a docker daemon/client do not match. It ignores the environment variable DOCKER_API_VERSION so the client needs to be passed the 'auto' version flag to detect the api difference. 