### PR TITLE
Moved galaxy and playbook members "private"

### DIFF
--- a/molecule/ansible_galaxy.py
+++ b/molecule/ansible_galaxy.py
@@ -44,9 +44,9 @@ class AnsibleGalaxy(object):
         """
         self._config = config
         self._galaxy = None
-        self.env = _env if _env else os.environ.copy()
-        self.out = _out
-        self.err = _err
+        self._env = _env if _env else os.environ.copy()
+        self._out = _out
+        self._err = _err
 
         # defaults can be redefined with call to add_env_arg() before baking
         self.add_env_arg('PYTHONUNBUFFERED', '1')
@@ -71,9 +71,9 @@ class AnsibleGalaxy(object):
 
         self._galaxy = sh.ansible_galaxy.bake(
             'install',
-            _env=self.env,
-            _out=self.out,
-            _err=self.err,
+            _env=self._env,
+            _out=self._out,
+            _err=self._err,
             **galaxy_options)
 
     def add_env_arg(self, name, value):
@@ -85,7 +85,7 @@ class AnsibleGalaxy(object):
         :param value: Value of argument to be added
         :return: None
         """
-        self.env[name] = value
+        self._env[name] = value
 
     def execute(self):
         """

--- a/molecule/ansible_playbook.py
+++ b/molecule/ansible_playbook.py
@@ -53,7 +53,7 @@ class AnsiblePlaybook(object):
         self._cli = {}
         self._cli_pos = []
         self._raw_ansible_args = raw_ansible_args
-        self.env = _env if _env else os.environ.copy()
+        self._env = _env if _env else os.environ.copy()
 
         for k, v in args.iteritems():
             self.parse_arg(k, v)
@@ -69,6 +69,10 @@ class AnsiblePlaybook(object):
         self.add_cli_arg('_out', _out)
         self.add_cli_arg('_err', _err)
 
+    @property
+    def env(self):
+        return self._env
+
     def bake(self):
         """
         Bake ansible-playbook command so it's ready to execute and returns
@@ -77,7 +81,7 @@ class AnsiblePlaybook(object):
         :return: None
         """
         self._ansible = sh.ansible_playbook.bake(
-            self._playbook, *self._cli_pos, _env=self.env, **self._cli)
+            self._playbook, *self._cli_pos, _env=self._env, **self._cli)
         if self._raw_ansible_args:
             self._ansible = self._ansible.bake(self._raw_ansible_args)
 
@@ -157,7 +161,7 @@ class AnsiblePlaybook(object):
         :param value: The value of argument to be added.
         :return: None
         """
-        self.env[name] = value
+        self._env[name] = value
 
     def remove_env_arg(self, name):
         """
@@ -166,7 +170,7 @@ class AnsiblePlaybook(object):
         :param name: A string containing the name of argument to be removed.
         :return: None
         """
-        self.env.pop(name, None)
+        self._env.pop(name, None)
 
     def execute(self, hide_errors=False):
         """

--- a/test/unit/test_ansible_galaxy.py
+++ b/test/unit/test_ansible_galaxy.py
@@ -39,7 +39,7 @@ def ansible_galaxy_instance(temp_files):
 def test_add_env_arg(ansible_galaxy_instance):
     ansible_galaxy_instance.add_env_arg('MOLECULE_1', 'test')
 
-    assert 'test' == ansible_galaxy_instance.env['MOLECULE_1']
+    assert 'test' == ansible_galaxy_instance._env['MOLECULE_1']
 
 
 def test_install(patched_ansible_galaxy, ansible_galaxy_instance):


### PR DESCRIPTION
While cleaning up sh logging, noticed we have some members listed
as "public".  Simply moved them to "private" for cleanliness.