### PR TITLE
Write templates even when a custom ansible.cfg is specified

### DIFF
--- a/molecule/core.py
+++ b/molecule/core.py
@@ -181,8 +181,7 @@ class Molecule(object):
         molecule_dir = self.config.config['molecule']['molecule_dir']
         role_path = os.getcwd()
         extra_context = self._get_cookiecutter_context(molecule_dir)
-        if not os.path.isfile(self.config.config['ansible']['config_file']):
-            util.process_templates('molecule', extra_context, role_path)
+        util.process_templates('molecule', extra_context, role_path)
 
     def write_instances_state(self):
         self.state.change_state('hosts', self._instances_state())


### PR DESCRIPTION
This guard was removed because it isn't needed, and was preventing all templates from being written when specifying a custom ansible.cfg file. This change will cause molecule to create .molecule/ansible.cfg to be created even a user specifies their own, but it won't be used. The path to ansible.cfg specified in molecule.yml will get priority.