### PR TITLE
Feature/add links param to docker

### DIFF
--- a/doc/source/driver/docker/index.rst
+++ b/doc/source/driver/docker/index.rst
@@ -38,6 +38,7 @@ Options
 * ``command`` - **(default='')** the command to launch the container.
 * ``environment`` - **(default=None)** the environment variables passed to the
   container.
+* ``links`` - **(default=[])** the link mapping to allow containers to discover each other.
 
 The available param for the Docker driver itself is:
 

--- a/molecule/driver/dockerdriver.py
+++ b/molecule/driver/dockerdriver.py
@@ -120,6 +120,7 @@ class DockerDriver(basedriver.BaseDriver):
             privileged = container.get('privileged', False)
             port_bindings = container.get('port_bindings', {})
             volume_mounts = container.get('volume_mounts', [])
+            links = container.get('links', {})
             cap_add = container.get('cap_add', [])
             cap_drop = container.get('cap_drop', [])
             command = container.get('command', '')
@@ -129,6 +130,7 @@ class DockerDriver(basedriver.BaseDriver):
                 privileged=privileged,
                 port_bindings=port_bindings,
                 binds=volume_mounts,
+                links=links,
                 cap_add=cap_add,
                 cap_drop=cap_drop)
 

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -212,6 +212,9 @@ def docker_v1_section_data():
             }, {
                 'name': 'test2',
                 'image': 'ubuntu',
+                'links': {
+                    'test1': '80',
+                },
                 'image_version': 'latest',
                 'ansible_groups': ['group2'],
                 'command': '/bin/sh',

--- a/test/unit/driver/test_dockerdriver.py
+++ b/test/unit/driver/test_dockerdriver.py
@@ -226,3 +226,10 @@ def test_environment(docker_instance):
     d2 = docker_instance._docker.inspect_container('test2')['Config']['Env']
     assert 'FOO=BAR' not in d2
     assert 'BAZ=QUX' not in d2
+
+
+def test_links(docker_instance):
+    docker_instance.up()
+    d2 = docker_instance._docker.inspect_container('test2')['HostConfig']['Links']
+    assert '/test1:/test2/80' in d2
+


### PR DESCRIPTION
Adds the links parameter which ended up being an easy add. The links functionality is deprecated in Docker though, so the networks parameter is still desireable. This was the "bonus" request in Issue #650 