### PR TITLE
Removed logger usage from base

### DIFF
--- a/molecule/ansible_playbook.py
+++ b/molecule/ansible_playbook.py
@@ -184,6 +184,6 @@ class AnsiblePlaybook(object):
                 self._ansible, debug=self._debug).stdout
         except (sh.ErrorReturnCode, sh.ErrorReturnCode_2) as e:
             if not hide_errors:
-                LOG.error('ERROR: {}'.format(e))
+                util.print_error(str(e))
 
             return e.exit_code, None

--- a/molecule/command/base.py
+++ b/molecule/command/base.py
@@ -24,8 +24,6 @@ from molecule import config
 from molecule import core
 from molecule import util
 
-LOG = util.get_logger(__name__)
-
 
 class InvalidHost(Exception):
     """
@@ -72,8 +70,9 @@ class Base(object):
         :returns: None
         """
         if not self._config.molecule_file_exists():
-            msg = 'Unable to find {}. Exiting.'
-            LOG.error(msg.format(self._config.molecule_file))
+            msg = ('Unable to find {}. '
+                   'Exiting.').format(self._config.molecule_file)
+            util.print_error(msg)
             util.sysexit()
         self.molecule.main()
 

--- a/molecule/command/check.py
+++ b/molecule/command/check.py
@@ -24,8 +24,6 @@ from molecule import ansible_playbook
 from molecule import util
 from molecule.command import base
 
-LOG = util.get_logger(__name__)
-
 
 class Check(base.Base):
     def execute(self, exit=True):
@@ -39,7 +37,7 @@ class Check(base.Base):
         if not self.molecule.state.created:
             msg = ('Instance(s) not created, `check` should be run '
                    'against created instance(s)')
-            LOG.error('ERROR: {}'.format(msg))
+            util.print_error(msg)
             util.sysexit()
 
         debug = self.args.get('debug')

--- a/molecule/command/converge.py
+++ b/molecule/command/converge.py
@@ -27,8 +27,6 @@ from molecule.command import base
 from molecule.command import create
 from molecule.command import dependency
 
-LOG = util.get_logger(__name__)
-
 
 class Converge(base.Base):
     def execute(self,

--- a/molecule/command/create.py
+++ b/molecule/command/create.py
@@ -24,8 +24,6 @@ import subprocess
 from molecule import util
 from molecule.command import base
 
-LOG = util.get_logger(__name__)
-
 
 class Create(base.Base):
     def execute(self, exit=True):
@@ -46,7 +44,7 @@ class Create(base.Base):
             if self.command_args.get('platform') == 'all':
                 self.molecule.state.change_state('multiple_platforms', True)
         except subprocess.CalledProcessError as e:
-            LOG.error('ERROR: {}'.format(e))
+            util.print_error(str(e))
             if exit:
                 util.sysexit(e.returncode)
             return e.returncode, e.message

--- a/molecule/command/dependency.py
+++ b/molecule/command/dependency.py
@@ -25,8 +25,6 @@ from molecule.command import base
 from molecule.dependency import ansible_galaxy
 from molecule.dependency import shell
 
-LOG = util.get_logger(__name__)
-
 
 class Dependency(base.Base):
     def execute(self, exit=True):
@@ -42,21 +40,21 @@ class Dependency(base.Base):
             return (None, None)
         dependency_name = self.molecule.dependency
         if dependency_name == 'galaxy':
-            msg = "Downloading dependencies with '{}' ...".format(
-                dependency_name)
-            util.print_info(msg)
             dd = self.molecule.config.config.get('dependency')
             if dd.get('requirements_file'):
+                msg = "Downloading dependencies with '{}' ...".format(
+                    dependency_name)
+                util.print_info(msg)
                 g = ansible_galaxy.AnsibleGalaxy(
                     self.molecule.config.config, debug=debug)
                 g.execute()
                 self.molecule.state.change_state('installed_deps', True)
         elif dependency_name == 'shell':
-            msg = "Downloading dependencies with '{}' ...".format(
-                dependency_name)
-            util.print_info(msg)
             dd = self.molecule.config.config.get('dependency')
             if dd.get('command'):
+                msg = "Downloading dependencies with '{}' ...".format(
+                    dependency_name)
+                util.print_info(msg)
                 s = shell.Shell(self.molecule.config.config, debug=debug)
                 s.execute()
                 self.molecule.state.change_state('installed_deps', True)

--- a/molecule/command/destroy.py
+++ b/molecule/command/destroy.py
@@ -24,8 +24,6 @@ import subprocess
 from molecule import util
 from molecule.command import base
 
-LOG = util.get_logger(__name__)
-
 
 class Destroy(base.Base):
     def execute(self, exit=True):
@@ -44,7 +42,7 @@ class Destroy(base.Base):
             self.molecule.driver.destroy()
             self.molecule.state.reset()
         except subprocess.CalledProcessError as e:
-            LOG.error('ERROR: {}'.format(e))
+            util.print_error(str(e))
             if exit:
                 util.sysexit(e.returncode)
             return e.returncode, e.message

--- a/molecule/command/idempotence.py
+++ b/molecule/command/idempotence.py
@@ -26,8 +26,6 @@ from molecule import util
 from molecule.command import base
 from molecule.command import converge
 
-LOG = util.get_logger(__name__)
-
 
 class Idempotence(base.Base):
     def execute(self, exit=True):
@@ -56,9 +54,9 @@ class Idempotence(base.Base):
             util.print_success('Idempotence test passed.')
             return None, None
         else:
-            LOG.error(
-                'Idempotence test failed because of the following tasks:')
-            LOG.error('\n'.join(self._non_idempotent_tasks(output)))
+            msg = 'Idempotence test failed because of the following tasks:'
+            util.print_error(msg)
+            util.print_error('\n'.join(self._non_idempotent_tasks(output)))
             if exit:
                 util.sysexit()
 

--- a/molecule/command/init.py
+++ b/molecule/command/init.py
@@ -25,8 +25,6 @@ import click
 from molecule import util
 from molecule.command import base
 
-LOG = util.get_logger(__name__)
-
 
 class Init(base.Base):
     def main(self):
@@ -55,13 +53,15 @@ class Init(base.Base):
             self._init_existing_role(role, role_path, driver, verifier)
         else:
             if os.path.isdir(role):
-                msg = 'The directory {} exists. Cannot create new role.'
-                LOG.error(msg.format(role))
+                msg = ('The directory {} exists. '
+                       'Cannot create new role.').format(role)
+                util.print_error(msg)
                 util.sysexit()
             self._init_new_role(role, role_path, driver, verifier)
 
-        msg = 'Successfully initialized new role in {} ...'
-        util.print_success(msg.format(os.path.join(role_path, role)))
+        path = os.path.join(role_path, role)
+        msg = 'Successfully initialized new role in {} ...'.format(path)
+        util.print_success(msg)
         util.sysexit(0)
 
     def _init_existing_role(self, role, role_path, driver, verifier):

--- a/molecule/command/list.py
+++ b/molecule/command/list.py
@@ -23,8 +23,6 @@ import click
 from molecule import util
 from molecule.command import base
 
-LOG = util.get_logger(__name__)
-
 
 class List(base.Base):
     def execute(self, exit=True):

--- a/molecule/command/login.py
+++ b/molecule/command/login.py
@@ -32,8 +32,6 @@ import click
 from molecule import util
 from molecule.command import base
 
-LOG = util.get_logger(__name__)
-
 
 class Login(base.Base):
     def execute(self, exit=True):
@@ -91,12 +89,13 @@ class Login(base.Base):
                 hostname = match[0]
 
         except subprocess.CalledProcessError:
-            msg = "Unknown host '{}'.\n\nAvailable hosts:\n{}"
-            LOG.error(
-                msg.format(self.command_args.get('host'), '\n'.join(hosts)))
+            msg = ("Unknown host '{}'.\n\n"
+                   "Available hosts:\n{}").format(
+                       self.command_args.get('host'), '\n'.join(hosts))
+            util.print_error(msg)
             util.sysexit()
         except base.InvalidHost as e:
-            LOG.error(e.message)
+            util.print_error(e.message)
             util.sysexit()
 
         self._get_login(hostname)

--- a/molecule/command/status.py
+++ b/molecule/command/status.py
@@ -25,8 +25,6 @@ import click
 from molecule import util
 from molecule.command import base
 
-LOG = util.get_logger(__name__)
-
 
 class Status(base.Base):
     def execute(self, exit=True):
@@ -48,7 +46,7 @@ class Status(base.Base):
         # TODO(retr0h): Pretty sure this handling is wrong.  We don't always
         # shell out for status.
         except subprocess.CalledProcessError as e:
-            LOG.error(e.message)
+            util.print_error(e.message)
             return e.returncode, e.message
 
         # Display the results in procelain mode.

--- a/molecule/command/syntax.py
+++ b/molecule/command/syntax.py
@@ -25,8 +25,6 @@ from molecule import util
 from molecule.command import base
 from molecule.command import dependency
 
-LOG = util.get_logger(__name__)
-
 
 class Syntax(base.Base):
     def execute(self, exit=True):

--- a/molecule/command/test.py
+++ b/molecule/command/test.py
@@ -24,8 +24,6 @@ import molecule.command  # prevent circular dependencies
 from molecule import util
 from molecule.command import base
 
-LOG = util.get_logger(__name__)
-
 
 class Test(base.Base):
     def execute(self, exit=True):
@@ -48,7 +46,7 @@ class Test(base.Base):
             # Fail fast
             if status is not 0 and status is not None:
                 if output:
-                    LOG.error(output)
+                    util.print_error(output)
                 util.sysexit(status)
 
         if self.command_args.get('destroy') == 'always':

--- a/molecule/command/verify.py
+++ b/molecule/command/verify.py
@@ -29,8 +29,6 @@ from molecule.verifier import serverspec
 from molecule.verifier import testinfra
 from molecule.verifier import trailing
 
-LOG = util.get_logger(__name__)
-
 
 class Verify(base.Base):
     def execute(self, exit=True):
@@ -62,7 +60,7 @@ class Verify(base.Base):
 
             v.execute()
         except sh.ErrorReturnCode as e:
-            LOG.error('ERROR: {}'.format(e))
+            util.print_error(str(e))
             if exit:
                 util.sysexit(e.exit_code)
             return e.exit_code, e.stdout

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -28,8 +28,6 @@ from molecule import state
 from molecule import util
 from molecule.driver import basedriver
 
-LOG = util.get_logger(__name__)
-
 
 class Molecule(object):
     def __init__(self, config, args):
@@ -57,18 +55,21 @@ class Molecule(object):
         try:
             self.driver = self._get_driver()
         except basedriver.InvalidDriverSpecified:
-            LOG.error("Invalid driver '{}'".format(self._get_driver_name()))
+            msg = "Invalid driver '{}'".format(self._get_driver_name())
+            util.print_error(msg)
             # TODO(retr0h): Print valid drivers.
             util.sysexit()
         except basedriver.InvalidProviderSpecified:
-            LOG.error("Invalid provider '{}'".format(self.args['provider']))
+            msg = "Invalid provider '{}'".format(self.args['provider'])
+            util.print_error(msg)
             self.args['provider'] = None
             self.args['platform'] = None
             self.driver = self._get_driver()
             self.print_valid_providers()
             util.sysexit()
         except basedriver.InvalidPlatformSpecified:
-            LOG.error("Invalid platform '{}'".format(self.args['platform']))
+            msg = "Invalid platform '{}'".format(self.args['platform'])
+            util.print_error(msg)
             self.args['provider'] = None
             self.args['platform'] = None
             self.driver = self._get_driver()
@@ -120,9 +121,7 @@ class Molecule(object):
 
     def print_valid_platforms(self, porcelain=False):
         if not porcelain:
-            # NOTE(retr0h): Should we log here, when ``display_tabulate_data``
-            # prints?
-            LOG.info("AVAILABLE PLATFORMS")
+            util.print_info("AVAILABLE PLATFORMS")
 
         data = []
         default_platform = self.driver.default_platform
@@ -138,9 +137,7 @@ class Molecule(object):
 
     def print_valid_providers(self, porcelain=False):
         if not porcelain:
-            # NOTE(retr0h): Should we log here, when ``display_tabulate_data``
-            # prints?
-            LOG.info("AVAILABLE PROVIDERS")
+            util.print_info("AVAILABLE PROVIDERS")
 
         data = []
         default_provider = self.driver.default_provider
@@ -229,8 +226,9 @@ class Molecule(object):
         try:
             util.write_file(inventory_file, inventory)
         except IOError:
-            LOG.warning('WARNING: could not write inventory file {}'.format(
-                inventory_file))
+            msg = 'WARNING: could not write inventory file {}'.format(
+                inventory_file)
+            util.print_warn(msg)
 
     def remove_inventory_file(self):
         if os._exists(self.config.config['ansible']['inventory_file']):
@@ -287,7 +285,7 @@ class Molecule(object):
         if (self.state.driver is not None) and (self.state.driver != driver):
             msg = ("ERROR: Instance(s) were converged with the '{}' driver, "
                    "but the subcommand is using '{}' driver.")
-            LOG.error(msg.format(self.state.driver, driver))
+            util.print_error(msg.format(self.state.driver, driver))
             util.sysexit()
 
         if driver == 'vagrant':

--- a/molecule/dependency/ansible_galaxy.py
+++ b/molecule/dependency/ansible_galaxy.py
@@ -106,5 +106,5 @@ class AnsibleGalaxy(object):
         try:
             return util.run_command(self._galaxy, debug=self._debug).stdout
         except sh.ErrorReturnCode as e:
-            LOG.error('ERROR: {}'.format(e))
+            util.print_error(str(e))
             util.sysexit(e.exit_code)

--- a/molecule/dependency/shell.py
+++ b/molecule/dependency/shell.py
@@ -79,5 +79,5 @@ class Shell(object):
         try:
             return util.run_command(self._command, debug=self._debug).stdout
         except sh.ErrorReturnCode as e:
-            LOG.error('ERROR: {}'.format(e))
+            util.print_error(str(e))
             util.sysexit(e.exit_code)

--- a/molecule/driver/dockerdriver.py
+++ b/molecule/driver/dockerdriver.py
@@ -31,8 +31,6 @@ except ImportError:
 from molecule import util
 from molecule.driver import basedriver
 
-LOG = util.get_logger(__name__)
-
 
 class DockerDriver(basedriver.BaseDriver):
     def __init__(self, molecule):
@@ -135,10 +133,11 @@ class DockerDriver(basedriver.BaseDriver):
                 cap_drop=cap_drop)
 
             if (container['created'] is not True):
-                LOG.warning(
-                    'Creating container {} with base image {}:{} ...'.format(
-                        container['name'], container['image'],
-                        container['image_version']), )
+                msg = ('Creating container {} '
+                       'with base image {}:{} ...').format(
+                           container['name'], container['image'],
+                           container['image_version'])
+                util.print_warn(msg)
                 container = self._docker.create_container(
                     image=self.image_tag.format(container['image'],
                                                 container['image_version']),
@@ -155,18 +154,18 @@ class DockerDriver(basedriver.BaseDriver):
                 util.print_success('Container created.')
             else:
                 self._docker.start(container['name'])
-                util.print_success('Starting container {} ...'.format(
-                    container['name']))
+                msg = 'Starting container {} ...'.format(container['name'])
+                util.print_success(msg)
 
     def destroy(self):
         for container in self.instances:
             if (container['created']):
-                LOG.warning('Stopping container {} ...'.format(container[
-                    'name']))
+                msg = 'Stopping container {} ...'.format(container['name'])
+                util.print_warn(msg)
                 self._docker.stop(container['name'], timeout=0)
                 self._docker.remove_container(container['name'])
-                util.print_success('Removed container {}.'.format(container[
-                    'name']))
+                msg = 'Removed container {}.'.format(container['name'])
+                util.print_success(msg)
                 container['created'] = False
 
     def status(self):
@@ -220,9 +219,10 @@ class DockerDriver(basedriver.BaseDriver):
 
         for container in self.instances:
             if container.get('build_image'):
-                util.print_info(
-                    "Creating Ansible compatible image of {}:{} ...".format(
-                        container['image'], container['image_version']))
+                msg = ('Creating Ansible compatible '
+                       'image of {}:{} ...').format(container['image'],
+                                                    container['image_version'])
+                util.print_info(msg)
 
             if 'registry' in container:
                 container['registry'] += '/'
@@ -274,19 +274,22 @@ class DockerDriver(basedriver.BaseDriver):
                         if len(line_split) > 0:
                             line = json.loads(line_split)
                             if 'stream' in line:
-                                LOG.warning('\t{}'.format(line['stream']))
+                                msg = '\t{}'.format(line['stream'])
+                                util.print_warn(msg)
                             if 'errorDetail' in line:
-                                LOG.warning('\t{}'.format(line['errorDetail'][
-                                    'message']))
+                                ed = line['errorDetail']['message']
+                                msg = '\t{}'.format(ed)
+                                util.print_warn(msg)
                                 errors = True
                             if 'status' in line:
                                 if previous_line not in line['status']:
-                                    LOG.warning('\t{} ...'.format(line[
-                                        'status']))
+                                    msg = '\t{} ...'.format(line['status'])
+                                    util.print_warn(msg)
                                 previous_line = line['status']
 
                 if errors:
-                    LOG.error('Build failed for {}'.format(tag_string))
+                    msg = 'Build failed for {}'.format(tag_string)
+                    util.print_error(msg)
                     return
                 else:
                     util.print_success('Finished building {}'.format(

--- a/molecule/driver/openstackdriver.py
+++ b/molecule/driver/openstackdriver.py
@@ -34,8 +34,6 @@ except ImportError:
 from molecule import util
 from molecule.driver import basedriver
 
-LOG = util.get_logger(__name__)
-
 
 class OpenstackDriver(basedriver.BaseDriver):
     def __init__(self, molecule):
@@ -110,10 +108,11 @@ class OpenstackDriver(basedriver.BaseDriver):
             for instance in active_instances
         }
 
-        LOG.warning("Creating openstack instances ...")
+        util.print_warn("Creating openstack instances ...")
         for instance in self.instances:
             if instance['name'] not in active_instance_names:
-                LOG.info("\tBringing up {}".format(instance['name']))
+                msg = "\tBringing up {}".format(instance['name'])
+                util.print_info(msg)
                 server = self._openstack.create_server(
                     name=instance['name'],
                     image=self._openstack.get_image(instance['image']),
@@ -132,11 +131,11 @@ class OpenstackDriver(basedriver.BaseDriver):
                         timeout=6,
                         sshkey_filename=self._get_keyfile(
                         )) or num_retries == 5:
-                    LOG.info("\t Waiting for ssh availability ...")
+                    util.print_info("\t Waiting for ssh availability ...")
                     num_retries += 1
 
     def destroy(self):
-        LOG.info("Deleting openstack instances ...")
+        util.print_info("Deleting openstack instances ...")
 
         active_instances = self._openstack.list_servers()
         active_instance_names = {
@@ -145,11 +144,12 @@ class OpenstackDriver(basedriver.BaseDriver):
         }
 
         for instance in self.instances:
-            LOG.warning("\tRemoving {} ...".format(instance['name']))
+            util.print_warn("\tRemoving {} ...".format(instance['name']))
             if instance['name'] in active_instance_names:
                 if not self._openstack.delete_server(
                         active_instance_names[instance['name']], wait=True):
-                    LOG.error("Unable to remove {}!".format(instance['name']))
+                    msg = "Unable to remove {}!".format(instance['name'])
+                    util.print_error(msg)
                 else:
                     util.print_success('\tRemoved {}'.format(instance['name']))
                     instance['created'] = False
@@ -242,7 +242,8 @@ class OpenstackDriver(basedriver.BaseDriver):
         kpn = self._get_temp_keyname()
 
         if not self._openstack.search_keypairs(kpn):
-            LOG.info("\tCreating openstack keypair {} ...".format(kpn))
+            msg = "\tCreating openstack keypair {} ...".format(kpn)
+            util.print_info(msg)
             pub_key_file = self._get_keyfile() + '.pub'
             self._openstack.create_keypair(kpn,
                                            open(pub_key_file,
@@ -257,7 +258,7 @@ class OpenstackDriver(basedriver.BaseDriver):
         publoc = kl + '/' + kn + '.pub'
 
         if not os.path.exists(pvtloc):
-            LOG.info("\tCreating local ssh key {} ...".format(pvtloc))
+            util.print_info("\tCreating local ssh key {} ...".format(pvtloc))
             k = paramiko.RSAKey.generate(2048)
             k.write_private_key_file(pvtloc)
             # write the public key too
@@ -298,13 +299,14 @@ class OpenstackDriver(basedriver.BaseDriver):
         if ('keypair' not in self.molecule.config.config['openstack']):
             kpn = self._get_temp_keyname()
             if self._openstack.search_keypairs(kpn):
-                LOG.warning("\tRemoving openstack keypair {} ...".format(kpn))
+                msg = "\tRemoving openstack keypair {} ...".format(kpn)
+                util.print_warn(msg)
                 if not self._openstack.delete_keypair(kpn):
-                    LOG.error("Unable to remove openstack keypair {}!".format(
-                        kpn))
+                    msg = "Unable to remove openstack keypair {}!".format(kpn)
+                    util.print_error(msg)
                 else:
-                    util.print_success('\tRemoved openstack keypair {}'.format(
-                        kpn))
+                    msg = '\tRemoved openstack keypair {}'.format(kpn)
+                    util.print_success(msg)
 
     def _cleanup_temp_keyfile(self):
         # if we don't have a keyfile config, delete the temp one
@@ -314,10 +316,10 @@ class OpenstackDriver(basedriver.BaseDriver):
             pvtloc = kl + '/' + kn
             publoc = kl + '/' + kn + '.pub'
             if os.path.exists(pvtloc):
-                LOG.warning("\tRemoving {} ...".format(pvtloc))
+                util.print_warn("\tRemoving {} ...".format(pvtloc))
                 os.remove(pvtloc)
             if os.path.exists(publoc):
-                LOG.warning("\tRemoving {} ...".format(publoc))
+                util.print_warn("\tRemoving {} ...".format(publoc))
                 os.remove(publoc)
 
     def _host_template(self):

--- a/molecule/util.py
+++ b/molecule/util.py
@@ -61,9 +61,7 @@ def get_logger(name=None):
     logger.setLevel(logging.DEBUG)
 
     logger.addHandler(_get_info_logger())
-    logger.addHandler(_get_warn_logger())
     logger.addHandler(_get_error_logger())
-    logger.addHandler(_get_debug_logger())
     logger.propagate = False
 
     return logger
@@ -97,6 +95,14 @@ def print_debug(title, data):
     ]))
 
 
+def print_warn(msg):
+    print('{}{}'.format(colorama.Fore.YELLOW, msg.rstrip()))
+
+
+def print_error(msg):
+    print('{}ERROR: {}'.format(colorama.Fore.RED, msg.rstrip()))
+
+
 def write_template(src, dest, kwargs={}, _module='molecule', _dir='template'):
     """
     Writes a file from a jinja2 template and returns None.
@@ -115,11 +121,11 @@ def write_template(src, dest, kwargs={}, _module='molecule', _dir='template'):
     src = os.path.expanduser(src)
     path = os.path.dirname(src)
     filename = os.path.basename(src)
-    log = get_logger(__name__)
 
     # template file doesn't exist
     if path and not os.path.isfile(src):
-        log.error('Unable to locate template file: {}'.format(src))
+        msg = 'Unable to locate template file: {}'.format(src)
+        print_error(msg)
         sysexit()
 
     # look for template in filesystem, then molecule package
@@ -244,26 +250,6 @@ def _get_info_logger():
     info.setFormatter(TrailingNewlineFormatter('%(message)s'))
 
     return info
-
-
-def _get_warn_logger():
-    warn = logging.StreamHandler(sys.stdout)
-    warn.setLevel(logging.WARN)
-    warn.addFilter(LogFilter(logging.WARN))
-    warn.setFormatter(
-        TrailingNewlineFormatter('{}%(message)s'.format(colorama.Fore.YELLOW)))
-
-    return warn
-
-
-def _get_debug_logger():
-    debug = logging.StreamHandler(sys.stdout)
-    debug.setLevel(logging.DEBUG)
-    debug.addFilter(LogFilter(logging.DEBUG))
-    debug.setFormatter(
-        TrailingNewlineFormatter('{}%(message)s'.format(colorama.Fore.BLUE)))
-
-    return debug
 
 
 def _get_error_logger():

--- a/molecule/verifier/trailing.py
+++ b/molecule/verifier/trailing.py
@@ -24,8 +24,6 @@ import re
 from molecule import util
 from molecule.verifier import base
 
-LOG = util.get_logger(__name__)
-
 
 class Trailing(base.Base):
     def __init__(self, molecule):
@@ -81,16 +79,17 @@ class Trailing(base.Base):
             whitespace = self._trailing_whitespace(data)
 
             if newline:
-                msg = 'Trailing newline found at the end of {}'
-                LOG.error(msg.format(filename))
+                msg = 'Trailing newline found at the end of {}'.format(
+                    filename)
+                util.print_error(msg)
                 found_error = True
 
             if len(whitespace) > 0:
                 msg = 'Trailing whitespace found in {} on lines: {}'
                 lines = ', '.join(str(x) for x in whitespace)
-                LOG.error(msg.format(
+                util.print_error(msg.format(
                     filename,
-                    lines, ))
+                    lines))
                 found_error = True
 
         if exit and found_error:

--- a/test/functional/test_docker_scenarios.py
+++ b/test/functional/test_docker_scenarios.py
@@ -61,7 +61,7 @@ def test_command_idempotence(scenario_setup):
     try:
         sh.molecule('test')
     except sh.ErrorReturnCode_1 as e:
-        assert re.search('Idempotence test failed.', e.message)
+        assert re.search('Idempotence test failed.', e.stdout)
 
 
 def test_command_init(temp_dir):

--- a/test/unit/command/conftest.py
+++ b/test/unit/command/conftest.py
@@ -96,11 +96,6 @@ def patched_verify(mocker):
 
 
 @pytest.fixture
-def patched_print_info(mocker):
-    return mocker.patch('molecule.util.print_info')
-
-
-@pytest.fixture
 def patched_create_inventory(mocker):
     return mocker.patch('molecule.core.Molecule.create_inventory_file')
 

--- a/test/unit/command/test_base.py
+++ b/test/unit/command/test_base.py
@@ -40,11 +40,11 @@ def test_main(mocker, molecule_instance):
     patched_molecule_main.assert_called_once()
 
 
-def test_main_exits_when_missing_config(patched_logger_error,
+def test_main_exits_when_missing_config(patched_print_error,
                                         molecule_instance):
     foo = Foo({}, {}, molecule_instance)
     with pytest.raises(SystemExit):
         foo.main()
 
     msg = 'Unable to find molecule.yml. Exiting.'
-    patched_logger_error.assert_called_once_with(msg)
+    patched_print_error.assert_called_once_with(msg)

--- a/test/unit/command/test_check.py
+++ b/test/unit/command/test_check.py
@@ -24,15 +24,15 @@ from molecule.command import check
 
 
 def test_execute_raises_when_instance_not_created(
-        patched_check_main, patched_logger_error, molecule_instance):
+        patched_check_main, patched_print_error, molecule_instance):
     c = check.Check({}, {}, molecule_instance)
 
     with pytest.raises(SystemExit):
         c.execute()
 
-    msg = ('ERROR: Instance(s) not created, `check` should be run against '
+    msg = ('Instance(s) not created, `check` should be run against '
            'created instance(s)')
-    patched_logger_error.assert_called_once_with(msg)
+    patched_print_error.assert_called_once_with(msg)
 
 
 def test_execute(mocker, patched_check_main, patched_ansible_playbook,

--- a/test/unit/command/test_converge.py
+++ b/test/unit/command/test_converge.py
@@ -30,11 +30,8 @@ def test_execute_creates_instances(
     c = converge.Converge({}, {}, molecule_instance)
     result = c.execute()
 
-    expected = [
-        mocker.call("Downloading dependencies with 'galaxy' ..."),
-        mocker.call('Starting Ansible Run ...')
-    ]
-    assert expected == patched_print_info.mock_calls
+    msg = 'Starting Ansible Run ...'
+    patched_print_info.assert_called_with(msg)
 
     patched_ansible_playbook.assert_called_once_with(hide_errors=True)
     assert (None, None) == result

--- a/test/unit/command/test_create.py
+++ b/test/unit/command/test_create.py
@@ -54,23 +54,23 @@ def test_execute_creates_instances_with_platform_all(
 
 def test_execute_raises_on_exit(
         patched_driver_up, patched_create_templates, patched_remove_inventory,
-        patched_create_inventory, patched_logger_error,
+        patched_create_inventory, patched_print_error,
         patched_write_instances_state, molecule_instance):
     patched_driver_up.side_effect = subprocess.CalledProcessError(1, None,
                                                                   None)
     c = create.Create({}, {}, molecule_instance)
     with pytest.raises(SystemExit):
         c.execute()
-    msg = "ERROR: Command 'None' returned non-zero exit status 1"
-    patched_logger_error.assert_called_with(msg)
+    msg = "Command 'None' returned non-zero exit status 1"
+    patched_print_error.assert_called_with(msg)
     assert not patched_create_inventory.called
     assert not patched_write_instances_state.called
 
 
 def test_execute_does_not_raise_on_exit(
         patched_driver_up, patched_create_templates, patched_remove_inventory,
-        patched_create_inventory, patched_logger_error,
-        patched_write_instances_state, molecule_instance):
+        patched_create_inventory, patched_write_instances_state,
+        molecule_instance):
     patched_driver_up.side_effect = subprocess.CalledProcessError(1, None,
                                                                   None)
     c = create.Create({}, {}, molecule_instance)

--- a/test/unit/command/test_destroy.py
+++ b/test/unit/command/test_destroy.py
@@ -44,7 +44,7 @@ def test_execute_deletes_instances(
 
 
 def test_execute_raises_on_exit(patched_driver_destroy, patched_print_info,
-                                patched_logger_error, patched_remove_templates,
+                                patched_print_error, patched_remove_templates,
                                 patched_remove_inventory, molecule_instance):
     patched_driver_destroy.side_effect = subprocess.CalledProcessError(1, None,
                                                                        None)
@@ -53,16 +53,15 @@ def test_execute_raises_on_exit(patched_driver_destroy, patched_print_info,
     with pytest.raises(SystemExit):
         d.execute()
 
-    msg = "ERROR: Command 'None' returned non-zero exit status 1"
-    patched_logger_error.assert_called_with(msg)
+    msg = "Command 'None' returned non-zero exit status 1"
+    patched_print_error.assert_called_with(msg)
 
     assert not patched_remove_templates.called
     assert not patched_remove_inventory.called
 
 
-def test_execute_does_not_raise_on_exit(
-        patched_driver_destroy, patched_print_info, patched_logger_error,
-        molecule_instance):
+def test_execute_does_not_raise_on_exit(patched_driver_destroy,
+                                        patched_print_info, molecule_instance):
     patched_driver_destroy.side_effect = subprocess.CalledProcessError(1, None,
                                                                        None)
     d = destroy.Destroy({}, {}, molecule_instance)

--- a/test/unit/command/test_idempotence.py
+++ b/test/unit/command/test_idempotence.py
@@ -49,7 +49,7 @@ def test_execute_does_not_raise_on_converge_error(
 
 
 def test_execute_does_not_raise_on_idempotence_failure(
-        mocker, patched_converge, patched_logger_error, molecule_instance):
+        mocker, patched_converge, patched_print_error, molecule_instance):
     output = 'check-command-01: ok=2    changed=1    unreachable=0    failed=0'
     patched_converge.return_value = None, output
 
@@ -60,12 +60,12 @@ def test_execute_does_not_raise_on_idempotence_failure(
         mocker.call('Idempotence test failed because of the following tasks:'),
         mocker.call('')
     ]
-    assert patched_logger_error.mock_calls == expected_calls
+    assert patched_print_error.mock_calls == expected_calls
     assert (1, None) == result
 
 
 def test_execute_raises_on_idempotence_failure(
-        mocker, patched_converge, patched_logger_error, molecule_instance):
+        mocker, patched_converge, patched_print_error, molecule_instance):
     output = 'check-command-01: ok=2    changed=1    unreachable=0    failed=0'
     patched_converge.return_value = None, output
 
@@ -77,7 +77,7 @@ def test_execute_raises_on_idempotence_failure(
         mocker.call('Idempotence test failed because of the following tasks:'),
         mocker.call('')
     ]
-    assert patched_logger_error.mock_calls == expected_calls
+    assert patched_print_error.mock_calls == expected_calls
 
 
 def test_non_idempotent_tasks_idempotent(molecule_instance):

--- a/test/unit/command/test_login.py
+++ b/test/unit/command/test_login.py
@@ -23,18 +23,18 @@ import pytest
 from molecule.command import login
 
 
-def test_execute_raises_when_no_running_hosts(patched_logger_error,
+def test_execute_raises_when_no_running_hosts(patched_print_error,
                                               molecule_instance):
     l = login.Login({}, {}, molecule_instance)
     with pytest.raises(SystemExit):
         l.execute()
 
     msg = 'There are no running hosts.'
-    patched_logger_error.assert_called_once_with(msg)
+    patched_print_error.assert_called_once_with(msg)
 
 
 def test_execute_raises_when_no_host_privided_but_multiple_instances_exist(
-        patched_logger_error, molecule_instance):
+        patched_print_error, molecule_instance):
     molecule_instance.state.change_state('hosts', {'foo': None, 'baz': None})
     l = login.Login({}, {}, molecule_instance)
     with pytest.raises(SystemExit):
@@ -42,10 +42,10 @@ def test_execute_raises_when_no_host_privided_but_multiple_instances_exist(
 
     msg = ('There are 2 running hosts. Please specify which with --host.\n'
            '\nAvailable hosts:\nbaz\nfoo')
-    patched_logger_error.assert_called_once_with(msg)
+    patched_print_error.assert_called_once_with(msg)
 
 
-def test_execute_raises_when_host_unknown(patched_logger_error,
+def test_execute_raises_when_host_unknown(patched_print_error,
                                           molecule_instance):
     molecule_instance.state.change_state('hosts', {'foo': None})
     command_args = {'host': 'unknown'}
@@ -54,7 +54,7 @@ def test_execute_raises_when_host_unknown(patched_logger_error,
         l.execute()
 
     msg = "Unknown host 'unknown'.\n\nAvailable hosts:\nfoo"
-    patched_logger_error.assert_called_once_with(msg)
+    patched_print_error.assert_called_once_with(msg)
 
 
 def test_execute_single_instance(mocker, molecule_instance):
@@ -101,7 +101,7 @@ def test_execute_more_specific_hostname_match(mocker, molecule_instance):
 
 
 def test_execute_partial_hostname_raises_when_many_match(
-        mocker, patched_logger_error, molecule_instance):
+        mocker, patched_print_error, molecule_instance):
     molecule_instance.state.change_state('hosts', {'foo': None, 'fooo': None})
     command_args = {'host': 'fo'}
 
@@ -111,4 +111,4 @@ def test_execute_partial_hostname_raises_when_many_match(
 
     msg = ("There are 2 hosts that match 'fo'. You can only login to one at a "
            "time.\n\nAvailable hosts:\nfoo\nfooo")
-    patched_logger_error.assert_called_once_with(msg)
+    patched_print_error.assert_called_once_with(msg)

--- a/test/unit/command/test_status.py
+++ b/test/unit/command/test_status.py
@@ -51,7 +51,7 @@ def test_execute_with_porcelain(capsys, molecule_instance):
 
 
 def test_execute_exits_when_command_fails_and_exit_flag_set(
-        patched_logger_error, mocker, molecule_instance):
+        patched_print_error, mocker, molecule_instance):
     command_args = {'porcelain': True}
     patched_status = mocker.patch(
         'molecule.driver.vagrantdriver.VagrantDriver.status')
@@ -60,5 +60,5 @@ def test_execute_exits_when_command_fails_and_exit_flag_set(
     s = status.Status({}, command_args, molecule_instance)
     result = s.execute()
 
-    patched_logger_error.assert_called_once_with('')
+    patched_print_error.assert_called_once_with('')
     assert (1, '') == result

--- a/test/unit/command/test_syntax.py
+++ b/test/unit/command/test_syntax.py
@@ -28,11 +28,8 @@ def test_execute(mocker, patched_ansible_playbook, patched_print_info,
     s = syntax.Syntax({}, {}, molecule_instance)
     result = s.execute()
 
-    expected = [
-        mocker.call("Downloading dependencies with 'galaxy' ..."),
-        mocker.call("Checking playbook's syntax ...")
-    ]
-    assert expected == patched_print_info.mock_calls
+    msg = "Checking playbook's syntax ..."
+    patched_print_info.assert_called_once_with(msg)
 
     patched_ansible_playbook.assert_called_once_with(hide_errors=True)
     assert 'returned' == result

--- a/test/unit/command/test_test.py
+++ b/test/unit/command/test_test.py
@@ -44,7 +44,7 @@ def test_execute(mocker, patched_destroy_main, patched_destroy,
     assert (None, None) == result
 
 
-def test_execute_fail_fast(patched_destroy, patched_logger_error,
+def test_execute_fail_fast(patched_destroy, patched_print_error,
                            molecule_instance):
     patched_destroy.return_value = 1, 'output'
 
@@ -52,7 +52,7 @@ def test_execute_fail_fast(patched_destroy, patched_logger_error,
     with pytest.raises(SystemExit):
         t.execute()
 
-    patched_logger_error.assert_called_once_with('output')
+    patched_print_error.assert_called_once_with('output')
 
 
 def test_execute_always_destroy(

--- a/test/unit/command/test_verify.py
+++ b/test/unit/command/test_verify.py
@@ -81,7 +81,7 @@ def test_execute_with_goss(mocker, patched_ansible_lint, patched_trailing,
 
 def test_execute_exits_when_command_fails_and_exit_flag_set(
         mocker, patched_ansible_lint, patched_trailing, patched_ssh_config,
-        patched_logger_error, molecule_instance):
+        patched_print_error, molecule_instance):
     patched_testinfra = mocker.patch('molecule.verifier.testinfra.Testinfra')
     patched_testinfra.side_effect = sh.ErrorReturnCode_1(sh.ls, None, None)
 
@@ -89,19 +89,19 @@ def test_execute_exits_when_command_fails_and_exit_flag_set(
     with pytest.raises(SystemExit):
         v.execute()
 
-    msg = ("ERROR: \n\n  RAN: <Command '/bin/ls'>\n\n  "
+    msg = ("\n\n  RAN: <Command '/bin/ls'>\n\n  "
            "STDOUT:\n<redirected>\n\n  STDERR:\n<redirected>")
-    patched_logger_error.assert_called_once_with(msg)
+    patched_print_error.assert_called_once_with(msg)
 
 
 def test_execute_returns_when_command_fails_and_exit_flag_unset(
         mocker, patched_ansible_lint, patched_trailing, patched_ssh_config,
-        patched_logger_error, molecule_instance):
+        patched_print_error, molecule_instance):
     patched_testinfra = mocker.patch('molecule.verifier.testinfra.Testinfra')
     patched_testinfra.side_effect = sh.ErrorReturnCode_1(sh.ls, None, None)
 
     v = verify.Verify({}, {}, molecule_instance)
     result = v.execute(exit=False)
 
-    patched_logger_error.assert_called()
+    patched_print_error.assert_called()
     assert (1, None) == result

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -332,13 +332,18 @@ def patched_ansible_galaxy(patched_run_command):
 
 
 @pytest.fixture
-def patched_logger_error(mocker):
-    return mocker.patch('logging.Logger.error')
+def patched_print_info(mocker):
+    return mocker.patch('molecule.util.print_info')
 
 
 @pytest.fixture
 def patched_print_debug(mocker):
     return mocker.patch('molecule.util.print_debug')
+
+
+@pytest.fixture
+def patched_print_error(mocker):
+    return mocker.patch('molecule.util.print_error')
 
 
 @pytest.fixture()

--- a/test/unit/core/test_core_docker.py
+++ b/test/unit/core/test_core_docker.py
@@ -45,7 +45,7 @@ def test_print_valid_platforms(capsys, docker_molecule_instance):
     docker_molecule_instance.print_valid_platforms()
     out, _ = capsys.readouterr()
 
-    assert 'docker  (default)\n' == out
+    assert 'docker  (default)\n' in out
 
 
 def test_print_valid_platforms_with_porcelain(capsys,
@@ -60,7 +60,7 @@ def test_print_valid_providers(capsys, docker_molecule_instance):
     docker_molecule_instance.print_valid_providers()
     out, _ = capsys.readouterr()
 
-    assert 'docker  (default)\n' == out
+    assert 'docker  (default)\n' in out
 
 
 def test_print_valid_providers_with_porcelain(capsys,

--- a/test/unit/core/test_core_openstack.py
+++ b/test/unit/core/test_core_openstack.py
@@ -45,7 +45,7 @@ def test_print_valid_platforms(capsys, openstack_molecule_instance):
     openstack_molecule_instance.print_valid_platforms()
     out, _ = capsys.readouterr()
 
-    assert 'openstack  (default)\n' == out
+    assert 'openstack  (default)\n' in out
 
 
 def test_print_valid_platforms_with_porcelain(capsys,
@@ -60,7 +60,7 @@ def test_print_valid_providers(capsys, openstack_molecule_instance):
     openstack_molecule_instance.print_valid_providers()
     out, _ = capsys.readouterr()
 
-    assert 'openstack  (default)\n' == out
+    assert 'openstack  (default)\n' in out
 
 
 def test_print_valid_providers_with_porcelain(capsys,

--- a/test/unit/core/test_core_vagrant.py
+++ b/test/unit/core/test_core_vagrant.py
@@ -66,7 +66,7 @@ def test_print_valid_providers(capsys, vagrant_molecule_instance):
     vagrant_molecule_instance.print_valid_providers()
     out, _ = capsys.readouterr()
 
-    assert 'virtualbox  (default)\n' == out
+    assert 'virtualbox  (default)\n' in out
 
 
 def test_print_valid_providers_with_porcelain(capsys,

--- a/test/unit/dependency/test_ansible_galaxy.py
+++ b/test/unit/dependency/test_ansible_galaxy.py
@@ -74,7 +74,7 @@ def test_execute_overrides(patched_ansible_galaxy, ansible_galaxy_instance):
     assert expected == sorted(parts[2:])
 
 
-def test_execute_exits_with_return_code_and_logs(patched_logger_error,
+def test_execute_exits_with_return_code_and_logs(patched_print_error,
                                                  ansible_galaxy_instance):
     ansible_galaxy_instance._galaxy = sh.false.bake()
     with pytest.raises(SystemExit) as e:
@@ -82,5 +82,5 @@ def test_execute_exits_with_return_code_and_logs(patched_logger_error,
 
     assert 1 == e.value.code
 
-    msg = "ERROR: \n\n  RAN: '/usr/bin/false'\n\n  STDOUT:\n\n\n  STDERR:\n"
-    patched_logger_error.assert_called_once_with(msg)
+    msg = "\n\n  RAN: '/usr/bin/false'\n\n  STDOUT:\n\n\n  STDERR:\n"
+    patched_print_error.assert_called_once_with(msg)

--- a/test/unit/dependency/test_shell.py
+++ b/test/unit/dependency/test_shell.py
@@ -41,12 +41,12 @@ def test_execute(patched_run_command, shell_instance):
     patched_run_command.assert_called_once_with(cmd, debug=False)
 
 
-def test_execute_raises(patched_logger_error, shell_instance):
+def test_execute_raises(patched_print_error, shell_instance):
     shell_instance._command = sh.false.bake()
     with pytest.raises(SystemExit) as e:
         shell_instance.execute()
 
     assert 1 == e.value.code
 
-    msg = "ERROR: \n\n  RAN: '/usr/bin/false'\n\n  STDOUT:\n\n\n  STDERR:\n"
-    patched_logger_error.assert_called_once_with(msg)
+    msg = "\n\n  RAN: '/usr/bin/false'\n\n  STDOUT:\n\n\n  STDERR:\n"
+    patched_print_error.assert_called_once_with(msg)

--- a/test/unit/test_ansible_playbook.py
+++ b/test/unit/test_ansible_playbook.py
@@ -171,12 +171,12 @@ def test_execute(mocker, ansible_playbook_instance):
     assert isinstance(result, tuple)
 
 
-def test_execute_exits_with_return_code_and_logs(patched_logger_error,
+def test_execute_exits_with_return_code_and_logs(patched_print_error,
                                                  ansible_playbook_instance):
     ansible_playbook_instance._ansible = sh.false.bake()
     result = ansible_playbook_instance.execute()
 
-    msg = "ERROR: \n\n  RAN: '/usr/bin/false'\n\n  STDOUT:\n\n\n  STDERR:\n"
-    patched_logger_error.assert_called_once_with(msg)
+    msg = "\n\n  RAN: '/usr/bin/false'\n\n  STDOUT:\n\n\n  STDERR:\n"
+    patched_print_error.assert_called_once_with(msg)
 
     assert (1, None) == result

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -49,6 +49,44 @@ def test_print_info(capsys):
     assert expected == result
 
 
+def test_print_warn(capsys):
+    util.print_warn('test')
+    result, _ = capsys.readouterr()
+
+    print '{}{}'.format(colorama.Fore.YELLOW, 'test'.rstrip())
+    expected, _ = capsys.readouterr()
+
+    assert expected == result
+
+
+def test_print_error(capsys):
+    util.print_error('test')
+    result, _ = capsys.readouterr()
+
+    print '{}ERROR: {}'.format(colorama.Fore.RED, 'test'.rstrip())
+    expected, _ = capsys.readouterr()
+
+    assert expected == result
+
+
+def test_print_debug(capsys):
+    util.print_debug('test_title', 'test_data')
+    result_title, _ = capsys.readouterr()
+
+    print(''.join([
+        colorama.Back.WHITE, colorama.Style.BRIGHT, colorama.Fore.BLACK,
+        'DEBUG: ' + 'test_title', colorama.Fore.RESET, colorama.Back.RESET,
+        colorama.Style.RESET_ALL
+    ]))
+    print(''.join([
+        colorama.Fore.BLACK, colorama.Style.BRIGHT, 'test_data',
+        colorama.Style.RESET_ALL, colorama.Fore.RESET
+    ]))
+    expected_title, _ = capsys.readouterr()
+
+    assert expected_title == result_title
+
+
 def test_write_template(temp_dir):
     source_file = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), os.path.pardir,
@@ -113,24 +151,6 @@ def test_format_instance_name_03():
 @pytest.mark.skipif(reason="determine how to test such a function")
 def test_check_ssh_availability():
     pass
-
-
-def test_debug(capsys):
-    util.print_debug('test_title', 'test_data')
-    result_title, _ = capsys.readouterr()
-
-    print(''.join([
-        colorama.Back.WHITE, colorama.Style.BRIGHT, colorama.Fore.BLACK,
-        'DEBUG: ' + 'test_title', colorama.Fore.RESET, colorama.Back.RESET,
-        colorama.Style.RESET_ALL
-    ]))
-    print(''.join([
-        colorama.Fore.BLACK, colorama.Style.BRIGHT, 'test_data',
-        colorama.Style.RESET_ALL, colorama.Fore.RESET
-    ]))
-    expected_title, _ = capsys.readouterr()
-
-    assert expected_title == result_title
 
 
 def test_sysexit():


### PR DESCRIPTION
Using the logger to print doesn't make sense.  We are configuring it
simply to write to stdout/error.

Loggers are only used when passed to the `sh` module as callbacks.