### PR TITLE
Added a dependency command

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -112,20 +112,21 @@ Role Requirements
 ^^^^^^^^^^^^^^^^^
 
 Testing roles may rely upon additional roles.  In this case adding
-``requirements_file`` to the ansible section, will cause molecule to download
-roles using `Ansible Galaxy`_.
+``requirements_file`` to the ``dependencies`` section, will cause molecule to
+download roles using `Ansible Galaxy`_.
 
-Additional options can be passed to ``ansible-galaxy`` through the ``galaxy``
-option under the ansible section.  Any option set in this section will override
-the defaults.
+Additional options can be passed to ``ansible-galaxy`` through the ``options``
+option under the ``dependencies`` section.  Any option set in this section will
+override the defaults.
 
 .. _`Ansible Galaxy`: http://docs.ansible.com/ansible/galaxy.html
 
 .. code-block:: yaml
 
-  ansible:
+  dependencies:
+    name: galaxy
     requirements_file: requirements.yml
-    galaxy:
+    options:
         ignore-certs: True
         ignore-errors: True
 

--- a/molecule/ansible_galaxy.py
+++ b/molecule/ansible_galaxy.py
@@ -64,7 +64,7 @@ class AnsibleGalaxy(object):
 
         :return: None
         """
-        requirements_file = self._config['ansible']['requirements_file']
+        requirements_file = self._config['dependencies']['requirements_file']
         roles_path = os.path.join(self._config['molecule']['molecule_dir'],
                                   'roles')
         galaxy_default_options = {
@@ -72,8 +72,8 @@ class AnsibleGalaxy(object):
             'role-file': requirements_file,
             'roles-path': roles_path
         }
-        galaxy_options = config.merge_dicts(galaxy_default_options,
-                                            self._config['ansible']['galaxy'])
+        galaxy_options = config.merge_dicts(
+            galaxy_default_options, self._config['dependencies']['options'])
 
         self._galaxy = sh.ansible_galaxy.bake(
             'install',

--- a/molecule/ansible_playbook.py
+++ b/molecule/ansible_playbook.py
@@ -95,10 +95,6 @@ class AnsiblePlaybook(object):
         :return: None
         """
 
-        # skip `requirements_file` since it used by ansible-galaxy only
-        if name == 'requirements_file':
-            return
-
         if name == 'raw_env_vars':
             for k, v in value.iteritems():
                 self.add_env_arg(k, v)

--- a/molecule/command/__init__.py
+++ b/molecule/command/__init__.py
@@ -26,6 +26,7 @@ from molecule.command import base  # noqa
 from molecule.command import check  # noqa
 from molecule.command import converge  # noqa
 from molecule.command import create  # noqa
+from molecule.command import dependency  # noqa
 from molecule.command import destroy  # noqa
 from molecule.command import idempotence  # noqa
 from molecule.command import init  # noqa

--- a/molecule/command/converge.py
+++ b/molecule/command/converge.py
@@ -21,11 +21,11 @@
 import click
 import yaml
 
-from molecule import ansible_galaxy
 from molecule import ansible_playbook
 from molecule import util
 from molecule.command import base
 from molecule.command import create
+from molecule.command import dependency
 
 LOG = util.get_logger(__name__)
 
@@ -71,14 +71,8 @@ class Converge(base.Base):
         if create_inventory:
             self.molecule.create_inventory_file()
 
-        # Install role dependencies only during `molecule converge`
-        if not idempotent and 'requirements_file' in \
-            self.molecule.config.config['ansible'] and not \
-                self.molecule.state.installed_deps:
-            galaxy = ansible_galaxy.AnsibleGalaxy(
-                self.molecule.config.config, debug=debug)
-            galaxy.execute()
-            self.molecule.state.change_state('installed_deps', True)
+        d = dependency.Dependency(self.args, self.command_args, self.molecule)
+        d.execute()
 
         ansible = ansible_playbook.AnsiblePlaybook(
             self.molecule.config.config['ansible'],

--- a/molecule/command/init.py
+++ b/molecule/command/init.py
@@ -90,6 +90,7 @@ class Init(base.Base):
             'repo_name': role,
             'role_name': role,
             'driver_name': driver,
+            'dependencies_name': 'galaxy',  # static for now
             'verifier_name': verifier,
         }
         if driver == 'vagrant':

--- a/molecule/command/test.py
+++ b/molecule/command/test.py
@@ -37,8 +37,8 @@ class Test(base.Base):
         :return: Return a tuple of (`exit status`, `command output`), otherwise
          sys.exit on command failure.
         """
-        for task in self.molecule.config.config['molecule']['test'][
-                'sequence']:
+        ts = self.molecule.config.config['molecule']['test']['sequence']
+        for task in ts:
             command_module = getattr(molecule.command, task)
             command = getattr(command_module, task.capitalize())
             c = command(self.args, self.command_args, self.molecule)

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -131,7 +131,6 @@ class ConfigV1(Config):
                 'ask_vault_pass': False,
                 'config_file': 'ansible.cfg',
                 'diff': True,
-                'galaxy': {},
                 'host_key_checking': False,
                 'inventory_file': 'ansible_inventory',
                 'limit': 'all',
@@ -175,8 +174,8 @@ class ConfigV1(Config):
                 'state_file': 'state.yml',
                 'test': {
                     'sequence': [
-                        'destroy', 'syntax', 'create', 'converge',
-                        'idempotence', 'check', 'verify'
+                        'destroy', 'dependency', 'syntax', 'create',
+                        'converge', 'idempotence', 'check', 'verify'
                     ]
                 },
                 'testinfra_dir': 'tests',
@@ -185,6 +184,10 @@ class ConfigV1(Config):
             },
             'verifier': {
                 'name': 'testinfra',
+                'options': {}
+            },
+            'dependencies': {
+                'name': 'galaxy',
                 'options': {}
             },
             '_disabled': [],

--- a/molecule/cookiecutter/driver/docker/cookiecutter.json
+++ b/molecule/cookiecutter/driver/docker/cookiecutter.json
@@ -1,4 +1,5 @@
 {
+  "dependencies_name": "OVERRIDEN",
   "repo_name": "OVERRIDEN",
   "role_name": "OVERRIDEN",
   "verifier_name": "OVERRIDEN",

--- a/molecule/cookiecutter/driver/docker/{{cookiecutter.repo_name}}/molecule.yml
+++ b/molecule/cookiecutter/driver/docker/{{cookiecutter.repo_name}}/molecule.yml
@@ -1,4 +1,6 @@
 ---
+dependencies:
+  name: {{ cookiecutter.dependencies_name }}
 driver:
   name: {{ cookiecutter.driver_name }}
 docker:

--- a/molecule/cookiecutter/driver/openstack/cookiecutter.json
+++ b/molecule/cookiecutter/driver/openstack/cookiecutter.json
@@ -1,4 +1,5 @@
 {
+  "dependencies_name": "OVERRIDEN",
   "repo_name": "OVERRIDEN",
   "role_name": "OVERRIDEN",
   "verifier_name": "OVERRIDEN",

--- a/molecule/cookiecutter/driver/openstack/{{cookiecutter.repo_name}}/molecule.yml
+++ b/molecule/cookiecutter/driver/openstack/{{cookiecutter.repo_name}}/molecule.yml
@@ -1,4 +1,6 @@
 ---
+dependencies:
+  name: {{ cookiecutter.dependencies_name }}
 driver:
   name: {{ cookiecutter.driver_name }}
 openstack:

--- a/molecule/cookiecutter/driver/vagrant/cookiecutter.json
+++ b/molecule/cookiecutter/driver/vagrant/cookiecutter.json
@@ -1,4 +1,5 @@
 {
+  "dependencies_name": "OVERRIDEN",
   "repo_name": "OVERRIDEN",
   "role_name": "OVERRIDEN",
   "platform_name": "OVERRIDEN",

--- a/molecule/cookiecutter/driver/vagrant/{{cookiecutter.repo_name}}/molecule.yml
+++ b/molecule/cookiecutter/driver/vagrant/{{cookiecutter.repo_name}}/molecule.yml
@@ -1,4 +1,6 @@
 ---
+dependencies:
+  name: {{ cookiecutter.dependencies_name }}
 driver:
   name: {{ cookiecutter.driver_name }}
 vagrant:

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -45,6 +45,7 @@ class Molecule(object):
         self.args = args
         self._verifier = self._get_verifier()
         self._verifier_options = self._get_verifier_options()
+        self._dependencies = self._get_dependencies()
         self._disabled = self._get_disabled()
 
     def main(self):
@@ -102,6 +103,14 @@ class Molecule(object):
     @verifier_options.setter
     def verifier_options(self, val):
         self._verifier_options = val
+
+    @property
+    def dependencies(self):
+        return self._dependencies
+
+    @dependencies.setter
+    def dependencies(self, val):
+        self._dependencies = val
 
     @property
     def disabled(self):
@@ -374,6 +383,11 @@ class Molecule(object):
         # syntax.
         return self.config.config.get(
             'testinfra', self.config.config['verifier'].get('options', {}))
+
+    def _get_dependencies(self):
+        if self.config.config.get('dependencies'):
+            return 'galaxy'
+        return self.config.config['dependencies']['name']
 
     def _get_disabled(self):
         # Ability to turn off features until we roll them out.

--- a/test/scenarios/command_check/molecule.yml
+++ b/test/scenarios/command_check/molecule.yml
@@ -1,12 +1,12 @@
 ---
+dependencies:
+  name: galaxy
 driver:
   name: docker
-
 docker:
   containers:
     - name: check-scenario
       image: ubuntu
       image_version: latest
-
 verifier:
   name: testinfra

--- a/test/scenarios/command_converge/molecule.yml
+++ b/test/scenarios/command_converge/molecule.yml
@@ -1,12 +1,12 @@
 ---
+dependencies:
+  name: galaxy
 driver:
   name: docker
-
 docker:
   containers:
     - name: converge-scenario
       image: ubuntu
       image_version: latest
-
 verifier:
   name: testinfra

--- a/test/scenarios/command_idempotence/molecule.yml
+++ b/test/scenarios/command_idempotence/molecule.yml
@@ -1,12 +1,12 @@
 ---
+dependencies:
+  name: galaxy
 driver:
   name: docker
-
 docker:
   containers:
     - name: idempotence-scenario
       image: ubuntu
       image_version: latest
-
 verifier:
   name: testinfra

--- a/test/scenarios/command_status/molecule.yml
+++ b/test/scenarios/command_status/molecule.yml
@@ -1,26 +1,23 @@
 ---
+dependencies:
+  name: galaxy
 driver:
   name: docker
-
 ansible:
   raw_env_vars:
     ANSIBLE_ROLES_PATH: ../../../../roles:../../../../../roles
-
 vagrant:
   platforms:
     - name: ubuntu
       box: ubuntu/trusty64
     - name: centos7
       box: centos/7
-
   providers:
     - name: virtualbox
       type: virtualbox
-
   instances:
     - name: status-scenario-01
     - name: status-scenario-02
-
 openstack:
   keypair: KeyName
   keyfile: ~/.ssh/id_rsa
@@ -33,7 +30,6 @@ openstack:
       image: 'CentOS 7'
       flavor: m1.xlarge
       sshuser: centos
-
 docker:
   containers:
     - name: status-scenario-01
@@ -42,6 +38,5 @@ docker:
     - name: status-scenario-02
       image: ubuntu
       image_version: latest
-
 verifier:
   name: testinfra

--- a/test/scenarios/command_test/molecule.yml
+++ b/test/scenarios/command_test/molecule.yml
@@ -1,11 +1,11 @@
 ---
+dependencies:
+  name: galaxy
 driver:
   name: docker
-
 ansible:
   raw_env_vars:
     ANSIBLE_ROLES_PATH: ../../roles:../../../roles
-
 docker:
   containers:
     - name: test-scenario-01
@@ -20,7 +20,6 @@ docker:
         - example-group2
       image: ubuntu
       image_version: latest
-
 vagrant:
   platforms:
     - name: ubuntu
@@ -41,6 +40,5 @@ vagrant:
       ansible_groups:
         - example-group
         - example-group2
-
 verifier:
   name: testinfra

--- a/test/scenarios/command_verify/molecule.yml
+++ b/test/scenarios/command_verify/molecule.yml
@@ -1,12 +1,12 @@
 ---
+dependencies:
+  name: galaxy
 driver:
   name: docker
-
 docker:
   containers:
     - name: verify-scenario
       image: ubuntu
       image_version: latest
-
 verifier:
   name: testinfra

--- a/test/scenarios/command_verify_trailing_newline/molecule.yml
+++ b/test/scenarios/command_verify_trailing_newline/molecule.yml
@@ -1,12 +1,12 @@
 ---
+dependencies:
+  name: galaxy
 driver:
   name: docker
-
 docker:
   containers:
     - name: verify-newline-scenario
       image: ubuntu
       image_version: latest
-
 verifier:
   name: testinfra

--- a/test/scenarios/command_verify_trailing_whitespace/molecule.yml
+++ b/test/scenarios/command_verify_trailing_whitespace/molecule.yml
@@ -1,12 +1,12 @@
 ---
+dependencies:
+  name: galaxy
 driver:
   name: docker
-
 docker:
   containers:
     - name: verify-whitespace-scenario
       image: ubuntu
       image_version: latest
-
 verifier:
   name: testinfra

--- a/test/scenarios/custom_ansible_cfg/molecule.yml
+++ b/test/scenarios/custom_ansible_cfg/molecule.yml
@@ -1,14 +1,14 @@
 ---
+dependencies:
+  name: galaxy
 ansible:
   config_file: ../ansible.cfg
 driver:
   name: docker
-
 docker:
   containers:
     - name: custom-ansible-cfg-scenario
       image: ubuntu
       image_version: latest
-
 verifier:
   name: testinfra

--- a/test/scenarios/dockerfile/molecule.yml
+++ b/test/scenarios/dockerfile/molecule.yml
@@ -1,7 +1,8 @@
 ---
+dependencies:
+  name: galaxy
 driver:
   name: docker
-
 docker:
   containers:
     - name: dockerfile-scenario
@@ -9,6 +10,5 @@ docker:
       image_version: latest
       dockerfile: Dockerfile
       command: /bin/bash
-
 verifier:
   name: testinfra

--- a/test/scenarios/group_host_vars/molecule.yml
+++ b/test/scenarios/group_host_vars/molecule.yml
@@ -1,7 +1,8 @@
 ---
+dependencies:
+  name: galaxy
 driver:
   name: docker
-
 ansible:
   group_vars:
     example:
@@ -11,7 +12,6 @@ ansible:
   host_vars:
     group-vars-scenario:
       - group_host_vars_host_molecule_yml: bar
-
 docker:
   containers:
     - name: group-vars-scenario
@@ -21,7 +21,6 @@ docker:
           - example
       image: ubuntu
       image_version: latest
-
 vagrant:
   platforms:
     - name: ubuntu
@@ -37,6 +36,5 @@ vagrant:
         - example
         - example2:children:
           - example
-
 verifier:
   name: testinfra

--- a/test/scenarios/requirements_file/molecule.yml
+++ b/test/scenarios/requirements_file/molecule.yml
@@ -1,15 +1,13 @@
 ---
+dependencies:
+  requirements_file: requirements.yml
+  name: galaxy
 driver:
   name: docker
-
-ansible:
-  requirements_file: requirements.yml
-
 docker:
   containers:
     - name: requirements-file-scenario
       image: ubuntu
       image_version: latest
-
 verifier:
   name: testinfra

--- a/test/unit/command/conftest.py
+++ b/test/unit/command/conftest.py
@@ -27,21 +27,8 @@ def patched_check_main(mocker):
 
 
 @pytest.fixture
-def patched_destroy_main(mocker):
-    return mocker.patch('molecule.command.destroy.Destroy.main')
-
-
-@pytest.fixture
-def patched_destroy(mocker):
-    m = mocker.patch('molecule.command.destroy.Destroy.execute')
-    m.return_value = None, None
-
-    return m
-
-
-@pytest.fixture
-def patched_syntax(mocker):
-    m = mocker.patch('molecule.command.syntax.Syntax.execute')
+def patched_check(mocker):
+    m = mocker.patch('molecule.command.check.Check.execute')
     m.return_value = None, None
 
     return m
@@ -64,6 +51,27 @@ def patched_converge(mocker):
 
 
 @pytest.fixture
+def patched_dependency(mocker):
+    m = mocker.patch('molecule.command.dependency.Dependency.execute')
+    m.return_value = None, None
+
+    return m
+
+
+@pytest.fixture
+def patched_destroy_main(mocker):
+    return mocker.patch('molecule.command.destroy.Destroy.main')
+
+
+@pytest.fixture
+def patched_destroy(mocker):
+    m = mocker.patch('molecule.command.destroy.Destroy.execute')
+    m.return_value = None, None
+
+    return m
+
+
+@pytest.fixture
 def patched_idempotence(mocker):
     m = mocker.patch('molecule.command.idempotence.Idempotence.execute')
     m.return_value = None, None
@@ -72,8 +80,8 @@ def patched_idempotence(mocker):
 
 
 @pytest.fixture
-def patched_check(mocker):
-    m = mocker.patch('molecule.command.check.Check.execute')
+def patched_syntax(mocker):
+    m = mocker.patch('molecule.command.syntax.Syntax.execute')
     m.return_value = None, None
 
     return m

--- a/test/unit/command/test_converge.py
+++ b/test/unit/command/test_converge.py
@@ -85,15 +85,14 @@ def test_execute_create_inventory_and_instances_with_platform_all_state_file(
 
 
 def test_execute_installs_dependencies(
-        patched_create, patched_ansible_playbook, patched_ansible_galaxy,
+        patched_create, patched_ansible_playbook, patched_dependency,
         patched_create_inventory, molecule_instance):
-    molecule_instance.config.config['ansible']['requirements_file'] = True
+    molecule_instance.config.config['dependencies']['requirements_file'] = True
 
     c = converge.Converge({}, {}, molecule_instance)
     c.execute()
 
-    patched_ansible_galaxy.assert_called_once()
-    assert molecule_instance.state.installed_deps
+    patched_dependency.assert_called_once()
 
 
 def test_execute_with_debug(patched_create, patched_ansible_playbook,

--- a/test/unit/command/test_syntax.py
+++ b/test/unit/command/test_syntax.py
@@ -34,13 +34,14 @@ def test_execute(mocker, patched_ansible_playbook, patched_print_info,
     assert 'returned' == result
 
 
-def test_execute_installs_requirements(patched_ansible_playbook,
-                                       patched_ansible_galaxy,
-                                       patched_print_info, molecule_instance):
-    molecule_instance.config.config['ansible']['requirements_file'] = str()
+def test_execute_installs_dependencies(patched_ansible_playbook,
+                                       patched_dependency, patched_print_info,
+                                       molecule_instance):
+    molecule_instance.config.config['dependencies']['requirements_file'] = str(
+    )
 
     s = syntax.Syntax({}, {}, molecule_instance)
     s.execute()
 
-    patched_ansible_galaxy.assert_called_once()
+    patched_dependency.assert_called_once()
     patched_ansible_playbook.assert_called_once_with(hide_errors=True)

--- a/test/unit/command/test_test.py
+++ b/test/unit/command/test_test.py
@@ -23,13 +23,15 @@ import pytest
 from molecule.command import test
 
 
-def test_execute(mocker, patched_destroy_main, patched_destroy, patched_syntax,
-                 patched_create, patched_converge, patched_idempotence,
-                 patched_check, patched_verify, molecule_instance):
+def test_execute(mocker, patched_destroy_main, patched_destroy,
+                 patched_dependency, patched_syntax, patched_create,
+                 patched_converge, patched_idempotence, patched_check,
+                 patched_verify, molecule_instance):
     t = test.Test({}, {}, molecule_instance)
     result = t.execute()
 
     patched_syntax.assert_called_once_with(exit=False)
+    patched_dependency.assert_called_once_with(exit=False)
     patched_create.assert_called_once_with(exit=False)
     patched_converge.assert_called_once_with(exit=False)
     patched_idempotence.assert_called_once_with(exit=False)

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -146,8 +146,8 @@ def molecule_v1_section_data(state_path_without_data):
             ],
             'test': {
                 'sequence': [
-                    'destroy', 'syntax', 'create', 'converge', 'idempotence',
-                    'check', 'verify'
+                    'destroy', 'dependency', 'syntax', 'create', 'converge',
+                    'idempotence', 'check', 'verify'
                 ]
             }
         }
@@ -257,7 +257,6 @@ def ansible_v1_section_data(playbook):
                 '-o UserKnownHostsFile=/dev/null', '-o IdentitiesOnly=yes',
                 '-o ControlMaster=auto', '-o ControlPersist=60s'
             ],
-            'galaxy': {},
             'config_file': 'config_file',
             'inventory_file': 'inventory_file',
             'playbook': playbook,
@@ -267,6 +266,10 @@ def ansible_v1_section_data(playbook):
         },
         'verifier': {
             'name': 'testinfra',
+            'options': {}
+        },
+        'dependencies': {
+            'name': 'galaxy',
             'options': {}
         },
         '_disabled': []

--- a/test/unit/core/test_core.py
+++ b/test/unit/core/test_core.py
@@ -99,6 +99,16 @@ def test_verifier_disabled(molecule_instance):
     assert [] == molecule_instance.disabled
 
 
+def test_dependencies_setter(molecule_instance):
+    molecule_instance.dependencies = 'foo'
+
+    assert 'foo' == molecule_instance.dependencies
+
+
+def test_dependencies(molecule_instance):
+    assert 'galaxy' == molecule_instance.dependencies
+
+
 @pytest.mark.skip(reason='TODO(retr0h): Determine best way to test this')
 def test_remove_templates():
     pass

--- a/test/unit/test_ansible_galaxy.py
+++ b/test/unit/test_ansible_galaxy.py
@@ -29,7 +29,7 @@ from molecule import config
 def ansible_galaxy_instance(temp_files):
     confs = temp_files(fixtures=['molecule_vagrant_v1_config'])
     c = config.ConfigV1(configs=confs)
-    c.config['ansible']['requirements_file'] = 'requirements.yml'
+    c.config['dependencies']['requirements_file'] = 'requirements.yml'
 
     return ansible_galaxy.AnsibleGalaxy(c.config)
 
@@ -58,7 +58,7 @@ def test_execute(patched_ansible_galaxy, ansible_galaxy_instance):
 
 
 def test_execute_overrides(patched_ansible_galaxy, ansible_galaxy_instance):
-    ansible_galaxy_instance._config['ansible']['galaxy'] = {
+    ansible_galaxy_instance._config['dependencies']['options'] = {
         'foo': 'bar',
         'force': False
     }

--- a/test/unit/test_ansible_playbook.py
+++ b/test/unit/test_ansible_playbook.py
@@ -154,12 +154,6 @@ def test_bake_with_raw_ansible_args(mocker, ansible_playbook_instance):
     assert re.search('-v --foo bar$', str(ansible_playbook_instance._ansible))
 
 
-def test_ignores_requirements_file():
-    a = ansible_playbook.AnsiblePlaybook({'requirements_file': 'foo/bar'}, {})
-
-    assert not a._cli.get('requirements_file')
-
-
 def test_ignores_host_group_vars():
     a = ansible_playbook.AnsiblePlaybook({
         'host_vars': 'foo',


### PR DESCRIPTION
The dependency command is executed prior to `syntax` and `converge`.  Also,
added to the test sequence.  This will allow us generify role dependencies
in the future.

Breaking Change: The galaxy override options have been moved to the
`dependencies` section of molecule's config.