### PR TITLE
Corrected linked clone options checking

### DIFF
--- a/molecule/template/vagrantfile.j2
+++ b/molecule/template/vagrantfile.j2
@@ -36,7 +36,7 @@ Vagrant.configure('2') do |config|
       {%- if not provider.options.cpus %}
     vb.cpus = 2
       {%- endif %}
-      {%- if provider.options.linked_clone == none %}
+      {%- if provider.options.linked_clone is not defined %}
     vb.linked_clone = true if Vagrant::VERSION =~ /^1.8/
       {%- endif %}
     {%- else %}


### PR DESCRIPTION
If the provider had options specified, the conditional would no longer
match, and the linked cloning would disappear.