### PR TITLE
Removed default multiple-instances from init

### DIFF
--- a/molecule/cookiecutter/driver/docker/cookiecutter.json
+++ b/molecule/cookiecutter/driver/docker/cookiecutter.json
@@ -1,7 +1,6 @@
 {
   "repo_name": "OVERRIDEN",
   "role_name": "OVERRIDEN",
-  "instances": 2,
   "verifier_name": "OVERRIDEN",
   "driver_name": "OVERRIDEN"
 }

--- a/molecule/cookiecutter/driver/docker/{{cookiecutter.repo_name}}/molecule.yml
+++ b/molecule/cookiecutter/driver/docker/{{cookiecutter.repo_name}}/molecule.yml
@@ -1,17 +1,12 @@
 ---
 driver:
   name: {{ cookiecutter.driver_name }}
-
 docker:
   containers:
-    {%- for n in range(cookiecutter.instances|int) %}
-
-      - name: {{ cookiecutter.role_name }}-{{ '%02d' % loop.index }}
-        image: ubuntu
-        image_version: latest
-        ansible_groups:
-          - group1
-    {%- endfor %}
-
+    - name: {{ cookiecutter.role_name }}
+      image: ubuntu
+      image_version: latest
+      ansible_groups:
+        - group1
 verifier:
   name: {{ cookiecutter.verifier_name }}

--- a/molecule/cookiecutter/driver/openstack/{{cookiecutter.repo_name}}/molecule.yml
+++ b/molecule/cookiecutter/driver/openstack/{{cookiecutter.repo_name}}/molecule.yml
@@ -1,7 +1,6 @@
 ---
 driver:
   name: {{ cookiecutter.driver_name }}
-
 openstack:
   keyfile: ~/.ssh/id_rsa
   keypair: NameKey
@@ -12,6 +11,5 @@ openstack:
       sshuser: centos
       ansible_groups:
         - group1
-
 verifier:
   name: {{ cookiecutter.verifier_name }}

--- a/molecule/cookiecutter/driver/vagrant/cookiecutter.json
+++ b/molecule/cookiecutter/driver/vagrant/cookiecutter.json
@@ -1,7 +1,6 @@
 {
   "repo_name": "OVERRIDEN",
   "role_name": "OVERRIDEN",
-  "instances": 2,
   "platform_name": "OVERRIDEN",
   "platform_box": "OVERRIDEN",
   "platform_box_url": "OVERRIDEN",

--- a/molecule/cookiecutter/driver/vagrant/{{cookiecutter.repo_name}}/molecule.yml
+++ b/molecule/cookiecutter/driver/vagrant/{{cookiecutter.repo_name}}/molecule.yml
@@ -1,27 +1,20 @@
 ---
 driver:
   name: {{ cookiecutter.driver_name }}
-
 vagrant:
   platforms:
     - name: {{ cookiecutter.platform_name }}
       box: {{ cookiecutter.platform_box }}
       box_url: {{ cookiecutter.platform_box_url }}
-
   providers:
     - name: {{ cookiecutter.provider_name }}
       type: {{ cookiecutter.provider_type }}
       options:
         memory: {{ cookiecutter.provider_options_memory }}
         cpus: {{ cookiecutter.provider_options_cpu }}
-
   instances:
-    {%- for n in range(cookiecutter.instances|int) %}
-
-      - name: {{ cookiecutter.role_name }}-{{ '%02d' % loop.index }}
-        ansible_groups:
-          - group1
-    {%- endfor %}
-
+    - name: {{ cookiecutter.role_name }}
+      ansible_groups:
+        - group1
 verifier:
   name: {{ cookiecutter.verifier_name }}


### PR DESCRIPTION
Init does not need to initialize multiple instances.  This is
well documented.  Also, removed the extra spacing in the config.