### PR TITLE
Preserve sudo passed in config section

### DIFF
--- a/molecule/verifier/testinfra.py
+++ b/molecule/verifier/testinfra.py
@@ -55,7 +55,8 @@ class Testinfra(base.Base):
             self._molecule.verifier_options)
         testinfra_options['env'] = ansible.env
         testinfra_options['debug'] = self._molecule.args.get('debug', False)
-        testinfra_options['sudo'] = self._molecule.args.get('sudo', False)
+        if self._molecule.args.get('sudo'):
+            testinfra_options['sudo'] = True
 
         tests_glob = self._get_tests()
         if len(tests_glob) > 0:

--- a/molecule/verifier/testinfra.py
+++ b/molecule/verifier/testinfra.py
@@ -54,7 +54,8 @@ class Testinfra(base.Base):
             self._molecule.driver.testinfra_args,
             self._molecule.verifier_options)
         testinfra_options['env'] = ansible.env
-        testinfra_options['debug'] = self._molecule.args.get('debug', False)
+        if self._molecule.args.get('debug'):
+            testinfra_options['debug'] = True
         if self._molecule.args.get('sudo'):
             testinfra_options['sudo'] = True
 

--- a/test/unit/verifier/test_testinfra.py
+++ b/test/unit/verifier/test_testinfra.py
@@ -52,8 +52,6 @@ def test_execute(patched_code_verifier, patched_test_verifier,
     assert (['/test/1', '/test/2'], ) == patched_test_verifier.call_args[0]
 
     ca = patched_test_verifier.call_args[1]
-    assert not ca['debug']
-    assert not ca['sudo']
     assert 'ansible' == ca['connection']
     assert 'test/inventory_file' == ca['ansible-inventory']
     assert 'env' in ca


### PR DESCRIPTION
The sudo option was getting reset, and would not respect option set
in molecule.yml.

Fixes: #496