### PR TITLE
Improve initial debug logging

### DIFF
--- a/molecule/command/converge.py
+++ b/molecule/command/converge.py
@@ -98,14 +98,6 @@ class Converge(base.Base):
                 k: v
                 for (k, v) in ansible.env.items() if 'ANSIBLE' in k
             }
-            other_env = {
-                k: v
-                for (k, v) in ansible.env.items() if 'ANSIBLE' not in k
-            }
-            util.print_debug(
-                'OTHER ENVIRONMENT',
-                yaml.dump(
-                    other_env, default_flow_style=False, indent=2))
             util.print_debug(
                 'ANSIBLE ENVIRONMENT',
                 yaml.dump(

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -75,15 +75,7 @@ class Molecule(object):
             self.print_valid_platforms()
             util.sysexit()
 
-        # updates instances config with full machine names
         self.config.populate_instance_names(self.driver.platform)
-
-        if self.args.get('debug'):
-            util.print_debug(
-                'RUNNING CONFIG',
-                yaml.dump(
-                    self.config.config, default_flow_style=False, indent=2))
-
         self._add_or_update_vars('group_vars')
         self._add_or_update_vars('host_vars')
 


### PR DESCRIPTION
We dump way too much info to stdout on debug.  Most of it is not
relevant.  Debug now prints the ANSIBLE env vars and command executed
on converge.  Will continue to improve debug via #578.