### PR TITLE
Correct functional tests

### DIFF
--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -35,6 +35,9 @@ def scenario_setup(request):
     sh.molecule('destroy')
 
     def cleanup():
-        sh.molecule('destroy')
+        try:
+            sh.molecule('destroy')
+        except:
+            pass
 
     request.addfinalizer(cleanup)


### PR DESCRIPTION
Some tests call destroy prior to cleanup running.  Wrap cleanup to
ignore errors.