### PR TITLE
Fix environment passed to ansible-lint (closes #642)

### DIFF
--- a/molecule/verifier/ansible_lint.py
+++ b/molecule/verifier/ansible_lint.py
@@ -49,6 +49,7 @@ class AnsibleLint(base.Base):
         env = {
             'ANSIBLE_CONFIG':
             self._molecule.config.config['ansible']['config_file'],
+            'PYTHONPATH': os.environ.get('PYTHONPATH'),
             'HOME': os.environ.get('HOME')
         }
 


### PR DESCRIPTION
Pass `PYTHONPATH` environment variable to `ansible-lint`, which when stripped, renders Molecule incompatible with any Ansible version running from source (i.e. failing on each `Executing ansible-lint...` task).