### PR TITLE
Cleaned up call_args tests

### DIFF
--- a/molecule/driver/openstackdriver.py
+++ b/molecule/driver/openstackdriver.py
@@ -94,7 +94,7 @@ class OpenstackDriver(basedriver.BaseDriver):
     @property
     def testinfra_args(self):
         return {
-            'ansible-inventory':
+            'ansible_inventory':
             self.molecule.config.config['ansible']['inventory_file'],
             'connection': 'ansible'
         }

--- a/molecule/driver/vagrantdriver.py
+++ b/molecule/driver/vagrantdriver.py
@@ -125,7 +125,7 @@ class VagrantDriver(basedriver.BaseDriver):
     @property
     def testinfra_args(self):
         return {
-            'ansible-inventory':
+            'ansible_inventory':
             self.molecule.config.config['ansible']['inventory_file'],
             'connection': 'ansible'
         }

--- a/molecule/verifier/serverspec.py
+++ b/molecule/verifier/serverspec.py
@@ -54,7 +54,6 @@ class Serverspec(base.Base):
     def _rake(self,
               rakefile,
               debug=False,
-              env=os.environ.copy(),
               out=LOG.info,
               err=LOG.error):
         """
@@ -63,16 +62,13 @@ class Serverspec(base.Base):
 
         :param rakefile: A string containing path to the rakefile.
         :param debug: An optional bool to toggle debug output.
-        :param env: An optional environment to pass to underlying :func:`sh`
-         call.
         :param out: An optional function to process STDOUT for underlying
          :func:`sh` call.
         :param err: An optional function to process STDERR for underlying
          :func:`sh` call.
         :return: :func:`sh` response object.
         """
-        kwargs = {'_env': env,
-                  '_out': out,
+        kwargs = {'_out': out,
                   '_err': err,
                   'trace': debug,
                   'rakefile': rakefile}
@@ -86,7 +82,6 @@ class Serverspec(base.Base):
     def _rubocop(self,
                  serverspec_dir,
                  debug=False,
-                 env=os.environ.copy(),
                  pattern='/**/*.rb',
                  out=LOG.info,
                  err=LOG.error):
@@ -98,15 +93,13 @@ class Serverspec(base.Base):
         to lint.
         :param debug: An optional bool to toggle debug output.
         :param pattern: A string containing the pattern of files to lint.
-        :param env: An optional environment to pass to underlying :func:`sh`
-         call.
         :param out: An optional function to process STDOUT for underlying
          :func:`sh` call.
         :param err: An optional function to process STDERR for underlying
          :func:`sh` call.
         :return: :func:`sh` response object.
         """
-        kwargs = {'_env': env, '_out': out, '_err': err, 'debug': debug}
+        kwargs = {'_out': out, '_err': err, 'debug': debug}
 
         msg = 'Executing rubocop on *.rb files found in {}/.'.format(
             serverspec_dir)

--- a/molecule/verifier/testinfra.py
+++ b/molecule/verifier/testinfra.py
@@ -53,7 +53,8 @@ class Testinfra(base.Base):
         testinfra_options = config.merge_dicts(
             self._molecule.driver.testinfra_args,
             self._molecule.verifier_options)
-        testinfra_options['env'] = ansible.env
+
+        testinfra_options['ansible_env'] = ansible.env
         if self._molecule.args.get('debug'):
             testinfra_options['debug'] = True
         if self._molecule.args.get('sudo'):
@@ -67,7 +68,7 @@ class Testinfra(base.Base):
     def _testinfra(self,
                    tests,
                    debug=False,
-                   env=os.environ.copy(),
+                   ansible_env={},
                    out=LOG.info,
                    err=LOG.error,
                    **kwargs):
@@ -78,8 +79,8 @@ class Testinfra(base.Base):
         :param tests: A list of testinfra tests.
         :param debug: An optional bool to toggle debug output.
         :param pattern: A string containing the pattern of files to lint.
-        :param env: An optional environment to pass to underlying :func:`sh`
-         call.
+        :param ansible_env: An optional environment to pass to underlying
+         :func:`sh` call.
         :param out: An optional function to process STDOUT for underlying
          :func:`sh` call.
         :param err: An optional function to process STDERR for underlying
@@ -87,7 +88,7 @@ class Testinfra(base.Base):
         :return: :func:`sh` response object.
         """
         kwargs['debug'] = debug
-        kwargs['_env'] = env
+        kwargs['_env'] = ansible_env
         kwargs['_out'] = out
         kwargs['_err'] = err
 

--- a/test/unit/verifier/test_serverspec.py
+++ b/test/unit/verifier/test_serverspec.py
@@ -65,26 +65,20 @@ def test_execute_no_tests(patched_code_verifier, patched_test_verifier,
 
 def test_rake(mocker, serverspec_instance):
     patched_rake = mocker.patch('sh.rake')
-    kwargs = {'debug': True, 'out': None, 'err': '/dev/null'}
+    kwargs = {'debug': True, 'out': None, 'err': None}
     serverspec_instance._rake('/tmp/rakefile', **kwargs)
 
-    ca = patched_rake.call_args[1]
-    assert '/tmp/rakefile' == ca.get('rakefile')
-    assert ca.get('trace')
+    patched_rake.assert_called_once_with(
+        _err=None, _out=None, rakefile='/tmp/rakefile', trace=True)
 
 
 def test_rubocop(mocker, serverspec_instance):
     patched_rubocop = mocker.patch('sh.rubocop')
-    kwargs = {'pattern': '**/**/**/*',
-              'debug': True,
-              'out': '/dev/null',
-              'err': None}
+    kwargs = {'pattern': '**/**/**/*', 'debug': True, 'out': None, 'err': None}
     serverspec_instance._rubocop('spec', **kwargs)
 
-    assert ('spec**/**/**/*', ) == patched_rubocop.call_args[0]
-
-    ca = patched_rubocop.call_args[1]
-    assert ca.get('debug')
+    patched_rubocop.assert_called_once_with(
+        'spec**/**/**/*', _err=None, _out=None, debug=True)
 
 
 def test_get_tests(serverspec_instance):


### PR DESCRIPTION
The tests which used call_args were pretty gross.  We were also
needlessly passing the shell env to sh.  This made testing difficult
as well.