### PR TITLE
avoid images with <none> tag

### DIFF
--- a/molecule/driver/dockerdriver.py
+++ b/molecule/driver/dockerdriver.py
@@ -223,7 +223,7 @@ class DockerDriver(basedriver.BaseDriver):
     def _build_ansible_compatible_image(self):
         available_images = [
             tag.encode('utf-8')
-            for image in self._docker.images() for tag in image.get('RepoTags') if tag is not None
+            for image in self._docker.images() for tag in image.get('RepoTags', [])
         ]
 
         for container in self.instances:

--- a/molecule/driver/dockerdriver.py
+++ b/molecule/driver/dockerdriver.py
@@ -223,7 +223,7 @@ class DockerDriver(basedriver.BaseDriver):
     def _build_ansible_compatible_image(self):
         available_images = [
             tag.encode('utf-8')
-            for image in self._docker.images() for tag in image.get('RepoTags')
+            for image in self._docker.images() for tag in image.get('RepoTags') if tag is not None
         ]
 
         for container in self.instances:


### PR DESCRIPTION
This simply skips images with <none> tags (which are a common occurrence in heavily used environments.
Prior to this patch, I would get
```
playbook: playbook.yml
--> Creating instances ...
Traceback (most recent call last):
  File ".venv/bin/molecule", line 11, in <module>
    sys.exit(main())
  File "/var/jenkins_home/workspace/sample-role/.venv/local/lib/python2.7/site-packages/molecule/cli.py", line 41, in main
    cli(obj={})
  File "/var/jenkins_home/workspace/sample-role/.venv/local/lib/python2.7/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/var/jenkins_home/workspace/sample-role/.venv/local/lib/python2.7/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/var/jenkins_home/workspace/sample-role/.venv/local/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/var/jenkins_home/workspace/sample-role/.venv/local/lib/python2.7/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/var/jenkins_home/workspace/sample-role/.venv/local/lib/python2.7/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/var/jenkins_home/workspace/sample-role/.venv/local/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/var/jenkins_home/workspace/sample-role/.venv/local/lib/python2.7/site-packages/molecule/command/test.py", line 96, in test
    util.sysexit(t.execute()[0])
  File "/var/jenkins_home/workspace/sample-role/.venv/local/lib/python2.7/site-packages/molecule/command/test.py", line 46, in execute
    status, output = c.execute(exit=False)
  File "/var/jenkins_home/workspace/sample-role/.venv/local/lib/python2.7/site-packages/molecule/command/create.py", line 44, in execute
    self.molecule.driver.up(no_provision=True)
  File "/var/jenkins_home/workspace/sample-role/.venv/local/lib/python2.7/site-packages/molecule/driver/dockerdriver.py", line 117, in up
    self._build_ansible_compatible_image()
  File "/var/jenkins_home/workspace/sample-role/.venv/local/lib/python2.7/site-packages/molecule/driver/dockerdriver.py", line 226, in _build_ansible_compatible_image
    for tag in image.get('RepoTags')]
TypeError: 'NoneType' object is not iterable
```