### PR TITLE
Ability to pass arbitrary ansible cli flags

### DIFF
--- a/molecule/ansible_playbook.py
+++ b/molecule/ansible_playbook.py
@@ -30,6 +30,7 @@ class AnsiblePlaybook(object):
     def __init__(self,
                  args,
                  connection_params,
+                 raw_ansible_args=None,
                  _env=None,
                  _out=LOG.info,
                  _err=LOG.error):
@@ -51,6 +52,7 @@ class AnsiblePlaybook(object):
         self._ansible = None
         self._cli = {}
         self._cli_pos = []
+        self._raw_ansible_args = raw_ansible_args
         self.env = _env if _env else os.environ.copy()
 
         for k, v in args.iteritems():
@@ -76,6 +78,8 @@ class AnsiblePlaybook(object):
         """
         self._ansible = sh.ansible_playbook.bake(
             self._playbook, *self._cli_pos, _env=self.env, **self._cli)
+        if self._raw_ansible_args:
+            self._ansible = self._ansible.bake(self._raw_ansible_args)
 
     def parse_arg(self, name, value):
         """

--- a/molecule/command/converge.py
+++ b/molecule/command/converge.py
@@ -79,11 +79,8 @@ class Converge(base.Base):
 
         ansible = ansible_playbook.AnsiblePlaybook(
             self.molecule.config.config['ansible'],
-            self.molecule.driver.ansible_connection_params)
-
-        # Target tags passed in via CLI
-        if self.command_args.get('tags'):
-            ansible.add_cli_arg('tags', self.command_args.get('tags'))
+            self.molecule.driver.ansible_connection_params,
+            raw_ansible_args=self.command_args.get('ansible_args'))
 
         if idempotent:
             # Don't log stdout/err
@@ -132,18 +129,16 @@ class Converge(base.Base):
 @click.option('--driver', default=None, help='Specificy a driver.')
 @click.option('--platform', default=None, help='Specify a platform.')
 @click.option('--provider', default=None, help='Specify a provider.')
-@click.option(
-    '--tags',
-    default=None,
-    help='Comma separated group of ansible tags to target.')
+@click.argument('ansible_args', nargs=-1, type=click.UNPROCESSED)
 @click.pass_context
-def converge(ctx, driver, platform, provider, tags):  # pragma: no cover
+def converge(ctx, driver, platform, provider,
+             ansible_args):  # pragma: no cover
     """ Provisions all instances defined in molecule.yml. """
     command_args = {
         'driver': driver,
         'platform': platform,
         'provider': provider,
-        'tags': tags
+        'ansible_args': ansible_args
     }
 
     c = Converge(ctx.obj.get('args'), command_args)

--- a/test/unit/command/test_converge.py
+++ b/test/unit/command/test_converge.py
@@ -97,17 +97,6 @@ def test_execute_installs_dependencies(
     assert molecule_instance.state.installed_deps
 
 
-def test_execute_with_tags(mocker, patched_create, patched_ansible_playbook,
-                           patched_add_cli_arg, patched_create_inventory,
-                           molecule_instance):
-    command_args = {'tags': 'foo,bar'}
-
-    c = converge.Converge({}, command_args, molecule_instance)
-    c.execute()
-
-    patched_add_cli_arg.assert_called_with('tags', 'foo,bar')
-
-
 def test_execute_with_debug(patched_create, patched_ansible_playbook,
                             patched_create_inventory, patched_print_debug,
                             molecule_instance):

--- a/test/unit/test_ansible_playbook.py
+++ b/test/unit/test_ansible_playbook.py
@@ -19,6 +19,7 @@
 #  DEALINGS IN THE SOFTWARE.
 
 import pytest
+import re
 import sh
 
 from molecule import ansible_playbook
@@ -144,6 +145,13 @@ def test_bake(ansible_playbook_instance):
     ]
 
     assert expected == sorted(str(ansible_playbook_instance._ansible).split())
+
+
+def test_bake_with_raw_ansible_args(mocker, ansible_playbook_instance):
+    ansible_playbook_instance._raw_ansible_args = ('-v', '--foo', 'bar')
+    ansible_playbook_instance.bake()
+
+    assert re.search('-v --foo bar$', str(ansible_playbook_instance._ansible))
 
 
 def test_ignores_requirements_file():


### PR DESCRIPTION
We supported `--tags` when converging, and had a request to also
support `--skip-tags`.  Rather than supporting ansible options,
simply pass everything after -- to ansible.  Flags are added to
the end of the `ansible-playbook` command and take precedence over
anything before.

  molecule converge -- -v --tags foo,bar --skip-tags baz

Fixes: #571