### PR TITLE
Openstack: Fix security_groups default for newer shade versions

### DIFF
--- a/molecule/driver/openstackdriver.py
+++ b/molecule/driver/openstackdriver.py
@@ -120,8 +120,7 @@ class OpenstackDriver(basedriver.BaseDriver):
                     auto_ip=True,
                     wait=True,
                     key_name=kpn,
-                    security_groups=instance['security_groups']
-                    if 'security_groups' in instance else None)
+                    security_groups=instance.get('security_groups', []))
                 self._reset_known_host_key(server['interface_ip'])
                 instance['created'] = True
                 num_retries = 0


### PR DESCRIPTION
The openstack driver currently pases a `None` object to shade in case the `security_groups` paramter is undefined. In the current devel version of shade however, the `security_groups` parameter is put into a list in case it is not a list itself: https://github.com/openstack-infra/shade/blob/master/shade/openstackcloud.py#L4995


This results in a `[None]` list for the `security_groups` paramter which then makes the `create_server` call an invalid request.