### PR TITLE
Rename dependencies key to dependency

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -198,18 +198,18 @@ Testing roles may rely upon additional dependencies.
 Ansible Galaxy
 ^^^^^^^^^^^^^^
 
-Adding a ``requirements_file`` key to the ``dependencies`` section, will cause
+Adding a ``requirements_file`` key to the ``dependency`` section, will cause
 molecule to download roles using `Ansible Galaxy`_.
 
 Additional options can be passed to ``ansible-galaxy`` through the ``options``
-option under the ``dependencies`` section.  Any option set in this section will
+dict under the ``dependency`` section.  Any option set in this section will
 override the defaults.
 
 .. _`Ansible Galaxy`: http://docs.ansible.com/ansible/galaxy.html
 
 .. code-block:: yaml
 
-  dependencies:
+  dependency:
     name: galaxy
     requirements_file: requirements.yml
     options:
@@ -219,12 +219,12 @@ override the defaults.
 Shell
 ^^^^^
 
-Adding a ``command`` key to the ``dependencies`` section, will cause molecule
-to download roles using the command provided.
+Adding a ``command`` key to the ``dependency`` section, will cause molecule
+to execute the command provided.
 
 .. code-block:: yaml
 
-  dependencies:
+  dependency:
     name: shell
     command: script --flag1 subcommand --flag2
 

--- a/molecule/command/dependency.py
+++ b/molecule/command/dependency.py
@@ -40,15 +40,15 @@ class Dependency(base.Base):
         debug = self.args.get('debug')
         if self.molecule.state.installed_deps:
             return (None, None)
-        if self.molecule.dependencies == 'galaxy':
-            dd = self.molecule.config.config.get('dependencies')
+        if self.molecule.dependency == 'galaxy':
+            dd = self.molecule.config.config.get('dependency')
             if dd.get('requirements_file'):
                 g = ansible_galaxy.AnsibleGalaxy(
                     self.molecule.config.config, debug=debug)
                 g.execute()
                 self.molecule.state.change_state('installed_deps', True)
-        elif self.molecule.dependencies == 'shell':
-            dd = self.molecule.config.config.get('dependencies')
+        elif self.molecule.dependency == 'shell':
+            dd = self.molecule.config.config.get('dependency')
             if dd.get('command'):
                 s = shell.Shell(self.molecule.config.config, debug=debug)
                 s.execute()

--- a/molecule/command/init.py
+++ b/molecule/command/init.py
@@ -90,7 +90,7 @@ class Init(base.Base):
             'repo_name': role,
             'role_name': role,
             'driver_name': driver,
-            'dependencies_name': 'galaxy',  # static for now
+            'dependency_name': 'galaxy',  # static for now
             'verifier_name': verifier,
         }
         if driver == 'vagrant':

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -186,7 +186,7 @@ class ConfigV1(Config):
                 'name': 'testinfra',
                 'options': {}
             },
-            'dependencies': {
+            'dependency': {
                 'name': 'galaxy',
                 'options': {}
             },

--- a/molecule/cookiecutter/driver/docker/cookiecutter.json
+++ b/molecule/cookiecutter/driver/docker/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-  "dependencies_name": "OVERRIDEN",
+  "dependency_name": "OVERRIDEN",
   "repo_name": "OVERRIDEN",
   "role_name": "OVERRIDEN",
   "verifier_name": "OVERRIDEN",

--- a/molecule/cookiecutter/driver/docker/{{cookiecutter.repo_name}}/molecule.yml
+++ b/molecule/cookiecutter/driver/docker/{{cookiecutter.repo_name}}/molecule.yml
@@ -1,6 +1,6 @@
 ---
-dependencies:
-  name: {{ cookiecutter.dependencies_name }}
+dependency:
+  name: {{ cookiecutter.dependency_name }}
 driver:
   name: {{ cookiecutter.driver_name }}
 docker:

--- a/molecule/cookiecutter/driver/openstack/cookiecutter.json
+++ b/molecule/cookiecutter/driver/openstack/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-  "dependencies_name": "OVERRIDEN",
+  "dependency_name": "OVERRIDEN",
   "repo_name": "OVERRIDEN",
   "role_name": "OVERRIDEN",
   "verifier_name": "OVERRIDEN",

--- a/molecule/cookiecutter/driver/openstack/{{cookiecutter.repo_name}}/molecule.yml
+++ b/molecule/cookiecutter/driver/openstack/{{cookiecutter.repo_name}}/molecule.yml
@@ -1,6 +1,6 @@
 ---
-dependencies:
-  name: {{ cookiecutter.dependencies_name }}
+dependency:
+  name: {{ cookiecutter.dependency_name }}
 driver:
   name: {{ cookiecutter.driver_name }}
 openstack:

--- a/molecule/cookiecutter/driver/vagrant/cookiecutter.json
+++ b/molecule/cookiecutter/driver/vagrant/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-  "dependencies_name": "OVERRIDEN",
+  "dependency_name": "OVERRIDEN",
   "repo_name": "OVERRIDEN",
   "role_name": "OVERRIDEN",
   "platform_name": "OVERRIDEN",

--- a/molecule/cookiecutter/driver/vagrant/{{cookiecutter.repo_name}}/molecule.yml
+++ b/molecule/cookiecutter/driver/vagrant/{{cookiecutter.repo_name}}/molecule.yml
@@ -1,6 +1,6 @@
 ---
-dependencies:
-  name: {{ cookiecutter.dependencies_name }}
+dependency:
+  name: {{ cookiecutter.dependency_name }}
 driver:
   name: {{ cookiecutter.driver_name }}
 vagrant:

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -44,7 +44,7 @@ class Molecule(object):
         self.config = config
         self.args = args
         self._verifier = self._get_verifier()
-        self._dependencies = self._get_dependencies()
+        self._dependency = self._get_dependency()
         self._disabled = self._get_disabled()
 
     def main(self):
@@ -96,12 +96,12 @@ class Molecule(object):
         self._verifier = val
 
     @property
-    def dependencies(self):
-        return self._dependencies
+    def dependency(self):
+        return self._dependency
 
-    @dependencies.setter
-    def dependencies(self, val):
-        self._dependencies = val
+    @dependency.setter
+    def dependency(self, val):
+        self._dependency = val
 
     @property
     def disabled(self):
@@ -367,8 +367,8 @@ class Molecule(object):
     def _get_verifier(self):
         return self.config.config['verifier']['name']
 
-    def _get_dependencies(self):
-        return self.config.config['dependencies']['name']
+    def _get_dependency(self):
+        return self.config.config['dependency']['name']
 
     def _get_disabled(self):
         # Ability to turn off features until we roll them out.

--- a/molecule/dependency/ansible_galaxy.py
+++ b/molecule/dependency/ansible_galaxy.py
@@ -64,7 +64,7 @@ class AnsibleGalaxy(object):
 
         :return: None
         """
-        requirements_file = self._config['dependencies']['requirements_file']
+        requirements_file = self._config['dependency']['requirements_file']
         roles_path = os.path.join(self._config['molecule']['molecule_dir'],
                                   'roles')
         galaxy_default_options = {
@@ -73,7 +73,7 @@ class AnsibleGalaxy(object):
             'roles-path': roles_path
         }
         galaxy_options = config.merge_dicts(
-            galaxy_default_options, self._config['dependencies']['options'])
+            galaxy_default_options, self._config['dependency']['options'])
 
         self._galaxy = sh.ansible_galaxy.bake(
             'install',

--- a/molecule/dependency/shell.py
+++ b/molecule/dependency/shell.py
@@ -60,7 +60,7 @@ class Shell(object):
 
         :return: None
         """
-        command = self._config['dependencies']['command'].split(' ')
+        command = self._config['dependency']['command'].split(' ')
         self._command = getattr(sh, command.pop(0))
         self._command = self._command.bake(command)
         self._command = self._command.bake(

--- a/test/scenarios/command_check/molecule.yml
+++ b/test/scenarios/command_check/molecule.yml
@@ -1,5 +1,5 @@
 ---
-dependencies:
+dependency:
   name: galaxy
 driver:
   name: docker

--- a/test/scenarios/command_converge/molecule.yml
+++ b/test/scenarios/command_converge/molecule.yml
@@ -1,5 +1,5 @@
 ---
-dependencies:
+dependency:
   name: galaxy
 driver:
   name: docker

--- a/test/scenarios/command_idempotence/molecule.yml
+++ b/test/scenarios/command_idempotence/molecule.yml
@@ -1,5 +1,5 @@
 ---
-dependencies:
+dependency:
   name: galaxy
 driver:
   name: docker

--- a/test/scenarios/command_status/molecule.yml
+++ b/test/scenarios/command_status/molecule.yml
@@ -1,5 +1,5 @@
 ---
-dependencies:
+dependency:
   name: galaxy
 driver:
   name: docker

--- a/test/scenarios/command_test/molecule.yml
+++ b/test/scenarios/command_test/molecule.yml
@@ -1,5 +1,5 @@
 ---
-dependencies:
+dependency:
   name: galaxy
 driver:
   name: docker

--- a/test/scenarios/command_verify/molecule.yml
+++ b/test/scenarios/command_verify/molecule.yml
@@ -1,5 +1,5 @@
 ---
-dependencies:
+dependency:
   name: galaxy
 driver:
   name: docker

--- a/test/scenarios/command_verify_trailing_newline/molecule.yml
+++ b/test/scenarios/command_verify_trailing_newline/molecule.yml
@@ -1,5 +1,5 @@
 ---
-dependencies:
+dependency:
   name: galaxy
 driver:
   name: docker

--- a/test/scenarios/command_verify_trailing_whitespace/molecule.yml
+++ b/test/scenarios/command_verify_trailing_whitespace/molecule.yml
@@ -1,5 +1,5 @@
 ---
-dependencies:
+dependency:
   name: galaxy
 driver:
   name: docker

--- a/test/scenarios/custom_ansible_cfg/molecule.yml
+++ b/test/scenarios/custom_ansible_cfg/molecule.yml
@@ -1,5 +1,5 @@
 ---
-dependencies:
+dependency:
   name: galaxy
 ansible:
   config_file: ../ansible.cfg

--- a/test/scenarios/dockerfile/molecule.yml
+++ b/test/scenarios/dockerfile/molecule.yml
@@ -1,5 +1,5 @@
 ---
-dependencies:
+dependency:
   name: galaxy
 driver:
   name: docker

--- a/test/scenarios/group_host_vars/molecule.yml
+++ b/test/scenarios/group_host_vars/molecule.yml
@@ -1,5 +1,5 @@
 ---
-dependencies:
+dependency:
   name: galaxy
 driver:
   name: docker

--- a/test/scenarios/requirements_file/molecule.yml
+++ b/test/scenarios/requirements_file/molecule.yml
@@ -1,5 +1,5 @@
 ---
-dependencies:
+dependency:
   requirements_file: requirements.yml
   name: galaxy
 driver:

--- a/test/unit/command/test_converge.py
+++ b/test/unit/command/test_converge.py
@@ -87,7 +87,7 @@ def test_execute_create_inventory_and_instances_with_platform_all_state_file(
 def test_execute_installs_dependencies(
         patched_create, patched_ansible_playbook, patched_dependency,
         patched_create_inventory, molecule_instance):
-    molecule_instance.config.config['dependencies']['requirements_file'] = True
+    molecule_instance.config.config['dependency']['requirements_file'] = True
 
     c = converge.Converge({}, {}, molecule_instance)
     c.execute()

--- a/test/unit/command/test_dependency.py
+++ b/test/unit/command/test_dependency.py
@@ -22,7 +22,7 @@ from molecule.command import dependency
 
 
 def test_execute(patched_ansible_galaxy, molecule_instance):
-    molecule_instance.config.config['dependencies']['requirements_file'] = True
+    molecule_instance.config.config['dependency']['requirements_file'] = True
 
     d = dependency.Dependency({}, {}, molecule_instance)
     d.execute()
@@ -33,7 +33,7 @@ def test_execute(patched_ansible_galaxy, molecule_instance):
 
 def test_execute_does_not_install_when_installed(patched_ansible_galaxy,
                                                  molecule_instance):
-    molecule_instance.config.config['dependencies']['requirements_file'] = True
+    molecule_instance.config.config['dependency']['requirements_file'] = True
     molecule_instance.state.change_state('installed_deps', True)
 
     d = dependency.Dependency({}, {}, molecule_instance)
@@ -43,8 +43,8 @@ def test_execute_does_not_install_when_installed(patched_ansible_galaxy,
 
 
 def test_execute_shell(patched_shell, molecule_instance):
-    molecule_instance.dependencies = 'shell'
-    molecule_instance.config.config['dependencies']['command'] = True
+    molecule_instance.dependency = 'shell'
+    molecule_instance.config.config['dependency']['command'] = True
 
     d = dependency.Dependency({}, {}, molecule_instance)
     d.execute()
@@ -55,8 +55,8 @@ def test_execute_shell(patched_shell, molecule_instance):
 
 def test_execute_shell_does_not_install_when_installed(patched_shell,
                                                        molecule_instance):
-    molecule_instance.dependencies = 'shell'
-    molecule_instance.config.config['dependencies']['command'] = True
+    molecule_instance.dependency = 'shell'
+    molecule_instance.config.config['dependency']['command'] = True
     molecule_instance.state.change_state('installed_deps', True)
 
     d = dependency.Dependency({}, {}, molecule_instance)

--- a/test/unit/command/test_syntax.py
+++ b/test/unit/command/test_syntax.py
@@ -37,7 +37,7 @@ def test_execute(mocker, patched_ansible_playbook, patched_print_info,
 def test_execute_installs_dependencies(patched_ansible_playbook,
                                        patched_dependency, patched_print_info,
                                        molecule_instance):
-    molecule_instance.config.config['dependencies']['requirements_file'] = str(
+    molecule_instance.config.config['dependency']['requirements_file'] = str(
     )
 
     s = syntax.Syntax({}, {}, molecule_instance)

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -269,7 +269,7 @@ def ansible_v1_section_data(playbook):
             'name': 'testinfra',
             'options': {}
         },
-        'dependencies': {
+        'dependency': {
             'name': 'galaxy',
             'options': {}
         },

--- a/test/unit/core/test_core.py
+++ b/test/unit/core/test_core.py
@@ -81,14 +81,14 @@ def test_verifier_disabled(molecule_instance):
     assert [] == molecule_instance.disabled
 
 
-def test_dependencies_setter(molecule_instance):
-    molecule_instance.dependencies = 'foo'
+def test_dependency_setter(molecule_instance):
+    molecule_instance.dependency = 'foo'
 
-    assert 'foo' == molecule_instance.dependencies
+    assert 'foo' == molecule_instance.dependency
 
 
-def test_dependencies(molecule_instance):
-    assert 'galaxy' == molecule_instance.dependencies
+def test_dependency(molecule_instance):
+    assert 'galaxy' == molecule_instance.dependency
 
 
 @pytest.mark.skip(reason='TODO(retr0h): Determine best way to test this')

--- a/test/unit/dependency/test_ansible_galaxy.py
+++ b/test/unit/dependency/test_ansible_galaxy.py
@@ -29,7 +29,7 @@ from molecule.dependency import ansible_galaxy
 def ansible_galaxy_instance(temp_files):
     confs = temp_files(fixtures=['molecule_vagrant_v1_config'])
     c = config.ConfigV1(configs=confs)
-    c.config['dependencies']['requirements_file'] = 'requirements.yml'
+    c.config['dependency']['requirements_file'] = 'requirements.yml'
 
     return ansible_galaxy.AnsibleGalaxy(c.config)
 
@@ -58,7 +58,7 @@ def test_execute(patched_ansible_galaxy, ansible_galaxy_instance):
 
 
 def test_execute_overrides(patched_ansible_galaxy, ansible_galaxy_instance):
-    ansible_galaxy_instance._config['dependencies']['options'] = {
+    ansible_galaxy_instance._config['dependency']['options'] = {
         'foo': 'bar',
         'force': False
     }

--- a/test/unit/dependency/test_shell.py
+++ b/test/unit/dependency/test_shell.py
@@ -29,7 +29,7 @@ from molecule.dependency import shell
 def shell_instance(temp_files):
     confs = temp_files(fixtures=['molecule_vagrant_v1_config'])
     c = config.ConfigV1(configs=confs)
-    c.config['dependencies']['command'] = 'ls -l -a /tmp'
+    c.config['dependency']['command'] = 'ls -l -a /tmp'
 
     return shell.Shell(c.config)
 


### PR DESCRIPTION
Should follow suit with singular form of molecule config sections.
This functionality was added in 1.14, and this follow-up corrects
the usage, before 1.14 was utilized.

Breaking Change: The galaxy override options have been moved to the
`dependency` section of molecule's config.  No longer support a top
level `dependencies` config key.