### PR TITLE
Configure verifier like test kitchen

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -186,25 +186,10 @@ OpenStack Section
 
 See OpenStack :ref:`openstack_driver_usage`
 
-Testinfra Section
------------------
+Verifier Section
+----------------
 
-In the testinfra section, you can configure flags exactly as they're passed to
-`testinfra`. Some flags, such as ``ansible-inventory``, ``connection`` and
-``hosts``, are already set by Molecule. Any flag set in this section will
-override the defaults. See more details on using `testinfra's command line
-arguments`_.
-
-.. code-block:: yaml
-
-  testinfra:
-    n: 1
-
-Note: Testinfra is based on pytest, so additional `pytest arguments`_ can be
-passed through it.
-
-.. _`testinfra's command line arguments`: http://testinfra.readthedocs.io/en/latest/invocation.html
-.. _`PyTest arguments`: http://pytest.org/latest/usage.html#usage
+See OpenStack :ref:`verifiers`
 
 Playbook
 ========

--- a/doc/source/verifier.rst
+++ b/doc/source/verifier.rst
@@ -1,9 +1,15 @@
+.. _verifiers:
+
 *********
 Verifiers
 *********
 
 Molecule is `opinionated`.  By being opinionated molecue tries to enforce a
 common way in which roles are maintained.
+
+The verifier section, specifies the verifier to use, with options to override
+the defaults.  Currently `testinfra` is the only verifier which implements this
+override functionality.
 
 Testinfra
 =========
@@ -16,6 +22,25 @@ Example files are created with ``molecule init``.
 
 Usage
 -----
+
+Any flag set in this section will override the defaults. See more details on
+using `testinfra's command line arguments`_.
+
+.. code-block:: yaml
+
+  verifier:
+    name: testinfra
+    options:
+      n: 1
+
+Note: Testinfra is based on pytest, so additional `pytest arguments`_ can be
+passed through it.
+
+.. _`testinfra's command line arguments`: http://testinfra.readthedocs.io/en/latest/invocation.html
+.. _`PyTest arguments`: http://pytest.org/latest/usage.html#usage
+
+Project Structure
+-----------------
 
 .. code-block:: yaml
 
@@ -37,6 +62,14 @@ Example files are created with ``molecule init --serverspec``.
 
 Usage
 -----
+
+.. code-block:: yaml
+
+  verifier:
+    name: serverspec
+
+Project Structure
+-----------------
 
 .. code-block:: yaml
 
@@ -82,6 +115,14 @@ Example files are created with ``molecule init --goss``.
 
 Usage
 -----
+
+.. code-block:: yaml
+
+  verifier:
+    name: goss
+
+Project Structure
+-----------------
 
 .. code-block:: yaml
 

--- a/molecule/conf/defaults.yml
+++ b/molecule/conf/defaults.yml
@@ -90,4 +90,6 @@ ansible:
   config_file: ansible.cfg
   playbook: playbook.yml
 
-testinfra: {}
+verifier:
+  name: testinfra
+  options: {}

--- a/molecule/cookiecutter/driver/docker/cookiecutter.json
+++ b/molecule/cookiecutter/driver/docker/cookiecutter.json
@@ -1,5 +1,6 @@
 {
   "repo_name": "OVERRIDEN",
   "role_name": "OVERRIDEN",
-  "instances": 2
+  "instances": 2,
+  "verifier_name": "OVERRIDEN"
 }

--- a/molecule/cookiecutter/driver/docker/{{cookiecutter.repo_name}}/molecule.yml
+++ b/molecule/cookiecutter/driver/docker/{{cookiecutter.repo_name}}/molecule.yml
@@ -8,4 +8,7 @@ docker:
         image_version: latest
         ansible_groups:
           - group1
-    {%- endfor -%}
+    {%- endfor %}
+
+verifier:
+  name: {{ cookiecutter.verifier_name }}

--- a/molecule/cookiecutter/driver/openstack/cookiecutter.json
+++ b/molecule/cookiecutter/driver/openstack/cookiecutter.json
@@ -1,4 +1,5 @@
 {
   "repo_name": "OVERRIDEN",
-  "role_name": "OVERRIDEN"
+  "role_name": "OVERRIDEN",
+  "verifier_name": "OVERRIDEN"
 }

--- a/molecule/cookiecutter/driver/openstack/{{cookiecutter.repo_name}}/molecule.yml
+++ b/molecule/cookiecutter/driver/openstack/{{cookiecutter.repo_name}}/molecule.yml
@@ -9,3 +9,6 @@ openstack:
       sshuser: centos
       ansible_groups:
         - group1
+
+verifier:
+  name: {{ cookiecutter.verifier_name }}

--- a/molecule/cookiecutter/driver/vagrant/cookiecutter.json
+++ b/molecule/cookiecutter/driver/vagrant/cookiecutter.json
@@ -8,5 +8,6 @@
   "provider_name": "virtualbox",
   "provider_type": "virtualbox",
   "provider_options_memory": 512,
-  "provider_options_cpu": 2
+  "provider_options_cpu": 2,
+  "verifier_name": "OVERRIDEN"
 }

--- a/molecule/cookiecutter/driver/vagrant/{{cookiecutter.repo_name}}/molecule.yml
+++ b/molecule/cookiecutter/driver/vagrant/{{cookiecutter.repo_name}}/molecule.yml
@@ -18,4 +18,7 @@ vagrant:
       - name: {{ cookiecutter.role_name }}-{{ '%02d' % loop.index }}
         ansible_groups:
           - group1
-    {%- endfor -%}
+    {%- endfor %}
+
+verifier:
+  name: {{ cookiecutter.verifier_name }}

--- a/molecule/cookiecutter/verifier/serverspec/cookiecutter.json
+++ b/molecule/cookiecutter/verifier/serverspec/cookiecutter.json
@@ -1,5 +1,5 @@
 {
   "repo_name": "OVERRIDEN",
   "role_name": "OVERRIDEN",
-  "driver": "OVERRIDEN"
+  "driver_name": "OVERRIDEN"
 }

--- a/molecule/cookiecutter/verifier/serverspec/{{cookiecutter.repo_name}}/spec/spec_helper.rb
+++ b/molecule/cookiecutter/verifier/serverspec/{{cookiecutter.repo_name}}/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-{% if cookiecutter.driver == 'docker' -%}
+{% if cookiecutter.driver_name == 'docker' -%}
 require 'docker'
 require 'serverspec'
 

--- a/molecule/verifier/testinfra.py
+++ b/molecule/verifier/testinfra.py
@@ -50,7 +50,11 @@ class Testinfra(base.Base):
 
         testinfra_options = util.merge_dicts(
             self._molecule.driver.testinfra_args,
-            self._molecule.config.config['testinfra'])
+            # Preserve backward compatibility with old testinfra override
+            # syntax.
+            self._molecule.config.config.get(
+                'testinfra',
+                self._molecule.config.config['verifier'].get('options', {})))
         testinfra_options['env'] = ansible.env
         testinfra_options['debug'] = self._molecule.args.get('--debug', False)
         testinfra_options['sudo'] = self._molecule.args.get('--sudo', False)

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -219,7 +219,10 @@ def ansible_section_data():
                 'FOO': 'bar'
             }
         },
-        'testinfra': {}
+        'verifier': {
+            'name': 'testinfra',
+            'options': {}
+        }
     }
 
 


### PR DESCRIPTION
Reworking config slightly to understand the name of the verifier,
and options it accepts.  This is backward compatible with the old
syntax.