### PR TITLE
Correct RTD link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -164,7 +164,7 @@ Update the role with needed functionality and tests.  Now test it:
 Documentation
 =============
 
-https://molecule.readthedocs.io/en/latest/
+https://molecule.readthedocs.io/
 
 License
 =======


### PR DESCRIPTION
Allow RTD to manage the version which it believes is latest.