### PR TITLE
Created a molecule2 command

### DIFF
--- a/molecule/cli2.py
+++ b/molecule/cli2.py
@@ -21,7 +21,6 @@
 import click
 
 import molecule
-from molecule import command
 
 
 @click.group()
@@ -39,17 +38,3 @@ def cli(ctx, debug):  # pragma: no cover
 def main():
     """ Molecule aids in the development, and testing of Ansible roles. """
     cli(obj={})
-
-
-cli.add_command(command.create.create)
-cli.add_command(command.check.check)
-cli.add_command(command.converge.converge)
-cli.add_command(command.destroy.destroy)
-cli.add_command(command.idempotence.idempotence)
-cli.add_command(command.init.init)
-cli.add_command(command.list.list)
-cli.add_command(command.login.login)
-cli.add_command(command.syntax.syntax)
-cli.add_command(command.test.test)
-cli.add_command(command.status.status)
-cli.add_command(command.verify.verify)

--- a/molecule/command/base.py
+++ b/molecule/command/base.py
@@ -58,7 +58,7 @@ class Base(object):
         options.update(command_args)
 
         if not molecule:
-            self.molecule = core.Molecule(self._config, options)
+            self.molecule = self._get_core(options)
             self.main()
         else:
             self.molecule = molecule
@@ -82,5 +82,7 @@ class Base(object):
         pass
 
     def _get_config(self):
-        if not self.args.get('v2'):
-            return config.ConfigV1()
+        return config.ConfigV1()
+
+    def _get_core(self, options):
+        return core.Molecule(self._config, options)

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ warnerrors = True
 [entry_points]
 console_scripts =
     molecule = molecule.cli:main
+    molecule2 = molecule.cli2:main
 
 [files]
 data_files =

--- a/test/unit/test_cli2.py
+++ b/test/unit/test_cli2.py
@@ -18,38 +18,11 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 
-import click
+import pytest
 
-import molecule
-from molecule import command
-
-
-@click.group()
-@click.option(
-    '--debug/--no-debug',
-    default=False,
-    help='Enable or disable debug mode. Default is disabled.')
-@click.version_option(version=molecule.__version__)
-@click.pass_context
-def cli(ctx, debug):  # pragma: no cover
-    ctx.obj['args'] = {}
-    ctx.obj['args']['debug'] = debug
+from molecule import cli2
 
 
-def main():
-    """ Molecule aids in the development, and testing of Ansible roles. """
-    cli(obj={})
-
-
-cli.add_command(command.create.create)
-cli.add_command(command.check.check)
-cli.add_command(command.converge.converge)
-cli.add_command(command.destroy.destroy)
-cli.add_command(command.idempotence.idempotence)
-cli.add_command(command.init.init)
-cli.add_command(command.list.list)
-cli.add_command(command.login.login)
-cli.add_command(command.syntax.syntax)
-cli.add_command(command.test.test)
-cli.add_command(command.status.status)
-cli.add_command(command.verify.verify)
+def test_cli2():
+    with pytest.raises(SystemExit):
+        cli2.main()


### PR DESCRIPTION
We will likely be dealing with subcommands differently in v2.
Due to clicks `add_command` usage, we cannot side load different
command usage based on a CLI flag (inception).  Instead we created
a `molecule2` command to experiment with.