### PR TITLE
Pass HOME to ansible-lint environment

### DIFF
--- a/molecule/verifier/ansible_lint.py
+++ b/molecule/verifier/ansible_lint.py
@@ -18,6 +18,8 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 
+import os
+
 import sh
 
 from molecule import util
@@ -36,8 +38,6 @@ class AnsibleLint(base.Base):
     def __init__(self, molecule):
         super(AnsibleLint, self).__init__(molecule)
         self._playbook = molecule.config.config['ansible']['playbook']
-        self._env = {'ANSIBLE_CONFIG':
-                     molecule.config.config['ansible']['config_file']}
 
     def execute(self):
         """
@@ -46,8 +46,12 @@ class AnsibleLint(base.Base):
 
         :return: None
         """
+        env = {'ANSIBLE_CONFIG':
+               self._molecule.config.config['ansible']['config_file'],
+               'HOME': os.environ.get('HOME')}
+
         if 'ansible_lint' not in self._molecule.disabled:
             msg = 'Executing ansible-lint.'
             util.print_info(msg)
             sh.ansible_lint(
-                self._playbook, _env=self._env, _out=LOG.info, _err=LOG.error)
+                self._playbook, _env=env, _out=LOG.info, _err=LOG.error)

--- a/test/unit/verifier/test_ansible_lint.py
+++ b/test/unit/verifier/test_ansible_lint.py
@@ -28,7 +28,8 @@ def ansible_lint_instance(molecule_instance):
     return ansible_lint.AnsibleLint(molecule_instance)
 
 
-def test_execute(mocker, ansible_lint_instance):
+def test_execute(monkeypatch, mocker, ansible_lint_instance):
+    monkeypatch.setenv('HOME', '/foo/bar')
     patched_ansible_lint = mocker.patch('sh.ansible_lint')
     ansible_lint_instance.execute()
 
@@ -37,6 +38,7 @@ def test_execute(mocker, ansible_lint_instance):
 
     patched_ansible_lint.assert_called_once_with(
         ansible_lint_instance._playbook,
-        _env={'ANSIBLE_CONFIG': 'test/config_file'},
+        _env={'ANSIBLE_CONFIG': 'test/config_file',
+              'HOME': '/foo/bar'},
         _out=ansible_lint.LOG.info,
         _err=ansible_lint.LOG.error)


### PR DESCRIPTION
Pass HOME to ansible-lint since ansible wishes to create a temporary
directory in the user's home dir.

Fixes: #547