### PR TITLE
Added 'which' package to container install list

### DIFF
--- a/molecule/driver/dockerdriver.py
+++ b/molecule/driver/dockerdriver.py
@@ -232,9 +232,9 @@ class DockerDriver(basedriver.BaseDriver):
             dockerfile = '''
             FROM {container_image}:{container_version}
             {container_environment}
-            RUN bash -c 'if [ -x "$(command -v apt-get)" ]; then apt-get update && apt-get install -y python sudo which; fi'
+            RUN bash -c 'if [ -x "$(command -v apt-get)" ]; then apt-get update && apt-get install -y python sudo; fi'
             RUN bash -c 'if [ -x "$(command -v yum)" ]; then yum makecache fast && yum update -y && yum install -y python sudo which; fi'
-            RUN bash -c 'if [ -x "$(command -v zypper)" ]; then zypper refresh && zypper update -y && zypper install -y python sudo which; fi'
+            RUN bash -c 'if [ -x "$(command -v zypper)" ]; then zypper refresh && zypper update -y && zypper install -y python sudo; fi'
 
             '''  # noqa
 

--- a/molecule/driver/dockerdriver.py
+++ b/molecule/driver/dockerdriver.py
@@ -232,9 +232,9 @@ class DockerDriver(basedriver.BaseDriver):
             dockerfile = '''
             FROM {container_image}:{container_version}
             {container_environment}
-            RUN bash -c 'if [ -x "$(command -v apt-get)" ]; then apt-get update && apt-get install -y python sudo; fi'
-            RUN bash -c 'if [ -x "$(command -v yum)" ]; then yum makecache fast && yum update -y && yum install -y python sudo; fi'
-            RUN bash -c 'if [ -x "$(command -v zypper)" ]; then zypper refresh && zypper update -y && zypper install -y python sudo; fi'
+            RUN bash -c 'if [ -x "$(command -v apt-get)" ]; then apt-get update && apt-get install -y python sudo which; fi'
+            RUN bash -c 'if [ -x "$(command -v yum)" ]; then yum makecache fast && yum update -y && yum install -y python sudo which; fi'
+            RUN bash -c 'if [ -x "$(command -v zypper)" ]; then zypper refresh && zypper update -y && zypper install -y python sudo which; fi'
 
             '''  # noqa
 


### PR DESCRIPTION
Without `which`, I get the following failure on a vanilla centos:latest container when running testinfra(Package) tests:

```
E       Failed: Unexpected exit code 127 for CommandResult(command='which dpkg-query', exit_status=127, stdout='', stderr='/bin/sh: which: command not found\n')
```