### PR TITLE
Reverted regexp back to original

### DIFF
--- a/molecule/command/idempotence.py
+++ b/molecule/command/idempotence.py
@@ -84,7 +84,7 @@ class Idempotence(base.Base):
         output = re.sub("\n\s*\n*", "\n", output)
 
         # Look for any non-zero changed lines
-        changed = re.search(r'(changed=[1-9]+)', output)
+        changed = re.search(r'(changed=[1-9][0-9]*)', output)
 
         if changed:
             # Not idempotent


### PR DESCRIPTION
Somehow I missed this when moving to the new idempotence check.