### PR TITLE
Added missing completion targets.

### DIFF
--- a/asset/bash_completion/molecule.bash-completion.sh
+++ b/asset/bash_completion/molecule.bash-completion.sh
@@ -24,7 +24,7 @@ _molecule(){
 	prev=${COMP_WORDS[COMP_CWORD-1]}
 	firstword=$(_get_firstword)
 
-  GLOBAL_COMMANDS="syntax create converge destroy idempotence init list login status test verify"
+  GLOBAL_COMMANDS="syntax check create converge dependency destroy idempotence init list login status test verify"
   GLOBAL_OPTIONS="-h -v"
   SYNTAX_OPTIONS=""
   CHECK_OPTIONS=""

--- a/asset/bash_completion/molecule.bash-completion.sh
+++ b/asset/bash_completion/molecule.bash-completion.sh
@@ -116,7 +116,7 @@ _molecule(){
       complete_options="${STATUS_OPTIONS}"
       ;;
     syntax)
-      complete_options="${STATUS_OPTIONS}"
+      complete_options="${SYNTAX_OPTIONS}"
       ;;
     test)
       case "${prev}" in

--- a/asset/bash_completion/molecule.bash-completion.sh
+++ b/asset/bash_completion/molecule.bash-completion.sh
@@ -27,8 +27,10 @@ _molecule(){
   GLOBAL_COMMANDS="syntax create converge destroy idempotence init list login status test verify"
   GLOBAL_OPTIONS="-h -v"
   SYNTAX_OPTIONS=""
+  CHECK_OPTIONS=""
   CREATE_OPTIONS="--debug --platform --provider --tags"
   CONVERGE_OPTIONS="--debug --platform --provider --tags"
+  DEPENDENCY_OPTIONS=""
   DESTROY_OPTIONS="--debug --platform --provider --tags"
   IDEMPOTENCE_OPTIONS="--debug --platform --provider --tags"
   INIT_OPTIONS="--docker"
@@ -42,6 +44,9 @@ _molecule(){
   # echo -e "\nprev = $prev, cur = $cur, firstword = $firstword.\n"
 
   case "${firstword}" in
+    check)
+      complete_options="${CHECK_OPTIONS}"
+      ;;
     create)
       case "${prev}" in
         --platform)
@@ -67,6 +72,9 @@ _molecule(){
           complete_options="${CONVERGE_OPTIONS}"
           ;;
       esac
+      ;;
+    dependency)
+      complete_options="${CHECK_OPTIONS}"
       ;;
     destroy)
       case "${prev}" in
@@ -105,6 +113,9 @@ _molecule(){
       complete_words=$(_hosts)
       ;;
     status)
+      complete_options="${STATUS_OPTIONS}"
+      ;;
+    syntax)
       complete_options="${STATUS_OPTIONS}"
       ;;
     test)

--- a/asset/bash_completion/molecule.bash-completion.sh
+++ b/asset/bash_completion/molecule.bash-completion.sh
@@ -74,7 +74,7 @@ _molecule(){
       esac
       ;;
     dependency)
-      complete_options="${CHECK_OPTIONS}"
+      complete_options="${DEPENDENCY_OPTIONS}"
       ;;
     destroy)
       case "${prev}" in


### PR DESCRIPTION
Missing targets will now appear as follows

```
$ molecule 
check        converge     create       dependency   destroy      idempotence  init         list         login        status       syntax       test         verify ```