### PR TITLE
Added ability to specify custom dockerfile

### DIFF
--- a/doc/source/driver/docker/index.rst
+++ b/doc/source/driver/docker/index.rst
@@ -34,7 +34,7 @@ Options
 
 The available param for the docker driver itself is:
 
-* ``install_python`` - **(default=yes)** install python onto all images for all
-  containers
+* ``build_image`` - **(default=yes)** build image with python support or use custom dockerfile
+* ``dockerfile``- **dockerfile to use when building. By default the dockerfile will just install python onto the image given.
 
 .. _`host config`: https://github.com/docker/docker-py/blob/master/docs/port-bindings.md


### PR DESCRIPTION
This addresses the question from #393 

Simply put, you can specify a dockerfile to use. The `image` and `image_version` will be used as the proper image and version for the used dockerfile. The dockerfile used is relative to the root of the directory you are calling molecule from. 

The use case proposed with this feature addition is the ability to include a dockerfile with your tests and not have to worry about storing an image for someone else to use for testing. Another example is including a dockerfile for easier CI integration with molecule testing (using the dockerdriver). 

Also, the `install_python` flag has been replaced with `build_image`.

## Example
``` yaml
docker:
  containers:
  - name: foo1-01
    ansible_groups:
      - group1
    image: custom
    image_version: ver
    dockerfile: 'dockerfile'
    build_image: yes

```

## Test Results
```
  syntax: commands succeeded
  py27-ansible19-unit: commands succeeded
  py27-ansible19-functional: commands succeeded
  py27-ansible20-unit: commands succeeded
  py27-ansible20-functional: commands succeeded
  py27-ansible21-unit: commands succeeded
  py27-ansible21-functional: commands succeeded
  doc: commands succeeded
  congratulations :)
```
