### PR TITLE
Corrected vagrant driver's multi-platform status

### DIFF
--- a/molecule/driver/vagrantdriver.py
+++ b/molecule/driver/vagrantdriver.py
@@ -194,27 +194,27 @@ class VagrantDriver(basedriver.BaseDriver):
         ]
 
     def _populate_platform_instances(self):
-        if self.molecule.args.get('platform'):
-            if ((self.molecule.config.config['vagrant']['platforms'] > 1) and
-                (self.molecule.args['platform'] == 'all') and
-                    not self._updated_multiplatform):
-                new_instances = []
+        if ((self.molecule.config.config['vagrant']['platforms'] > 1) and
+            (self.molecule.args.get('platform') == 'all' or
+             self.molecule.state.default_platform == 'all') and
+                not self._updated_multiplatform):
 
-                for instance in self.molecule.config.config['vagrant'][
-                        'instances']:
-                    for platform in self.molecule.config.config['vagrant'][
-                            'platforms']:
-                        platform_instance = copy.deepcopy(instance)
-                        platform_instance['platform'] = platform['box']
-                        platform_instance['name'] = instance[
-                            'name'] + '-' + platform['name']
-                        platform_instance['vm_name'] = instance[
-                            'name'] + '-' + platform['name']
-                        new_instances.append(platform_instance)
+            new_instances = []
+            for instance in self.molecule.config.config['vagrant'][
+                    'instances']:
+                for platform in self.molecule.config.config['vagrant'][
+                        'platforms']:
+                    platform_instance = copy.deepcopy(instance)
+                    platform_instance['platform'] = platform['box']
+                    combined_name = '{}-{}'.format(platform_instance['name'],
+                                                   platform['name'])
+                    platform_instance['name'] = combined_name
+                    platform_instance['vm_name'] = combined_name
+                    new_instances.append(platform_instance)
 
-                self.molecule.config.config['vagrant'][
-                    'instances'] = new_instances
-                self._updated_multiplatform = True
+            self.molecule.config.config['vagrant'][
+                'instances'] = new_instances
+            self._updated_multiplatform = True
 
     def _get_provider(self):
         if self.molecule.args.get('provider'):

--- a/test/unit/command/test_list.py
+++ b/test/unit/command/test_list.py
@@ -27,7 +27,8 @@ def test_execute(capsys, patched_main, molecule_instance):
 
     out, _ = capsys.readouterr()
 
-    assert 'ubuntu  (default)' in out
+    assert 'ubuntu   (default)' in out
+    assert 'centos7' in out
     assert (None, None) == result
 
 
@@ -39,5 +40,6 @@ def test_execute_with_porcelain(capsys, patched_main, molecule_instance):
 
     out, _ = capsys.readouterr()
 
-    assert 'ubuntu  d' in out
+    assert 'ubuntu   d' in out
+    assert 'centos7' in out
     assert (None, None) == result

--- a/test/unit/command/test_status.py
+++ b/test/unit/command/test_status.py
@@ -28,9 +28,11 @@ def test_execute(capsys, patched_main, molecule_instance):
     result = s.execute()
 
     out, _ = capsys.readouterr()
+    decoded_out = out.encode('ascii', 'ignore').decode('ascii')
 
-    assert 'ubuntu  (default)' in out
-    assert 'virtualbox  (default)' in out
+    assert 'ubuntu   (default)' in decoded_out
+    assert 'centos7' in decoded_out
+    assert 'virtualbox  (default)' in decoded_out
     (None, None) == result
 
 
@@ -42,7 +44,8 @@ def test_execute_with_porcelain(capsys, patched_main, molecule_instance):
 
     out, _ = capsys.readouterr()
 
-    assert 'ubuntu  d' in out
+    assert 'ubuntu   d' in out
+    assert 'centos7' in out
     assert 'virtualbox  d' in out
     (None, None) == result
 

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -152,7 +152,8 @@ def vagrant_section_data():
         'vagrant': {
             'platforms': [
                 {'name': 'ubuntu',
-                 'box': 'ubuntu/trusty64'}
+                 'box': 'ubuntu/trusty64'}, {'name': 'centos7',
+                                             'box': 'centos/7'}
             ],
             'providers': [
                 {'name': 'virtualbox',
@@ -160,6 +161,9 @@ def vagrant_section_data():
             ],
             'instances': [
                 {'name': 'aio-01',
+                 'ansible_groups': ['example', 'example1'],
+                 'options': {'append_platform_to_hostname': True}},
+                {'name': 'aio-02',
                  'ansible_groups': ['example', 'example1'],
                  'options': {'append_platform_to_hostname': True}}
             ]

--- a/test/unit/core/test_core_vagrant.py
+++ b/test/unit/core/test_core_vagrant.py
@@ -63,14 +63,16 @@ def test_print_valid_platforms(capsys, molecule_instance):
     molecule_instance.print_valid_platforms()
     out, _ = capsys.readouterr()
 
-    assert 'ubuntu  (default)\n' == out
+    assert 'ubuntu   (default)' in out
+    assert 'centos7' in out
 
 
 def test_print_valid_platforms_with_porcelain(capsys, molecule_instance):
     molecule_instance.print_valid_platforms(porcelain=True)
     out, _ = capsys.readouterr()
 
-    assert 'ubuntu  d\n' == out
+    assert 'ubuntu   d' in out
+    assert 'centos7' in out
 
 
 def test_print_valid_providers(capsys, molecule_instance):
@@ -88,6 +90,7 @@ def test_print_valid_providers_with_porcelain(capsys, molecule_instance):
 
 
 def test_instances_state(molecule_instance):
-    expected = {'aio-01-ubuntu': {'groups': ['example', 'example1']}}
+    expected = {'aio-01-ubuntu': {'groups': ['example', 'example1']},
+                'aio-02-ubuntu': {'groups': ['example', 'example1']}}
 
     assert expected == molecule_instance._instances_state()

--- a/test/unit/driver/test_vagrantdriver.py
+++ b/test/unit/driver/test_vagrantdriver.py
@@ -80,7 +80,9 @@ def test_valid_providers(vagrant_instance):
 
 
 def test_valid_platforms(vagrant_instance):
-    expected = [{'box': 'ubuntu/trusty64', 'name': 'ubuntu'}]
+    expected = [{'box': 'ubuntu/trusty64',
+                 'name': 'ubuntu'}, {'box': 'centos/7',
+                                     'name': 'centos7'}]
 
     assert expected == vagrant_instance.valid_platforms
 
@@ -98,3 +100,23 @@ def test_ansible_connection_params(vagrant_instance):
 
 def test_serverspec_args(vagrant_instance):
     assert {} == vagrant_instance.serverspec_args
+
+
+def test_status(vagrant_instance):
+    assert 'aio-01' == vagrant_instance.status()[0].name
+    assert 'aio-02' == vagrant_instance.status()[1].name
+
+    assert 'not_created' in vagrant_instance.status()[0].state
+    assert 'not_created' in vagrant_instance.status()[1].state
+
+    assert 'virtualbox' in vagrant_instance.status()[0].provider
+    assert 'virtualbox' in vagrant_instance.status()[1].provider
+
+
+def test_status_multiplatform(vagrant_instance):
+    vagrant_instance.molecule.state.change_state('default_platform', 'all')
+
+    assert 'aio-01-ubuntu' == vagrant_instance.status()[0].name
+    assert 'aio-01-centos7' == vagrant_instance.status()[1].name
+    assert 'aio-02-ubuntu' == vagrant_instance.status()[2].name
+    assert 'aio-02-centos7' == vagrant_instance.status()[3].name


### PR DESCRIPTION
When molecule is passed `--platform=all`, `status` now displays the
$instance_name-$platform_name in result.

Fixes: #492