### PR TITLE
Moved _print_valid_platforms to "public"

### DIFF
--- a/molecule/command/list.py
+++ b/molecule/command/list.py
@@ -44,5 +44,5 @@ class List(base.Base):
         """
         porcelain = self.molecule.args['-m'] or self.molecule.args[
             '--porcelain']
-        self.molecule._print_valid_platforms(porcelain=porcelain)
+        self.molecule.print_valid_platforms(porcelain=porcelain)
         return None, None

--- a/molecule/command/status.py
+++ b/molecule/command/status.py
@@ -81,7 +81,7 @@ class Status(base.Base):
 
         # Display the platforms.
         if display_all or self.molecule.args['--platforms']:
-            self.molecule._print_valid_platforms(porcelain=porcelain)
+            self.molecule.print_valid_platforms(porcelain=porcelain)
 
         # Display the providers.
         if display_all or self.molecule.args['--providers']:

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -74,7 +74,7 @@ class Molecule(object):
             self.args['--provider'] = None
             self.args['--platform'] = None
             self.driver = self._get_driver()
-            self._print_valid_platforms()
+            self.print_valid_platforms()
             util.sysexit()
 
         # updates instances config with full machine names
@@ -119,7 +119,7 @@ class Molecule(object):
         out = self.driver.conf(ssh_config=True)
         util.write_file(ssh_config, out)
 
-    def _print_valid_platforms(self, porcelain=False):
+    def print_valid_platforms(self, porcelain=False):
         if not porcelain:
             # NOTE(retr0h): Should we log here, when ``_display_tabulate_data``
             # prints?

--- a/test/unit/core/test_core_docker.py
+++ b/test/unit/core/test_core_docker.py
@@ -52,14 +52,14 @@ def test_write_ssh_config(mocker, molecule_instance):
 
 
 def test_print_valid_platforms(capsys, molecule_instance):
-    molecule_instance._print_valid_platforms()
+    molecule_instance.print_valid_platforms()
     out, _ = capsys.readouterr()
 
     assert 'docker  (default)\n' == out
 
 
 def test_print_valid_platforms_with_porcelain(capsys, molecule_instance):
-    molecule_instance._print_valid_platforms(porcelain=True)
+    molecule_instance.print_valid_platforms(porcelain=True)
     out, _ = capsys.readouterr()
 
     assert 'docker  d\n' == out

--- a/test/unit/core/test_core_openstack.py
+++ b/test/unit/core/test_core_openstack.py
@@ -52,14 +52,14 @@ def test_write_ssh_config(mocker, molecule_instance):
 
 
 def test_print_valid_platforms(capsys, molecule_instance):
-    molecule_instance._print_valid_platforms()
+    molecule_instance.print_valid_platforms()
     out, _ = capsys.readouterr()
 
     assert 'openstack  (default)\n' == out
 
 
 def test_print_valid_platforms_with_porcelain(capsys, molecule_instance):
-    molecule_instance._print_valid_platforms(porcelain=True)
+    molecule_instance.print_valid_platforms(porcelain=True)
     out, _ = capsys.readouterr()
 
     assert 'openstack  d\n' == out

--- a/test/unit/core/test_core_vagrant.py
+++ b/test/unit/core/test_core_vagrant.py
@@ -55,14 +55,14 @@ def test_write_ssh_config(mocker, molecule_instance):
 
 
 def test_print_valid_platforms(capsys, molecule_instance):
-    molecule_instance._print_valid_platforms()
+    molecule_instance.print_valid_platforms()
     out, _ = capsys.readouterr()
 
     assert 'ubuntu  (default)\n' == out
 
 
 def test_print_valid_platforms_with_porcelain(capsys, molecule_instance):
-    molecule_instance._print_valid_platforms(porcelain=True)
+    molecule_instance.print_valid_platforms(porcelain=True)
     out, _ = capsys.readouterr()
 
     assert 'ubuntu  d\n' == out


### PR DESCRIPTION
This method is used outside of the molecule class, therefore it isn't
"private".