### PR TITLE
Corrected molecule login usage

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ Breaking Changes
   other than vagrant.
 * The ``init`` subcommand requires a ``--verifier`` flag when creating a
   verifier other than testinfra.
+* The ``login`` subcommand requires a ``--host`` flag when more than one
+  instance exists.
 
 1.11
 ====

--- a/molecule/command/login.py
+++ b/molecule/command/login.py
@@ -120,15 +120,15 @@ class Login(base.Base):
 
 
 @click.command()
-@click.argument('host')
+@click.option('--host', default=None, help='Host to access.')
 @click.pass_context
 def login(ctx, host):
     """
     Initiates an interactive ssh session with the given host.
 
     \b
-    Usage:
-        login [<host>]
+    If no `--host` flag provided, will login to the instance.  If more than
+    once instance exists, the `--host` flag must be provided.
     """
     command_args = {'host': host}
 


### PR DESCRIPTION
When cutting over to click, `molecule login` usage was not preserved.