### PR TITLE
Disable diff when executing idempotent check

### DIFF
--- a/molecule/command/converge.py
+++ b/molecule/command/converge.py
@@ -89,6 +89,8 @@ class Converge(base.Base):
             # Don't log stdout/err
             ansible.remove_cli_arg('_out')
             ansible.remove_cli_arg('_err')
+            # Idempotence task regexp cannot handle diff
+            ansible.remove_cli_arg('diff')
             # Disable color for regexp
             ansible.add_env_arg('ANSIBLE_NOCOLOR', 'true')
             ansible.add_env_arg('ANSIBLE_FORCE_COLOR', 'false')

--- a/test/unit/command/test_converge.py
+++ b/test/unit/command/test_converge.py
@@ -156,7 +156,7 @@ def test_execute_adds_idempotency_flags(
     c = converge.Converge({}, {}, molecule_instance)
     c.execute(idempotent=True)
 
-    expected = [mocker.call('_out'), mocker.call('_err')]
+    expected = [mocker.call('_out'), mocker.call('_err'), mocker.call('diff')]
     assert expected == patched_remove_cli_arg.mock_calls
 
     assert mocker.call('ANSIBLE_NOCOLOR',

--- a/test/unit/command/test_idempotence.py
+++ b/test/unit/command/test_idempotence.py
@@ -18,8 +18,6 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 
-import textwrap
-
 import pytest
 
 from molecule.command import idempotence
@@ -82,34 +80,32 @@ def test_execute_raises_on_idempotence_failure(
     assert patched_logger_error.mock_calls == expected_calls
 
 
-def test_non_idempotent_tasks_00(molecule_instance):
-    """Ensures an empty list is returned when the playbook is idempotent."""
-    output = textwrap.dedent("""\
-        PLAY [all] ***********************************************************
-        GATHERING FACTS ******************************************************
-        ok: [check-command-01]
-        TASK: [Idempotence test] *********************************************
-        ok: [check-command-01]
-        PLAY RECAP ***********************************************************
-        check-command-01: ok=3    changed=0    unreachable=0    failed=0
-        """)
+def test_non_idempotent_tasks_idempotent(molecule_instance):
+    output = """
+PLAY [all] ***********************************************************
+GATHERING FACTS ******************************************************
+ok: [check-command-01]
+TASK: [Idempotence test] *********************************************
+ok: [check-command-01]
+PLAY RECAP ***********************************************************
+check-command-01: ok=3    changed=0    unreachable=0    failed=0
+"""
     i = idempotence.Idempotence({}, {}, molecule_instance)
     ret = i._non_idempotent_tasks(output)
 
     assert ret == []
 
 
-def test_non_idempotent_tasks_01(molecule_instance):
-    """Ensures a non-idempotent task is detected."""
-    output = textwrap.dedent("""\
-        PLAY [all] ***********************************************************
-        GATHERING FACTS ******************************************************
-        ok: [check-command-01]
-        TASK: [Idempotence test] *********************************************
-        changed: [check-command-01]
-        PLAY RECAP ***********************************************************
-        check-command-01: ok=2    changed=1    unreachable=0    failed=0
-        """)
+def test_non_idempotent_tasks_not_idempotent(molecule_instance):
+    output = """
+PLAY [all] ***********************************************************
+GATHERING FACTS ******************************************************
+ok: [check-command-01]
+TASK: [Idempotence test] *********************************************
+changed: [check-command-01]
+PLAY RECAP ***********************************************************
+check-command-01: ok=2    changed=1    unreachable=0    failed=0
+"""
     i = idempotence.Idempotence({}, {}, molecule_instance)
     ret = i._non_idempotent_tasks(output)
 


### PR DESCRIPTION
When performing the idempotence check, the regexp fails when output
contains `--diff` output.  Run the reconverge without `--diff`.

Fixes: #554