### PR TITLE
Removed temp_file from changing directory

### DIFF
--- a/test/unit/command/conftest.py
+++ b/test/unit/command/conftest.py
@@ -18,33 +18,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-import os
-import shutil
-
 import pytest
-import yaml
-
-
-@pytest.fixture()
-def molecule_file(tmpdir, request, molecule_vagrant_config):
-    d = tmpdir.mkdir('molecule')
-    c = d.join(os.extsep.join(('molecule', 'yml')))
-    data = molecule_vagrant_config
-    c.write(data)
-
-    pbook = d.join(os.extsep.join(('playbook', 'yml')))
-    data = [{'hosts': 'all', 'tasks': [{'command': 'echo'}]}]
-    pbook.write(yaml.safe_dump(data))
-
-    os.chdir(d.strpath)
-
-    def cleanup():
-        os.remove(c.strpath)
-        shutil.rmtree(d.strpath)
-
-    request.addfinalizer(cleanup)
-
-    return c.strpath
 
 
 @pytest.fixture

--- a/test/unit/command/test_init.py
+++ b/test/unit/command/test_init.py
@@ -25,14 +25,6 @@ import pytest
 from molecule.command import init
 
 
-@pytest.fixture()
-def molecule_dir(tmpdir):
-    d = tmpdir.mkdir('test_molecule')
-    os.chdir(d.strpath)
-
-    return d.strpath
-
-
 @pytest.fixture
 def init_command_args():
     return {'role': 'docker_test',
@@ -40,27 +32,26 @@ def init_command_args():
             'verifier': 'testinfra'}
 
 
-def test_create_role(molecule_dir, init_command_args):
+def test_create_role(temp_dir, init_command_args):
     init_command_args.update({'role': 'unit_test1'})
     i = init.Init({}, init_command_args)
     with pytest.raises(SystemExit):
         i.execute()
 
-    assert os.path.isdir(os.path.join(molecule_dir, 'unit_test1'))
-    assert os.path.isfile(
-        os.path.join(molecule_dir, 'unit_test1', 'molecule.yml'))
+    assert os.path.isdir(os.path.join(temp_dir, 'unit_test1'))
+    assert os.path.isfile(os.path.join(temp_dir, 'unit_test1', 'molecule.yml'))
 
 
-def test_create_role_in_existing_directory(molecule_dir, init_command_args):
+def test_create_role_in_existing_directory(temp_dir, init_command_args):
     del init_command_args['role']
     i = init.Init({}, init_command_args)
     with pytest.raises(SystemExit):
         i.execute()
 
-    assert os.path.isdir(os.path.join(molecule_dir))
+    assert os.path.isdir(os.path.join(temp_dir))
 
 
-def test_create_role_existing_dir_error(init_command_args):
+def test_create_role_existing_dir_error(temp_dir, init_command_args):
     os.mkdir('test1')
     init_command_args.update({'role': 'test1'})
     i = init.Init({}, init_command_args)
@@ -70,27 +61,26 @@ def test_create_role_existing_dir_error(init_command_args):
 
 
 @pytest.mark.parametrize('driver', ['vagrant', 'docker', 'openstack'])
-def test_create_role_with_driver_flag(driver, molecule_dir, init_command_args):
+def test_create_role_with_driver_flag(driver, temp_dir, init_command_args):
     init_command_args.update({'driver': driver})
     i = init.Init({}, init_command_args)
     with pytest.raises(SystemExit):
         i.execute()
 
-    os.chdir(os.path.join(molecule_dir, 'docker_test'))
+    os.chdir(os.path.join(temp_dir, 'docker_test'))
 
     with open('molecule.yml') as f:
         assert driver in f.read()
 
 
 @pytest.mark.parametrize('verifier', ['testinfra', 'serverspec', 'goss'])
-def test_create_role_with_verifier_flag(verifier, molecule_dir,
-                                        init_command_args):
+def test_create_role_with_verifier_flag(verifier, temp_dir, init_command_args):
     init_command_args.update({'verifier': verifier})
     i = init.Init({}, init_command_args)
     with pytest.raises(SystemExit):
         i.execute()
 
-    os.chdir(os.path.join(molecule_dir, 'docker_test'))
+    os.chdir(os.path.join(temp_dir, 'docker_test'))
 
     with open('molecule.yml') as f:
         assert verifier in f.read()

--- a/test/unit/core/conftest.py
+++ b/test/unit/core/conftest.py
@@ -35,8 +35,8 @@ def molecule_args():
 
 
 @pytest.fixture()
-def molecule_default_provider_instance(temp_files, state_path_without_data,
-                                       molecule_args):
+def molecule_default_provider_instance(temp_dir, temp_files,
+                                       state_path_without_data, molecule_args):
     c = temp_files(fixtures=['molecule_vagrant_config'])
     m = core.Molecule(molecule_args)
     m.config = config.Config(configs=c)

--- a/test/unit/core/test_core_docker.py
+++ b/test/unit/core/test_core_docker.py
@@ -26,7 +26,7 @@ from molecule.driver import dockerdriver
 
 
 @pytest.fixture()
-def molecule_instance(temp_files, molecule_args):
+def molecule_instance(temp_dir, temp_files, molecule_args):
     c = temp_files(fixtures=['molecule_docker_config'])
     m = core.Molecule(molecule_args)
     m.config = config.Config(configs=c)

--- a/test/unit/core/test_core_openstack.py
+++ b/test/unit/core/test_core_openstack.py
@@ -26,7 +26,7 @@ from molecule.driver import openstackdriver
 
 
 @pytest.fixture()
-def molecule_instance(temp_files, molecule_args):
+def molecule_instance(temp_dir, temp_files, molecule_args):
     c = temp_files(fixtures=['molecule_openstack_config'])
     m = core.Molecule(molecule_args)
     m.config = config.Config(configs=c)

--- a/test/unit/core/test_core_vagrant.py
+++ b/test/unit/core/test_core_vagrant.py
@@ -26,7 +26,7 @@ from molecule.driver import vagrantdriver
 
 
 @pytest.fixture()
-def molecule_instance(temp_files, molecule_args):
+def molecule_instance(temp_dir, temp_files, molecule_args):
     c = temp_files(fixtures=['molecule_vagrant_config'])
     m = core.Molecule(molecule_args)
     m.config = config.Config(configs=c)

--- a/test/unit/driver/test_openstackdriver.py
+++ b/test/unit/driver/test_openstackdriver.py
@@ -31,7 +31,7 @@ from molecule.driver import openstackdriver
 
 
 @pytest.fixture()
-def molecule_instance(temp_files, state_path_without_data):
+def molecule_instance(temp_dir, temp_files, state_path_without_data):
     c = temp_files(fixtures=['molecule_openstack_config'])
     m = core.Molecule({})
     m.config = config.Config(configs=c)

--- a/test/unit/driver/test_vagrantdriver.py
+++ b/test/unit/driver/test_vagrantdriver.py
@@ -29,7 +29,7 @@ from molecule.driver import vagrantdriver
 
 
 @pytest.fixture()
-def molecule_instance(temp_files, state_path_without_data):
+def molecule_instance(temp_dir, temp_files, state_path_without_data):
     c = temp_files(fixtures=['molecule_vagrant_config'])
     m = core.Molecule({})
     m.config = config.Config(configs=c)

--- a/test/unit/support/playbook.yml
+++ b/test/unit/support/playbook.yml
@@ -1,6 +1,0 @@
----
-- hosts: all
-
-  tasks:
-    - name: TestCase
-      command: echo test

--- a/test/unit/test_ansible_playbook.py
+++ b/test/unit/test_ansible_playbook.py
@@ -66,7 +66,8 @@ def test_parse_arg_config_file(ansible_playbook_instance):
 
 def test_parse_arg_playbook(ansible_playbook_instance):
     assert ansible_playbook_instance._cli.get('playbook') is None
-    assert 'playbook.yml' == ansible_playbook_instance._playbook
+    assert 'playbook_data.yml' == pytest.helpers.os_split(
+        ansible_playbook_instance._playbook)[-1]
 
 
 def test_parse_arg_host_vars(ansible_playbook_instance):

--- a/test/unit/verifier/test_ansible_lint.py
+++ b/test/unit/verifier/test_ansible_lint.py
@@ -32,4 +32,5 @@ def test_execute(mocker, ansible_lint_instance):
     mocked = mocker.patch('sh.ansible_lint')
     ansible_lint_instance.execute()
 
-    assert ('playbook.yml', ) == mocked.call_args[0]
+    pieces = pytest.helpers.os_split(mocked.call_args[0][0])
+    assert 'playbook_data.yml' == pieces[-1]


### PR DESCRIPTION
This was a poorly implemented, and caused side-effects with
other tests.  Reworked tests which need their own temporary
directory, to use a temporary directory fixture.  Also, made
sure the fixture cleans up after itself.