### PR TITLE
Removed v2 command

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ warnerrors = True
 [entry_points]
 console_scripts =
     molecule = molecule.cli:main
-    molecule2 = molecule.cli2:main
 
 [files]
 data_files =


### PR DESCRIPTION
Will work on molecule v2 in a separate branch.  Should be able to
rebase against master without issue, now that we have a fairly
simple v1 interface defined.