### PR TITLE
Moved configs to individual files

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+exclude = .venv/,.tox/,dist/,build/,doc/,.eggs/,molecule/verifier/ansible/
+format = pylint

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = test/unit/

--- a/tox.ini
+++ b/tox.ini
@@ -12,12 +12,8 @@ deps =
     ansible21: ansible==2.1.2.0
     ansible22: ansible==2.2.0.0
 commands =
-    unit: py.test -x --cov={toxinidir}/molecule/ test/unit/ {posargs}
+    unit: py.test -x --cov={toxinidir}/molecule/ {posargs}
     functional: py.test -x test/functional/ {posargs}
-
-[flake8]
-exclude = .venv/,.tox/,dist/,build/,doc/,.eggs/,molecule/verifier/ansible/
-format = pylint
 
 [testenv:syntax]
 deps =


### PR DESCRIPTION
Sometimes we want to run flake or pytest outside of tox.  Having
the configs exist outside of tox allows both tox and the binary to
share the same settings.