### PR TITLE
Removed customconf from state file

### DIFF
--- a/molecule/cookiecutter/molecule/{{cookiecutter.repo_name}}/ansible.cfg
+++ b/molecule/cookiecutter/molecule/{{cookiecutter.repo_name}}/ansible.cfg
@@ -1,3 +1,5 @@
+# Molecule managed
+
 [defaults]
 
 roles_path      = {{ cookiecutter.ansiblecfg_molecule_dir }}/roles:{{ cookiecutter.ansiblecfg_molecule_dir }}/../roles:../:../../

--- a/molecule/cookiecutter/molecule/{{cookiecutter.repo_name}}/rakefile
+++ b/molecule/cookiecutter/molecule/{{cookiecutter.repo_name}}/rakefile
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # Molecule managed
 
 require 'rake'

--- a/molecule/cookiecutter/molecule/{{cookiecutter.repo_name}}/rakefile
+++ b/molecule/cookiecutter/molecule/{{cookiecutter.repo_name}}/rakefile
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# Molecule managed
 
 require 'rake'
 require 'rspec/core/rake_task'

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -164,9 +164,13 @@ class Molecule(object):
         """
         if os.path.exists(self.config.config['molecule']['rakefile_file']):
             os.remove(self.config.config['molecule']['rakefile_file'])
-        if not self.state.customconf:
-            if os.path.exists(self.config.config['ansible']['config_file']):
-                os.remove(self.config.config['ansible']['config_file'])
+
+        config = self.config.config['ansible']['config_file']
+        if os.path.exists(config):
+            with open(config, 'r') as stream:
+                data = stream.read().splitlines()
+                if '# Molecule managed' in data:
+                    os.remove(config)
 
     def create_templates(self):
         """
@@ -179,9 +183,6 @@ class Molecule(object):
         extra_context = self._get_cookiecutter_context(molecule_dir)
         if not os.path.isfile(self.config.config['ansible']['config_file']):
             util.process_templates('molecule', extra_context, role_path)
-            self.state.change_state('customconf', False)
-        else:
-            self.state.change_state('customconf', True)
 
     def write_instances_state(self):
         self.state.change_state('hosts', self._instances_state())

--- a/molecule/state.py
+++ b/molecule/state.py
@@ -32,7 +32,6 @@ from molecule import util
 
 VALID_KEYS = ['converged',
               'created',
-              'customconf',
               'default_platform',
               'default_provider',
               'driver',
@@ -97,10 +96,6 @@ class State(object):
         return self._data.get('multiple_platforms')
 
     @property
-    def customconf(self):
-        return self._data.get('customconf')
-
-    @property
     def installed_deps(self):
         return self._data.get('installed_deps')
 
@@ -133,7 +128,6 @@ class State(object):
         return {
             "converged": None,
             "created": None,
-            "customconf": None,
             "default_platform": None,
             "default_provider": None,
             "driver": None,

--- a/test/unit/test_state.py
+++ b/test/unit/test_state.py
@@ -42,10 +42,6 @@ def test_created(state_instance_without_data):
     assert not state_instance_without_data.created
 
 
-def test_customconf(state_instance_without_data):
-    assert not state_instance_without_data.customconf
-
-
 def test_default_platform(state_instance_without_data):
     assert not state_instance_without_data.default_platform
 


### PR DESCRIPTION
The state file was used to determine if ansible.cfg was custom or
provided by the user.  However, the logic was flawed.  We execute
`destroy` which first executes `remove_templates`.  Unfortunately,
`remove_templates` relies on the state file having `customconf` set,
but the setting occurs in another method, which is called after
`destroy`.

We now look for a "Molecule managed" string, to know if safe to delete
or not.