### PR TITLE
Adding docker capability support to docker driver

### DIFF
--- a/doc/source/driver/docker/index.rst
+++ b/doc/source/driver/docker/index.rst
@@ -31,6 +31,8 @@ Options
   `host config`_.
 * ``volume_mounts`` - **(OPTIONAL)** the volume mappings between the Docker
   host and the container.
+* ``cap_add`` - **(OPTIONAL)** add Linux Kernel `capability`_ to the Docker host
+* ``cap_drop`` - **(OPTIONAL)** drop Linux Kernel `capability`_ from the Docker host
 * ``command`` - **(OPTIONAL)** the command to launch the container with
 
 The available param for the docker driver itself is:
@@ -39,3 +41,4 @@ The available param for the docker driver itself is:
 * ``dockerfile`` - **dockerfile** to use when building. By default the dockerfile will just install python onto the image given.
 
 .. _`host config`: https://github.com/docker/docker-py/blob/master/docs/port-bindings.md
+.. _`capability`: https://docs.docker.com/engine/reference/run/#/runtime-privilege-and-linux-capabilities

--- a/doc/source/driver/docker/usage.rst
+++ b/doc/source/driver/docker/usage.rst
@@ -14,6 +14,9 @@ Usage
         image: ubuntu
         image_version: latest
         privileged: True
+        cap_add:
+          - SYS_ADMIN
+          - MKNOD
         port_bindings:
           80: 80
       - name: foo-02

--- a/molecule/driver/dockerdriver.py
+++ b/molecule/driver/dockerdriver.py
@@ -124,13 +124,21 @@ class DockerDriver(basedriver.BaseDriver):
             if 'volume_mounts' not in container:
                 container['volume_mounts'] = []
 
+            if 'cap_add' not in container:
+                container['cap_add'] = []
+
+            if 'cap_drop' not in container:
+                container['cap_drop'] = []
+
             if 'command' not in container:
                 container['command'] = ""
 
             docker_host_config = self._docker.create_host_config(
                 privileged=container['privileged'],
                 port_bindings=container['port_bindings'],
-                binds=container['volume_mounts'])
+                binds=container['volume_mounts'],
+                cap_add=container['cap_add'],
+                cap_drop=container['cap_drop'])
 
             if (container['created'] is not True):
                 LOG.warning(

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -166,6 +166,8 @@ def docker_section_data():
                  },
                  'options': {'append_platform_to_hostname': True},
                  'volume_mounts': ['/tmp/test1:/inside:rw'],
+                 'cap_add': ['SYS_ADMIN', 'SETPCAP'],
+                 'cap_drop': ['MKNOD'],
                  'ansible_groups': ['group1']}, {
                      'name': 'test2',
                      'image': 'ubuntu',

--- a/test/unit/driver/test_dockerdriver.py
+++ b/test/unit/driver/test_dockerdriver.py
@@ -181,6 +181,22 @@ def test_volume_mounts(docker_instance):
         'Mounts'][0]['Destination']
 
 
+def test_cap_add(docker_instance):
+    docker_instance.up()
+
+    assert "SYS_ADMIN" in docker_instance._docker.inspect_container('test1')[
+        'HostConfig']['CapAdd']
+    assert "SETPCAP" in docker_instance._docker.inspect_container('test1')[
+        'HostConfig']['CapAdd']
+
+
+def test_cap_drop(docker_instance):
+    docker_instance.up()
+
+    assert "MKNOD" in docker_instance._docker.inspect_container('test1')[
+        'HostConfig']['CapDrop']
+
+
 def test_destroy(docker_instance):
     docker_instance.up()
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist = syntax, py{27}-ansible{19,20,21}-{unit,functional}, doc
 passenv = *
 setenv =
     VIRTUAL_ENV={envdir}
-deps = 
+deps =
     -rrequirements.txt
     -rtest-requirements.txt
     ansible19: ansible==1.9.6
@@ -22,7 +22,7 @@ exclude = .venv, .tox, dist, build, doc, .eggs, asset
 format = pylint
 
 [testenv:syntax]
-deps = 
+deps =
     flake8
     # NOTE(retr0h): We specifically pin to a known version so formatting
     # is consistent across developer/PR.


### PR DESCRIPTION
This commit adds `cap_drop` and `cap_add` support to molecule's docker driver.  Capability support has been available in [docker-py](https://github.com/docker/docker-py/blob/master/docs/hostconfig.md) since version `1.2`. Adding and dropping docker capabilities is needed when testing services that require to be managed by `systemd`. You can read a bit about the background [here](https://github.com/docker/docker/issues/7459) and [here](https://github.com/docker/docker/pull/25567). This PR also removes some empty space characters from `tox` configuration - sorry, I have an OCD :-)