### PR TITLE
Removed testinfra config backward compatibility

### DIFF
--- a/molecule/core.py
+++ b/molecule/core.py
@@ -44,7 +44,6 @@ class Molecule(object):
         self.config = config
         self.args = args
         self._verifier = self._get_verifier()
-        self._verifier_options = self._get_verifier_options()
         self._dependencies = self._get_dependencies()
         self._disabled = self._get_disabled()
 
@@ -95,14 +94,6 @@ class Molecule(object):
     @verifier.setter
     def verifier(self, val):
         self._verifier = val
-
-    @property
-    def verifier_options(self):
-        return self._verifier_options
-
-    @verifier_options.setter
-    def verifier_options(self, val):
-        self._verifier_options = val
 
     @property
     def dependencies(self):
@@ -377,12 +368,6 @@ class Molecule(object):
         if self.config.config.get('testinfra'):
             return 'testinfra'
         return self.config.config['verifier']['name']
-
-    def _get_verifier_options(self):
-        # Preserve backward compatibility with old testinfra override
-        # syntax.
-        return self.config.config.get(
-            'testinfra', self.config.config['verifier'].get('options', {}))
 
     def _get_dependencies(self):
         if self.config.config.get('dependencies'):

--- a/molecule/verifier/testinfra.py
+++ b/molecule/verifier/testinfra.py
@@ -53,7 +53,7 @@ class Testinfra(base.Base):
 
         testinfra_options = config.merge_dicts(
             self._molecule.driver.testinfra_args,
-            self._molecule.verifier_options)
+            self._molecule.config.config['verifier']['options'])
 
         testinfra_options['ansible_env'] = ansible.env
         if self._molecule.args.get('debug'):

--- a/test/unit/core/test_core.py
+++ b/test/unit/core/test_core.py
@@ -71,24 +71,6 @@ def test_verifier_backward_compatible(molecule_instance):
     assert 'testinfra' == m.verifier
 
 
-def test_verifier_options_setter(molecule_instance):
-    molecule_instance.verifier_options = 'foo'
-
-    assert 'foo' == molecule_instance.verifier_options
-
-
-def test_verifier_options(molecule_instance):
-    assert {} == molecule_instance.verifier_options
-
-
-def test_verifier_options_backward_compatible(molecule_instance):
-    m = molecule_instance
-    m.config.config['testinfra'] = {'foo': 'bar'}
-    m.verifier_options = m._get_verifier_options()
-
-    assert {'foo': 'bar'} == m.verifier_options
-
-
 def test_verifier_disabled_setter(molecule_instance):
     molecule_instance.disabled = 'foo'
 


### PR DESCRIPTION
Breaking Change: The testinfra override options have been moved to the
`verifier` section of molecule's config.  No longer supporting the old
syntax.