### PR TITLE
Changed connection to ansible_connection

### DIFF
--- a/molecule/driver/dockerdriver.py
+++ b/molecule/driver/dockerdriver.py
@@ -194,7 +194,7 @@ class DockerDriver(basedriver.BaseDriver):
         pass
 
     def inventory_entry(self, instance):
-        template = '{} connection=docker\n'
+        template = '{} ansible_connection=docker\n'
 
         return template.format(instance['name'])
 

--- a/test/unit/driver/test_dockerdriver.py
+++ b/test/unit/driver/test_dockerdriver.py
@@ -218,5 +218,10 @@ def test_inventory_generation(molecule_instance, docker_instance):
     pb['inventory'] = 'test1,test2,'
     ansible = ansible_playbook.AnsiblePlaybook(pb)
 
+    for instance in molecule_instance.driver.instances:
+        expected = '{} ansible_connection=docker\n'.format(instance['name'])
+
+        assert expected == molecule_instance.driver.inventory_entry(instance)
+
     # TODO(retr0h): Understand why driver is None
     assert (None, '') == ansible.execute()


### PR DESCRIPTION
Allows ansible.executor.task_queue_manager.TaskQueueManager to pick up
the connection type.

Fixes: #459