### PR TITLE
Removed the driver requirements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ History
 * Additional command tests.
 * Changed connection to ansible_connection.
 * Implemented click vs docopt.  This slightly changes the CLI's semantics.
+* Removed the driver python packages from installing with molecule.
 
 Breaking Changes
 ----------------
@@ -24,6 +25,7 @@ Breaking Changes
   verifier other than testinfra.
 * The ``login`` subcommand requires a ``--host`` flag when more than one
   instance exists.
+* One must install the appropriate python package based on the driver used.
 
 1.11
 ====

--- a/README.rst
+++ b/README.rst
@@ -80,11 +80,16 @@ Provider
 Quick Start
 ===========
 
+.. important::
+
+  `Ansible`_ and the driver's python package require installation.
+
 Install molecule using pip:
 
 .. code-block:: bash
 
   $ pip install ansible
+  $ pip install docker-py
   $ pip install molecule
 
 Create a new role with the docker driver:

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -209,7 +209,7 @@ Usage
 Verifier Section
 ----------------
 
-See OpenStack :ref:`verifiers`
+See OpenStack :ref:`verifier_index`
 
 Playbook
 ========

--- a/doc/source/driver/docker/usage.rst
+++ b/doc/source/driver/docker/usage.rst
@@ -5,6 +5,10 @@ Example files are created with ``molecule init --driver docker``.
 Usage
 -----
 
+.. code-block:: bash
+
+  $ pip install docker-py
+
 .. code-block:: yaml
 
   ---

--- a/doc/source/driver/index.rst
+++ b/doc/source/driver/index.rst
@@ -8,6 +8,11 @@ Currently, Molecule supports three drivers: Vagrant, Docker, and OpenStack.
 The driver can set when using ``init`` command or through the
 ``molecule.yml`` file.
 
+.. important::
+
+  The driver's python package requires installation.  See the respective
+  section for details.
+
 .. include:: docker/index.rst
 .. include:: docker/usage.rst
 

--- a/doc/source/driver/openstack/usage.rst
+++ b/doc/source/driver/openstack/usage.rst
@@ -5,6 +5,10 @@ Example files are created with ``molecule init --driver openstack``.
 Usage
 -----
 
+.. code-block:: bash
+
+  $ pip install shade
+
 .. code-block:: yaml
 
   ---

--- a/doc/source/driver/vagrant/usage.rst
+++ b/doc/source/driver/vagrant/usage.rst
@@ -6,7 +6,11 @@ Usage
 -----
 
 This is an example of a set of vagrant instance - for information on specifying
-the platform/provider, see :ref:`providers`.
+the platform/provider, see :ref:`provider_index`.
+
+.. code-block:: bash
+
+  $ pip install python-vagrant
 
 .. code-block:: yaml
 

--- a/doc/source/provider/index.rst
+++ b/doc/source/provider/index.rst
@@ -1,4 +1,4 @@
-.. _providers:
+.. _provider_index:
 
 *********
 Providers

--- a/doc/source/verifier.rst
+++ b/doc/source/verifier.rst
@@ -1,4 +1,4 @@
-.. _verifiers:
+.. _verifier_index:
 
 *********
 Verifiers

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -28,9 +28,6 @@ from molecule import config
 from molecule import state
 from molecule import util
 from molecule.driver import basedriver
-from molecule.driver import dockerdriver
-from molecule.driver import openstackdriver
-from molecule.driver import vagrantdriver
 
 LOG = util.get_logger(__name__)
 
@@ -281,6 +278,11 @@ class Molecule(object):
             return 'openstack'
 
     def _get_driver(self):
+        """
+        Return an instance of the driver as returned by `_get_driver_name()`.
+
+        .. todo:: Implement a pluggable solution vs inline imports.
+        """
         driver = self._get_driver_name()
 
         if (self.state.driver is not None) and (self.state.driver != driver):
@@ -290,10 +292,13 @@ class Molecule(object):
             util.sysexit()
 
         if driver == 'vagrant':
+            from molecule.driver import vagrantdriver
             return vagrantdriver.VagrantDriver(self)
         elif driver == 'docker':
+            from molecule.driver import dockerdriver
             return dockerdriver.DockerDriver(self)
         elif driver == 'openstack':
+            from molecule.driver import openstackdriver
             return openstackdriver.OpenstackDriver(self)
         raise basedriver.InvalidDriverSpecified()
 

--- a/molecule/driver/dockerdriver.py
+++ b/molecule/driver/dockerdriver.py
@@ -21,11 +21,12 @@
 import collections
 import io
 import json
+import sys
 
 try:
     import docker
 except ImportError:
-    LOG.error('Driver missing, install docker-py!')
+    sys.exit('ERROR: Driver missing, install docker-py!')
 
 from molecule import util
 from molecule.driver import basedriver

--- a/molecule/driver/dockerdriver.py
+++ b/molecule/driver/dockerdriver.py
@@ -22,7 +22,10 @@ import collections
 import io
 import json
 
-import docker
+try:
+    import docker
+except ImportError:
+    LOG.error('Driver missing, install docker-py!')
 
 from molecule import util
 from molecule.driver import basedriver

--- a/molecule/driver/openstackdriver.py
+++ b/molecule/driver/openstackdriver.py
@@ -22,6 +22,7 @@ import collections
 import os
 import random
 import socket
+import sys
 import tempfile
 import time
 
@@ -29,7 +30,7 @@ import paramiko
 try:
     import shade
 except ImportError:
-    LOG.error('Driver missing, install shade!')
+    sys.exit('ERROR: Driver missing, install shade!')
 
 from molecule import util
 from molecule.driver import basedriver

--- a/molecule/driver/openstackdriver.py
+++ b/molecule/driver/openstackdriver.py
@@ -26,7 +26,10 @@ import tempfile
 import time
 
 import paramiko
-import shade
+try:
+    import shade
+except ImportError:
+    LOG.error('Driver missing, install shade!')
 
 from molecule import util
 from molecule.driver import basedriver

--- a/molecule/driver/vagrantdriver.py
+++ b/molecule/driver/vagrantdriver.py
@@ -22,7 +22,10 @@ import collections
 import copy
 import os
 
-import vagrant
+try:
+    import vagrant
+except ImportError:
+    LOG.error('Driver missing, install python-vagrant!')
 
 from molecule import util
 from molecule.driver import basedriver

--- a/molecule/driver/vagrantdriver.py
+++ b/molecule/driver/vagrantdriver.py
@@ -21,11 +21,12 @@
 import collections
 import copy
 import os
+import sys
 
 try:
     import vagrant
 except ImportError:
-    LOG.error('Driver missing, install python-vagrant!')
+    sys.exit('ERROR: Driver missing, install python-vagrant!')
 
 from molecule import util
 from molecule.driver import basedriver

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,15 +2,12 @@ ansible-lint==3.2.5
 anyconfig==0.6.0
 colorama==0.3.7
 cookiecutter==1.4.0
-docker-py==1.9.0
 flake8==3.0.4
 Jinja2==2.8
 paramiko==2.0.2
 pbr==1.10.0
 pexpect==4.2.1
-python-vagrant==0.5.14
 PyYAML==3.12
 sh==1.11
 tabulate==0.7.5
 testinfra==1.4.2
-shade==1.11.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,9 @@
+docker-py==1.9.0
 mock
 pytest
 pytest-cov
 pytest-helpers-namespace
 pytest-mock
+python-vagrant==0.5.14
+shade==1.11.1
 wheel


### PR DESCRIPTION
Now must install the appropriate python package based on the
driver used.  Opted not to add try catch around the imports,
since this is called out in the docs, and fairly obvious.
The requirements are also pinned in test-requirements so we
can test against a specific known version.

Fixes: #289