### PR TITLE
Hide verifier behind a verifier property on core

### DIFF
--- a/molecule/core.py
+++ b/molecule/core.py
@@ -47,6 +47,8 @@ class Molecule(object):
         self.env = os.environ.copy()
         self.args = args
         self.config = config.Config()
+        self._verifier = self._get_verifier()
+        self._verifier_options = self._get_verifier_options()
 
     def main(self):
         if not os.path.exists(self.config.config['molecule']['molecule_dir']):
@@ -91,6 +93,14 @@ class Molecule(object):
     @driver.setter
     def driver(self, val):
         self._driver = val
+
+    @property
+    def verifier(self):
+        return self._verifier
+
+    @property
+    def verifier_options(self):
+        return self._verifier_options
 
     def write_ssh_config(self):
         ssh_config = self._get_ssh_config()
@@ -308,3 +318,14 @@ class Molecule(object):
                 instances[instance_name]['groups'] = []
 
         return dict(instances)
+
+    def _get_verifier(self):
+        if self.config.config.get('testinfra'):
+            return 'testinfra'
+        return self.config.config['verifier']['name']
+
+    def _get_verifier_options(self):
+        # Preserve backward compatibility with old testinfra override
+        # syntax.
+        return self.config.config.get(
+            'testinfra', self.config.config['verifier'].get('options', {}))

--- a/molecule/verifier/testinfra.py
+++ b/molecule/verifier/testinfra.py
@@ -50,11 +50,7 @@ class Testinfra(base.Base):
 
         testinfra_options = util.merge_dicts(
             self._molecule.driver.testinfra_args,
-            # Preserve backward compatibility with old testinfra override
-            # syntax.
-            self._molecule.config.config.get(
-                'testinfra',
-                self._molecule.config.config['verifier'].get('options', {})))
+            self._molecule.verifier_options)
         testinfra_options['env'] = ansible.env
         testinfra_options['debug'] = self._molecule.args.get('--debug', False)
         testinfra_options['sudo'] = self._molecule.args.get('--sudo', False)

--- a/test/unit/core/test_core.py
+++ b/test/unit/core/test_core.py
@@ -40,6 +40,31 @@ def test_get_driver_invalid_instance(molecule_default_provider_instance):
     assert molecule_default_provider_instance._get_driver() is None
 
 
+def test_verifier(molecule_default_provider_instance):
+    assert 'testinfra' == molecule_default_provider_instance.verifier
+
+
+def test_verifier_backward_compatible(molecule_default_provider_instance):
+    m = molecule_default_provider_instance
+    m.config.config['testinfra'] = {}
+    m._verifier = m._get_verifier()
+
+    assert 'testinfra' == m.verifier
+
+
+def test_verifier_options(molecule_default_provider_instance):
+    assert {} == molecule_default_provider_instance.verifier_options
+
+
+def test_verifier_options_backward_compatible(
+        molecule_default_provider_instance):
+    m = molecule_default_provider_instance
+    m.config.config['testinfra'] = {'foo': 'bar'}
+    m._verifier_options = m._get_verifier_options()
+
+    assert {'foo': 'bar'} == m.verifier_options
+
+
 @pytest.mark.skip(reason='TODO(retr0h): Determine best way to test this')
 def test_remove_templates():
     pass


### PR DESCRIPTION
Core now has verifier and verifier_options properties.  The testinfra
verifier is consuming the new verifier_options property.  This is the
groundwork to selecting which verifier to use on a `verify` or `test`.