### PR TITLE
Removed check mode from running in test cycle

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,4 +4,4 @@ omit =
 
 [report]
 fail_under =
-  82
+  81

--- a/molecule/command/check.py
+++ b/molecule/command/check.py
@@ -47,9 +47,8 @@ class Check(base.Base):
             debug=debug)
         ansible.add_cli_arg('check', True)
 
-        if 'command_check' not in self.molecule.disabled:
-            util.print_info("Performing a 'Dry Run' of playbook...")
-            return ansible.execute(hide_errors=True)
+        util.print_info("Performing a 'Dry Run' of playbook...")
+        return ansible.execute(hide_errors=True)
 
         return (None, None)
 

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -154,7 +154,7 @@ class ConfigV1(Config):
                 'test': {
                     'sequence': [
                         'destroy', 'dependency', 'syntax', 'create',
-                        'converge', 'idempotence', 'check', 'verify'
+                        'converge', 'idempotence', 'verify'
                     ]
                 },
                 'testinfra_dir': 'tests',

--- a/test/unit/command/test_check.py
+++ b/test/unit/command/test_check.py
@@ -50,17 +50,3 @@ def test_execute(mocker, patched_check_main, patched_ansible_playbook,
     patched_print_info.assert_called_once_with(msg)
     patched_ansible_playbook.assert_called_once_with(hide_errors=True)
     assert 'returned' == result
-
-
-def test_execute_does_not_execute(patched_check_main, patched_ansible_playbook,
-                                  molecule_instance):
-    molecule_instance.disabled = ['command_check']
-    molecule_instance.state.change_state('created', True)
-    molecule_instance.state.change_state('converged', True)
-
-    c = check.Check({}, {}, molecule_instance)
-    result = c.execute()
-
-    assert not patched_ansible_playbook.called
-
-    assert (None, None) == result

--- a/test/unit/command/test_test.py
+++ b/test/unit/command/test_test.py
@@ -25,8 +25,8 @@ from molecule.command import test
 
 def test_execute(mocker, patched_destroy_main, patched_destroy,
                  patched_dependency, patched_syntax, patched_create,
-                 patched_converge, patched_idempotence, patched_check,
-                 patched_verify, molecule_instance):
+                 patched_converge, patched_idempotence, patched_verify,
+                 molecule_instance):
     t = test.Test({}, {}, molecule_instance)
     result = t.execute()
 
@@ -35,7 +35,6 @@ def test_execute(mocker, patched_destroy_main, patched_destroy,
     patched_create.assert_called_once_with(exit=False)
     patched_converge.assert_called_once_with(exit=False)
     patched_idempotence.assert_called_once_with(exit=False)
-    patched_check.assert_called_once_with(exit=False)
     patched_verify.assert_called_once_with(exit=False)
 
     expected = [mocker.call(exit=False), mocker.call()]
@@ -55,10 +54,10 @@ def test_execute_fail_fast(patched_destroy, patched_print_error,
     patched_print_error.assert_called_once_with('output')
 
 
-def test_execute_always_destroy(
-        mocker, patched_destroy_main, patched_destroy, patched_syntax,
-        patched_create, patched_converge, patched_idempotence, patched_check,
-        patched_verify, molecule_instance):
+def test_execute_always_destroy(mocker, patched_destroy_main, patched_destroy,
+                                patched_syntax, patched_create,
+                                patched_converge, patched_idempotence,
+                                patched_verify, molecule_instance):
     command_args = {'destroy': 'always'}
     t = test.Test({}, command_args, molecule_instance)
     result = t.execute()
@@ -69,10 +68,10 @@ def test_execute_always_destroy(
     assert (None, None) == result
 
 
-def test_execute_never_destroy(
-        patched_destroy_main, patched_destroy, patched_syntax, patched_create,
-        patched_converge, patched_idempotence, patched_check, patched_verify,
-        molecule_instance):
+def test_execute_never_destroy(patched_destroy_main, patched_destroy,
+                               patched_syntax, patched_create,
+                               patched_converge, patched_idempotence,
+                               patched_verify, molecule_instance):
     command_args = {'destroy': 'never'}
     t = test.Test({}, command_args, molecule_instance)
     result = t.execute()

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -147,7 +147,7 @@ def molecule_v1_section_data(state_path_without_data):
             'test': {
                 'sequence': [
                     'destroy', 'dependency', 'syntax', 'create', 'converge',
-                    'idempotence', 'check', 'verify'
+                    'idempotence', 'verify'
                 ]
             }
         }


### PR DESCRIPTION
Check mode quite frankly is a pain in the ass.  Having it run by default
without the ability to turn it off only causes pain.  We have written
a lot of real-world roles, and we end up disabling check mode most of
the time.

This PR disables check mode by default, but the user is free to add it
to their test sequence if they want it.