### PR TITLE
Corrected ansible 2.2 goss test

### DIFF
--- a/molecule/cookiecutter/verifier/goss/{{cookiecutter.repo_name}}/tests/test_default.yml
+++ b/molecule/cookiecutter/verifier/goss/{{cookiecutter.repo_name}}/tests/test_default.yml
@@ -19,7 +19,7 @@
                mode=0755
 {% raw %}
     - name: Copy tests to remote
-      copy: src="../../files/goss/{{ item }}"
+      copy: src="{{ playbook_dir }}/../files/goss/{{ item }}"
             dest="/tmp/{{ item }}"
       with_items:
         - hosts.yml


### PR DESCRIPTION
Ansible 2.2 does not seem happy with our relative file lookup.
Updated to work with all versions of ansible.

    TASK [Copy tests to remote]
    ****************************************************
    failed: [foo] (item=hosts.yml) => {"failed": true, "item": "hosts.yml",
    "msg": "Unable to find '../../../files/goss/hosts.yml' in expected
    paths."}