### PR TITLE
Added ansible install to instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,7 @@ Install molecule using pip:
 
 .. code-block:: bash
 
+  $ pip install ansible
   $ pip install molecule
 
 Create a new role with the docker driver:


### PR DESCRIPTION
We stopped installing ansible with molecule, since maintainers will
likely want to control this on their own.