### PR TITLE
Set ssh key if specified.

### DIFF
--- a/molecule/driver/openstackdriver.py
+++ b/molecule/driver/openstackdriver.py
@@ -208,8 +208,7 @@ class OpenstackDriver(basedriver.BaseDriver):
                             self._generated_ssh_key_location())
                 else:
                     ssh_line = 'ansible_ssh_private_key_file={}'.format(
-                        self._get_keyfile()
-                    )
+                        self._get_keyfile())
                     server_config['ssh_key_filename'] = ssh_line
                 return template.format(**server_config)
         return ''

--- a/molecule/driver/openstackdriver.py
+++ b/molecule/driver/openstackdriver.py
@@ -206,6 +206,11 @@ class OpenstackDriver(basedriver.BaseDriver):
                         'ssh_key_filename'] = \
                         'ansible_ssh_private_key_file={}'.format(
                             self._generated_ssh_key_location())
+                else:
+                    ssh_line = 'ansible_ssh_private_key_file={}'.format(
+                        self._get_keyfile()
+                    )
+                    server_config['ssh_key_filename'] = ssh_line
                 return template.format(**server_config)
         return ''
 


### PR DESCRIPTION
SSH wasn’t working for non-auto-generated keys.