### PR TITLE
Fix unittests to allow ls to be in both /usr/bin and /bin

### DIFF
--- a/test/unit/command/test_verify.py
+++ b/test/unit/command/test_verify.py
@@ -20,6 +20,7 @@
 
 import pytest
 import sh
+import os
 
 from molecule.command import verify
 
@@ -89,8 +90,10 @@ def test_execute_exits_when_command_fails_and_exit_flag_set(
     with pytest.raises(SystemExit):
         v.execute()
 
-    msg = ("\n\n  RAN: <Command '/bin/ls'>\n\n  "
-           "STDOUT:\n<redirected>\n\n  STDERR:\n<redirected>")
+    ls_path = '/usr/bin/ls' if os.path.exists('/usr/bin/ls') \
+                else '/bin/ls'
+    msg = ("\n\n  RAN: <Command '%s'>\n\n  "
+           "STDOUT:\n<redirected>\n\n  STDERR:\n<redirected>" % ls_path)
     patched_print_error.assert_called_once_with(msg)
 
 

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -210,7 +210,9 @@ def test_run_command_with_debug(patched_print_debug):
     cmd = sh.ls.bake()
     util.run_command(cmd, debug=True)
 
-    patched_print_debug.assert_called_with('COMMAND', '/bin/ls')
+    ls_path = '/usr/bin/ls' if os.path.exists('/usr/bin/ls') \
+                else '/bin/ls'
+    patched_print_debug.assert_called_with('COMMAND', ls_path)
 
 
 def test_resolve_template_dir_relative():


### PR DESCRIPTION
As mentioned in #659, the unittests didn't work for me because my $PATH does not contain `/bin` but `/usr/bin` instead. This is default for RHEL/CentOS 7 and Fedora.