### PR TITLE
Clearer error message for failed multi host login

### DIFF
--- a/molecule/command/login.py
+++ b/molecule/command/login.py
@@ -63,8 +63,8 @@ class Login(base.Base):
 
                 # But too many hosts is trouble as well.
                 else:
-                    message = ('There are {} running hosts. You can only '
-                               'login to one at a time.\n\n'
+                    message = ('There are {} running hosts. Please specify '
+                               'which with --host .\n\n'
                                'Available hosts:\n{}'.format(
                                    len(hosts), '\n'.join(sorted(hosts))))
                     raise base.InvalidHost(message)

--- a/test/unit/command/test_login.py
+++ b/test/unit/command/test_login.py
@@ -39,8 +39,7 @@ def test_execute_raises_when_no_host_privided_but_multiple_instances_exist(
     l = login.Login({}, {}, molecule_instance)
     with pytest.raises(SystemExit):
         l.execute()
-
-    msg = ('There are 2 running hosts. You can only login to one at a time.\n'
+    msg = ('There are 2 running hosts. Please specify which with --host .\n'
            '\nAvailable hosts:\nbaz\nfoo')
     patched_logger_error.assert_called_once_with(msg)
 

--- a/test/unit/command/test_login.py
+++ b/test/unit/command/test_login.py
@@ -39,6 +39,7 @@ def test_execute_raises_when_no_host_privided_but_multiple_instances_exist(
     l = login.Login({}, {}, molecule_instance)
     with pytest.raises(SystemExit):
         l.execute()
+
     msg = ('There are 2 running hosts. Please specify which with --host .\n'
            '\nAvailable hosts:\nbaz\nfoo')
     patched_logger_error.assert_called_once_with(msg)


### PR DESCRIPTION
the --host flag for login was undocumented.  Added a helper message.