### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -93,5 +93,5 @@ From the root for the project, run:
   $ tox -e syntax
 
 .. _`YAPF`: https://github.com/google/yapf
-.. _`Tox`: https://tox.readthedocs.org/en/latest
+.. _`Tox`: https://tox.readthedocs.io/en/latest
 .. _`Issue`: https://github.com/metacloud/molecule/issues

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Molecule
    :alt: PyPI Package
 
 .. image:: https://readthedocs.org/projects/molecule/badge/?version=latest
-   :target: https://molecule.readthedocs.org/en/latest/
+   :target: https://molecule.readthedocs.io/en/latest/
    :alt: Documentation Status
 
 Molecule is designed to aid in the development and testing of
@@ -68,7 +68,7 @@ Provider
 .. _`OpenStack`: https://www.openstack.org
 .. _`Parallels`: http://www.parallels.com
 .. _`Serverspec`: http://serverspec.org
-.. _`Testinfra`: http://testinfra.readthedocs.org
+.. _`Testinfra`: https://testinfra.readthedocs.io
 .. _`Vagrant`: http://docs.vagrantup.com/v2
 .. _`VirtualBox`: https://www.virtualbox.org
 .. _`VMware Fusion`: http://www.vmware.com/products/fusion.html
@@ -159,7 +159,7 @@ Update the role with needed functionality and tests.  Now test it:
 Documentation
 =============
 
-http://molecule.readthedocs.org/en/latest/
+https://molecule.readthedocs.io/en/latest/
 
 License
 =======

--- a/doc/source/development.rst
+++ b/doc/source/development.rst
@@ -75,5 +75,5 @@ Roadmap
 .. _`PyPI`: https://pypi.python.org/pypi/molecule
 .. _`ISSUES`: https://github.com/metacloud/molecule/issues
 .. _`CHANGELOG`: https://github.com/metacloud/molecule/blob/master/CHANGELOG.rst
-.. _`install from source`: http://molecule.readthedocs.org/en/latest/usage.html#installing-from-source
+.. _`install from source`: https://molecule.readthedocs.io/en/latest/usage.html#installing-from-source
 .. _`twine`: https://pypi.python.org/pypi/twine

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -23,7 +23,7 @@ Contents:
 .. _`playbook`: https://docs.ansible.com/ansible/playbooks.html
 .. _`role`: http://docs.ansible.com/ansible/playbooks_roles.html
 .. _`Serverspec`: http://serverspec.org
-.. _`Testinfra`: http://testinfra.readthedocs.org
+.. _`Testinfra`: https://testinfra.readthedocs.io
 .. _`Vagrant`: http://docs.vagrantup.com/v2
 .. _`Docker`: https://www.docker.com
 .. _`OpenStack`: https://www.openstack.org

--- a/doc/source/verifier.rst
+++ b/doc/source/verifier.rst
@@ -36,7 +36,7 @@ using `testinfra's command line arguments`_.
 Note: Testinfra is based on pytest, so additional `pytest arguments`_ can be
 passed through it.
 
-.. _`testinfra's command line arguments`: http://testinfra.readthedocs.io/en/latest/invocation.html
+.. _`testinfra's command line arguments`: https://testinfra.readthedocs.io/en/latest/invocation.html
 .. _`PyTest arguments`: http://pytest.org/latest/usage.html#usage
 
 Project Structure
@@ -49,7 +49,7 @@ Project Structure
     └── tests/
         └── test_*.py
 
-.. _`Testinfra`: http://testinfra.readthedocs.org
+.. _`Testinfra`: https://testinfra.readthedocs.io
 .. _`Flake8`: http://flake8.pycqa.org/en/latest/
 
 Serverspec


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.