### PR TITLE
Ensure raw_env_vars contains string values only

### DIFF
--- a/molecule/ansible_playbook.py
+++ b/molecule/ansible_playbook.py
@@ -95,6 +95,8 @@ class AnsiblePlaybook(object):
 
         if name == 'raw_env_vars':
             for k, v in value.iteritems():
+                if not isinstance(v, basestring):
+                    v = unicode(v)
                 self.add_env_arg(k, v)
             return
 

--- a/test/functional/test_docker_scenarios.py
+++ b/test/functional/test_docker_scenarios.py
@@ -145,6 +145,14 @@ def test_custom_ansible_cfg(scenario_setup):
 
 
 @pytest.mark.parametrize(
+    'scenario_setup', ['non_string_env'], indirect=['scenario_setup'])
+def test_non_string_env(scenario_setup):
+    sh.molecule('create')
+    sh.molecule('syntax')
+    sh.molecule('destroy')
+
+
+@pytest.mark.parametrize(
     'scenario_setup', ['dockerfile'], indirect=['scenario_setup'])
 def test_dockerfile(scenario_setup):
     sh.molecule('test')

--- a/test/scenarios/non_string_env/molecule.yml
+++ b/test/scenarios/non_string_env/molecule.yml
@@ -1,0 +1,13 @@
+---
+dependency:
+  name: galaxy
+ansible:
+  raw_env_vars:
+    RETRY_FILES_ENABLED: 0
+driver:
+  name: docker
+docker:
+  containers:
+    - name: non-string-env-scenario
+      image: ubuntu
+      image_version: latest

--- a/test/scenarios/non_string_env/playbook.yml
+++ b/test/scenarios/non_string_env/playbook.yml
@@ -1,0 +1,6 @@
+---
+- hosts: all
+  tasks:
+    - name: Non string environment functional scenario
+      command: /bin/true
+      changed_when: False


### PR DESCRIPTION
Required to not silently break Ansible runs.
Fixes #658