### PR TITLE
Switched to MS_DICTS strategy

### DIFF
--- a/molecule/config.py
+++ b/molecule/config.py
@@ -74,7 +74,7 @@ class Config(object):
 
         return anyconfig.load(configs,
                               ignore_missing=True,
-                              ac_merge=anyconfig.MS_DICTS_AND_LISTS)
+                              ac_merge=anyconfig.MS_DICTS)
 
     def _build_config_paths(self):
         """

--- a/molecule/util.py
+++ b/molecule/util.py
@@ -248,20 +248,14 @@ def merge_dicts(a, b):
 
     Will give an object such as::
 
-        {
-          'a': 1, 'b': [
-            {'c': 0}, {'c': 2}, {'c': 3}
-          ],
-          'd': {
-            'e': "bbb", 'f': 3
-          }
-        }
+        {'a': 1, 'b': [{'c': 3}], 'd': {'e': "bbb", 'f': 3}}
+
 
     :param a: the target dictionary
     :param b: the dictionary to import
     :return: dict
     """
-    md = m9dicts.make(a, merge=m9dicts.MS_DICTS_AND_LISTS)
+    md = m9dicts.make(a, merge=m9dicts.MS_DICTS)
     md.update(b)
 
     return md

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -158,10 +158,7 @@ def test_merge_dicts():
     # Example taken from python-anyconfig/anyconfig/__init__.py
     a = {'b': [{'c': 0}, {'c': 2}], 'd': {'e': 'aaa', 'f': 3}}
     b = {'a': 1, 'b': [{'c': 3}], 'd': {'e': 'bbb'}}
-    expected = {'a': 1,
-                'b': [{'c': 0}, {'c': 2}, {'c': 3}],
-                'd': {'e': "bbb",
-                      'f': 3}}
+    expected = {'a': 1, 'b': [{'c': 3}], 'd': {'e': "bbb", 'f': 3}}
     result = util.merge_dicts(a, b)
 
     assert expected == result


### PR DESCRIPTION
We shouldn't append list items to the config, we want to override
list items.  This is the behavior we had previously with our own
custom dict merging code.

Fixes: #381