### PR TITLE
Allow using environment variables in molecule.yml

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -14,6 +14,8 @@ molecule-specific information for the role in the directory in which it's
 located. It allows you to configure how Molecule, Ansible, verifiers, and
 drivers will behave. This information is contained in top level YAML sections
 described below.
+It is also possible to use environment variables by embbedding them in a
+string like this: ``playbook: "${envvar_containing_playbook_name}"``
 
 Molecule Section
 ----------------

--- a/test/unit/core/test_core.py
+++ b/test/unit/core/test_core.py
@@ -91,6 +91,28 @@ def test_dependency(molecule_instance):
     assert 'galaxy' == molecule_instance.dependency
 
 
+def test_envvar_expansion_dictkey(molecule_instance_with_env_expansion):
+    assert 'vagrant' == molecule_instance_with_env_expansion._get_driver_name()
+
+
+def test_envvar_expansion_multiple_vars(molecule_instance_with_env_expansion):
+    m = molecule_instance_with_env_expansion
+    assert 'ubuntu/trusty64' == m.config.config['vagrant']['platforms'][0][
+            'box']
+
+
+def test_envvar_expansion_in_list(molecule_instance_with_env_expansion):
+    m = molecule_instance_with_env_expansion
+    assert 'example1' == m.config.config['vagrant']['instances'][0][
+            'ansible_groups'][1]
+
+
+def test_envvar_expansion_deeply_nested(molecule_instance_with_env_expansion):
+    m = molecule_instance_with_env_expansion
+    assert 'append_platform_to_hostname' in m.config.config['vagrant'][
+            'instances'][0]['options']
+
+
 @pytest.mark.skip(reason='TODO(retr0h): Determine best way to test this')
 def test_remove_templates():
     pass


### PR DESCRIPTION
With this pull request it is possible to use environment variables in molecule.yml via the `"${my_var}"` syntax.

This is needed when using molecule via a CI, for example to avoid conflicting Openstack instance names on concurrent builds.


