### PR TITLE
Correct ansible-lint exit error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible-lint==3.2.5
+ansible-lint==3.4.8
 anyconfig==0.7.0
 colorama==0.3.7
 cookiecutter==1.4.0


### PR DESCRIPTION
Ansible-lint should not exit with error when role dependency is in newer
dictionary format[1].

[1] https://github.com/willthames/ansible-lint/issues/174

Fixes: #663