### PR TITLE
Allow group/host vars to work with ansible 1.9

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,4 +4,4 @@ omit =
 
 [report]
 fail_under =
-  80
+  79

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -22,6 +22,7 @@ import os
 import os.path
 
 import anyconfig
+import m9dicts
 
 from molecule import util
 
@@ -85,7 +86,7 @@ class Config(object):
             anyconfig.load(
                 configs, ignore_missing=True, ac_merge=MERGE_STRATEGY))
 
-        return conf
+        return m9dicts.convert_to(conf)
 
     def _build_config_paths(self):
         """

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -337,11 +337,14 @@ class Molecule(object):
 
         for target in vars_target.keys():
             target_var_content = vars_target[target][0]
+            path = os.path.join(os.path.abspath(target_vars_path), target)
 
             util.write_file(
-                os.path.join(os.path.abspath(target_vars_path), target),
-                "---\n" + yaml.dump(
-                    target_var_content, default_flow_style=False))
+                path,
+                yaml.dump(
+                    target_var_content,
+                    default_flow_style=False,
+                    explicit_start=True))
 
     def _instances_state(self):
         """

--- a/test/functional/test_vagrant_scenarios.py
+++ b/test/functional/test_vagrant_scenarios.py
@@ -61,3 +61,9 @@ def test_command_test_platform_centos(scenario_setup):
     'scenario_setup', ['command_test'], indirect=['scenario_setup'])
 def test_command_test_platform_all(scenario_setup):
     sh.molecule('test', '--driver', 'vagrant', '--platform', 'all')
+
+
+@pytest.mark.parametrize(
+    'scenario_setup', ['group_host_vars'], indirect=['scenario_setup'])
+def test_group_host_vars(scenario_setup):
+    sh.molecule('test', '--driver', 'vagrant')

--- a/test/scenarios/group_host_vars/molecule.yml
+++ b/test/scenarios/group_host_vars/molecule.yml
@@ -22,5 +22,21 @@ docker:
       image: ubuntu
       image_version: latest
 
+vagrant:
+  platforms:
+    - name: ubuntu
+      box: ubuntu/trusty64
+
+  providers:
+    - name: virtualbox
+      type: virtualbox
+
+  instances:
+    - name: group-vars-scenario
+      ansible_groups:
+        - example
+        - example2:children:
+          - example
+
 verifier:
   name: testinfra


### PR DESCRIPTION
Ansible 1.9 cannot parse the yaml serialized by anyconfig, when
using the host/group vars functionality.  Created a functional test
to cover this scenario.