### PR TITLE
Revert "Fix environment passed to ansible-lint (#649)"

### DIFF
--- a/molecule/verifier/ansible_lint.py
+++ b/molecule/verifier/ansible_lint.py
@@ -49,7 +49,6 @@ class AnsibleLint(base.Base):
         env = {
             'ANSIBLE_CONFIG':
             self._molecule.config.config['ansible']['config_file'],
-            'PYTHONPATH': os.environ.get('PYTHONPATH'),
             'HOME': os.environ.get('HOME')
         }
 


### PR DESCRIPTION
This reverts commit c7ffdf877daea2785cd409706201d25b4770d591.

This commit broke functional tests.  Reverting until submitter corrects it to work with tox.