### PR TITLE
Handle container stopped in status

### DIFF
--- a/molecule/config.py
+++ b/molecule/config.py
@@ -142,7 +142,7 @@ class Config(object):
                         'box': 'trusty64',
                         'box_url':
                         ('https://vagrantcloud.com/ubuntu/boxes/trusty64/'
-                            'versions/14.04/providers/virtualbox.box'),
+                         'versions/14.04/providers/virtualbox.box'),
                         'box_version': '0.1.0',
                         'name': 'trusty64'
                     },

--- a/molecule/driver/dockerdriver.py
+++ b/molecule/driver/dockerdriver.py
@@ -180,21 +180,19 @@ class DockerDriver(basedriver.BaseDriver):
         status_list = []
         for container in self.instances:
             name = container.get('name')
-            if container.get('created'):
-                cd = self._docker.containers(filters={'name': name})[0]
-                status_list.append(
-                    Status(
-                        name=name,
-                        state=cd.get('Status'),
-                        provider=self.provider,
-                        ports=cd.get('Ports')))
-            else:
-                status_list.append(
-                    Status(
-                        name=name,
-                        state="not_created",
-                        provider=self.provider,
-                        ports=[]))
+            try:
+                d = self._docker.containers(filters={'name': name})[0]
+                state = d.get('Status')
+                ports = d.get('Ports')
+            except IndexError:
+                state = 'not_created'
+                ports = []
+            status_list.append(
+                Status(
+                    name=name,
+                    state=state,
+                    provider=self.provider,
+                    ports=ports))
 
         return status_list
 

--- a/test/unit/driver/test_dockerdriver.py
+++ b/test/unit/driver/test_dockerdriver.py
@@ -141,6 +141,14 @@ def test_status(docker_instance):
     assert 'docker' in docker_instance.status()[1].provider
 
 
+def test_status_dirty_shutdown(docker_instance):
+    docker_instance.up()
+    docker_instance._docker.stop('test1', timeout=0)
+
+    assert 'not_created' in docker_instance.status()[0].state
+    assert 'Up' in docker_instance.status()[1].state
+
+
 def test_port_bindings(docker_instance):
     docker_instance.up()
     ports = sorted(


### PR DESCRIPTION
If a container wast stopped outside molecule, `status` raised
an IndexError.

Fixes: #466