### PR TITLE
Corrected double requirements.

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,3 @@
-flake8
 mock
 pytest
 pytest-cov


### PR DESCRIPTION
We now require flake8 for runtime as well as test.