### PR TITLE
Made the driver member "public"

### DIFF
--- a/molecule/command/converge.py
+++ b/molecule/command/converge.py
@@ -90,7 +90,7 @@ class Converge(base.Base):
             'ansible'])
 
         # params to work with driver
-        for k, v in self.molecule._driver.ansible_connection_params.items():
+        for k, v in self.molecule.driver.ansible_connection_params.items():
             ansible.add_cli_arg(k, v)
 
         # target tags passed in via CLI

--- a/molecule/command/create.py
+++ b/molecule/command/create.py
@@ -44,7 +44,7 @@ class Create(base.Base):
         self.molecule._create_templates()
         try:
             util.print_info("Creating instances ...")
-            self.molecule._driver.up(no_provision=True)
+            self.molecule.driver.up(no_provision=True)
             self.molecule._state.change_state('created', True)
             if self.args['--platform'] == 'all':
                 self.molecule._state.change_state('multiple_platforms', True)

--- a/molecule/command/destroy.py
+++ b/molecule/command/destroy.py
@@ -49,7 +49,7 @@ class Destroy(base.Base):
         self.molecule._create_templates()
         try:
             util.print_info("Destroying instances ...")
-            self.molecule._driver.destroy()
+            self.molecule.driver.destroy()
             self.molecule._state.reset()
         except subprocess.CalledProcessError as e:
             LOG.error('ERROR: {}'.format(e))

--- a/molecule/command/login.py
+++ b/molecule/command/login.py
@@ -83,8 +83,8 @@ class Login(base.Base):
                                 len(match), hostname, "\n".join(hosts)))
                 hostname = match[0]
 
-            login_cmd = self.molecule._driver.login_cmd(hostname)
-            login_args = self.molecule._driver.login_args(hostname)
+            login_cmd = self.molecule.driver.login_cmd(hostname)
+            login_args = self.molecule.driver.login_args(hostname)
 
         except subprocess.CalledProcessError:
             msg = "Unknown host '{}'.\n\nAvailable hosts:\n{}"

--- a/molecule/command/status.py
+++ b/molecule/command/status.py
@@ -47,7 +47,7 @@ class Status(base.Base):
 
         # Retrieve the status.
         try:
-            status = self.molecule._driver.status()
+            status = self.molecule.driver.status()
         except subprocess.CalledProcessError as e:
             LOG.error(e.message)
             return e.returncode, e.message

--- a/molecule/verifier/serverspec.py
+++ b/molecule/verifier/serverspec.py
@@ -36,7 +36,7 @@ class Serverspec(base.Base):
         self._rakefile = molecule.config.config['molecule']['rakefile_file']
 
     def execute(self):
-        serverspec_options = self._molecule._driver.serverspec_args
+        serverspec_options = self._molecule.driver.serverspec_args
         serverspec_options['debug'] = self._molecule._args.get('--debug',
                                                                False)
 

--- a/molecule/verifier/testinfra.py
+++ b/molecule/verifier/testinfra.py
@@ -42,7 +42,7 @@ class Testinfra(base.Base):
             _env=self._molecule._env)
 
         testinfra_options = util.merge_dicts(
-            self._molecule._driver.testinfra_args,
+            self._molecule.driver.testinfra_args,
             self._molecule.config.config['testinfra'])
         testinfra_options['env'] = ansible.env
         testinfra_options['debug'] = self._molecule._args.get('--debug', False)

--- a/test/unit/core/test_core.py
+++ b/test/unit/core/test_core.py
@@ -20,11 +20,24 @@
 
 import pytest
 
+from molecule.driver import vagrantdriver
+
+
+def test_driver(molecule_default_provider_instance):
+    assert isinstance(molecule_default_provider_instance.driver,
+                      vagrantdriver.VagrantDriver)
+
+
+def test_driver_setter(molecule_default_provider_instance):
+    molecule_default_provider_instance.driver = 'foo'
+
+    assert 'foo' == molecule_default_provider_instance.driver
+
 
 def test_get_driver_invalid_instance(molecule_default_provider_instance):
     del molecule_default_provider_instance.config.config['vagrant']
 
-    assert molecule_default_provider_instance.get_driver() is None
+    assert molecule_default_provider_instance._get_driver() is None
 
 
 def test_parse_provisioning_output_failure_00(

--- a/test/unit/core/test_core_docker.py
+++ b/test/unit/core/test_core_docker.py
@@ -36,7 +36,7 @@ def molecule_instance(temp_files, molecule_args):
 
 
 def test_get_driver(molecule_instance):
-    assert isinstance(molecule_instance.get_driver(),
+    assert isinstance(molecule_instance._get_driver(),
                       dockerdriver.DockerDriver)
 
 

--- a/test/unit/core/test_core_openstack.py
+++ b/test/unit/core/test_core_openstack.py
@@ -36,7 +36,7 @@ def molecule_instance(temp_files, molecule_args):
 
 
 def test_get_driver(molecule_instance):
-    assert isinstance(molecule_instance.get_driver(),
+    assert isinstance(molecule_instance._get_driver(),
                       openstackdriver.OpenstackDriver)
 
 

--- a/test/unit/core/test_core_vagrant.py
+++ b/test/unit/core/test_core_vagrant.py
@@ -36,7 +36,7 @@ def molecule_instance(temp_files, molecule_args):
 
 
 def test_get_driver(molecule_instance):
-    assert isinstance(molecule_instance.get_driver(),
+    assert isinstance(molecule_instance._get_driver(),
                       vagrantdriver.VagrantDriver)
 
 

--- a/test/unit/driver/test_dockerdriver.py
+++ b/test/unit/driver/test_dockerdriver.py
@@ -206,12 +206,12 @@ def test_provision(docker_instance):
 
 
 def test_inventory_generation(molecule_instance, docker_instance):
-    molecule_instance._driver = docker_instance
+    molecule_instance.driver = docker_instance
 
-    molecule_instance._driver.up()
+    molecule_instance.driver.up()
     molecule_instance._create_inventory_file()
 
-    pb = molecule_instance._driver.ansible_connection_params
+    pb = molecule_instance.driver.ansible_connection_params
     pb['playbook'] = 'playbook.yml'
     pb['inventory'] = 'test1,test2,'
     ansible = ansible_playbook.AnsiblePlaybook(pb)


### PR DESCRIPTION
We use the driver all over the place.  Doesn't make sense to reference
it in a "private" way.  Created a setter and getter on the core
class.