### PR TITLE
Further encapsulated AnsiblePlaybook

### DIFF
--- a/molecule/ansible_playbook.py
+++ b/molecule/ansible_playbook.py
@@ -27,11 +27,18 @@ LOG = util.get_logger(__name__)
 
 
 class AnsiblePlaybook(object):
-    def __init__(self, args, _env=None, _out=LOG.info, _err=LOG.error):
+    def __init__(self,
+                 args,
+                 connection_params,
+                 _env=None,
+                 _out=LOG.info,
+                 _err=LOG.error):
         """
         Sets up requirements for ansible-playbook, and returns None.
 
         :param args: A dict containing arguments to pass to ansible-playbook.
+        :param connection_params: A dict containing driver specific connection
+         params to pass to ansible-playbook.
         :param _env: An optional environment to pass to underlying :func:`sh`
          call.
         :param _out: An optional function to process STDOUT for underlying
@@ -46,9 +53,11 @@ class AnsiblePlaybook(object):
         self._cli_pos = []
         self.env = _env if _env else os.environ.copy()
 
-        # process arguments passed in (typically from molecule.yml's ansible block)
         for k, v in args.iteritems():
             self.parse_arg(k, v)
+
+        for k, v in connection_params.items():
+            self.add_cli_arg(k, v)
 
         # defaults can be redefined with call to add_env_arg() before baking
         self.add_env_arg('PYTHONUNBUFFERED', '1')

--- a/molecule/command/check.py
+++ b/molecule/command/check.py
@@ -42,11 +42,10 @@ class Check(base.Base):
             LOG.error('ERROR: {}'.format(msg))
             util.sysexit()
 
-        ansible = ansible_playbook.AnsiblePlaybook(self.molecule.config.config[
-            'ansible'])
+        ansible = ansible_playbook.AnsiblePlaybook(
+            self.molecule.config.config['ansible'],
+            self.molecule.driver.ansible_connection_params)
         ansible.add_cli_arg('check', True)
-        for k, v in self.molecule.driver.ansible_connection_params.items():
-            ansible.add_cli_arg(k, v)
 
         util.print_info('Performing a "Dry Run" of playbook ...')
         return ansible.execute(hide_errors=True)

--- a/molecule/command/converge.py
+++ b/molecule/command/converge.py
@@ -76,12 +76,9 @@ class Converge(base.Base):
             galaxy.install()
             self.molecule.state.change_state('installed_deps', True)
 
-        ansible = ansible_playbook.AnsiblePlaybook(self.molecule.config.config[
-            'ansible'])
-
-        # Params to work with driver
-        for k, v in self.molecule.driver.ansible_connection_params.items():
-            ansible.add_cli_arg(k, v)
+        ansible = ansible_playbook.AnsiblePlaybook(
+            self.molecule.config.config['ansible'],
+            self.molecule.driver.ansible_connection_params)
 
         # Target tags passed in via CLI
         if self.command_args.get('tags'):

--- a/molecule/command/syntax.py
+++ b/molecule/command/syntax.py
@@ -45,8 +45,8 @@ class Syntax(base.Base):
             galaxy.install()
             self.molecule.state.change_state('installed_deps', True)
 
-        ansible = ansible_playbook.AnsiblePlaybook(self.molecule.config.config[
-            'ansible'])
+        ansible = ansible_playbook.AnsiblePlaybook(
+            self.molecule.config.config['ansible'], {})
         ansible.add_cli_arg('syntax-check', True)
         ansible.add_cli_arg('inventory_file', 'localhost,')
         util.print_info('Checking playbook\'s syntax ...')

--- a/molecule/verifier/goss.py
+++ b/molecule/verifier/goss.py
@@ -73,9 +73,8 @@ class Goss(base.Base):
     def _get_ansible_instance(self):
         ac = self._molecule.config.config['ansible']
         ac['playbook'] = self._playbook
-        ansible = ansible_playbook.AnsiblePlaybook(ac)
-        for k, v in self._molecule.driver.ansible_connection_params.items():
-            ansible.add_cli_arg(k, v)
+        ansible = ansible_playbook.AnsiblePlaybook(
+            ac, self._molecule.driver.ansible_connection_params)
 
         return ansible
 

--- a/molecule/verifier/testinfra.py
+++ b/molecule/verifier/testinfra.py
@@ -47,7 +47,8 @@ class Testinfra(base.Base):
         :return: None
         """
         ansible = ansible_playbook.AnsiblePlaybook(
-            self._molecule.config.config['ansible'], _env=self._molecule.env)
+            self._molecule.config.config['ansible'], {},
+            _env=self._molecule.env)
 
         testinfra_options = config.merge_dicts(
             self._molecule.driver.testinfra_args,

--- a/test/unit/driver/test_dockerdriver.py
+++ b/test/unit/driver/test_dockerdriver.py
@@ -213,11 +213,11 @@ def test_destroy(docker_instance):
 
 
 def test_provision(docker_instance):
+    molecule_instance.driver = docker_instance
     docker_instance.up()
-    pb = docker_instance.ansible_connection_params
-    pb['playbook'] = 'playbook.yml'
-    pb['inventory'] = 'test1,test2,'
-    ansible = ansible_playbook.AnsiblePlaybook(pb)
+    args = {'playbook': 'playbook.yml', 'inventory': 'test1,test2,'}
+    ansible = ansible_playbook.AnsiblePlaybook(
+        args, molecule_instance.driver.ansible_connection_params)
 
     # TODO(retr0h): Understand why driver is None
     assert (None, '') == ansible.execute()
@@ -229,10 +229,9 @@ def test_inventory_generation(molecule_instance, docker_instance):
     molecule_instance.driver.up()
     molecule_instance.create_inventory_file()
 
-    pb = molecule_instance.driver.ansible_connection_params
-    pb['playbook'] = 'playbook.yml'
-    pb['inventory'] = 'test1,test2,'
-    ansible = ansible_playbook.AnsiblePlaybook(pb)
+    args = {'playbook': 'playbook.yml', 'inventory': 'test1,test2,'}
+    ansible = ansible_playbook.AnsiblePlaybook(
+        args, molecule_instance.driver.ansible_connection_params)
 
     for instance in molecule_instance.driver.instances:
         expected = '{} ansible_connection=docker\n'.format(instance['name'])

--- a/test/unit/test_ansible_playbook.py
+++ b/test/unit/test_ansible_playbook.py
@@ -25,7 +25,8 @@ from molecule import ansible_playbook
 
 @pytest.fixture()
 def ansible_playbook_instance(ansible_section_data):
-    return ansible_playbook.AnsiblePlaybook(ansible_section_data['ansible'])
+    return ansible_playbook.AnsiblePlaybook(ansible_section_data['ansible'],
+                                            {})
 
 
 def test_init_arg_loading_string(ansible_playbook_instance):


### PR DESCRIPTION
We were having to add additional driver specific connection
params to ansible playbook before use.  This should live inside
the class and handled internally.