### PR TITLE
Display the list of non idempotence tasks

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,2 +1,3 @@
 [style]
 based_on_style = pep8
+column_limit = 79

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,8 @@ deps =
     ansible20: ansible==2.0.2.0
     ansible21: ansible==2.1.1.0
 commands =
-    unit: py.test --cov={toxinidir}/molecule/ test/unit/ {posargs}
-    functional: py.test test/functional/ {posargs}
+    unit: py.test -x --cov={toxinidir}/molecule/ test/unit/ {posargs}
+    functional: py.test -x test/functional/ {posargs}
 
 [flake8]
 exclude = .venv/,.tox/,dist/,build/,doc/,.eggs/,molecule/verifier/ansible/


### PR DESCRIPTION
When running the `molecule idempotence` command, the output does not
show any information regarding the non idempotence tasks found if any.

This patch gives the ability to the command to log the list of guilty
task, and prevents the user to have to perform manual verifications to
fix the problem.

Fixes: #527