### PR TITLE
Create test skeleton with `molecule init`

### DIFF
--- a/molecule/command/init.py
+++ b/molecule/command/init.py
@@ -68,7 +68,10 @@ class Init(base.Base):
         extra_context = self._get_cookiecutter_context(role, driver, verifier)
 
         util.print_info('Initializing molecule in current directory...')
-        for template in ['playbook', 'driver/{}'.format(driver)]:
+        for template in [
+                'playbook', 'driver/{}'.format(driver), 'verifier/{}'.format(
+                    verifier)
+        ]:
             util.process_templates(template, extra_context, role_path)
 
     def _init_new_role(self, role, role_path, driver, verifier):

--- a/test/unit/command/test_init.py
+++ b/test/unit/command/test_init.py
@@ -40,8 +40,11 @@ def test_create_role(temp_dir, init_command_args):
     with pytest.raises(SystemExit):
         i.execute()
 
-    assert os.path.isdir(os.path.join(temp_dir, 'unit_test1'))
-    assert os.path.isfile(os.path.join(temp_dir, 'unit_test1', 'molecule.yml'))
+    role_directory = os.path.join(temp_dir, 'unit_test1')
+    assert os.path.isdir(role_directory)
+    assert os.path.isdir(os.path.join(role_directory, 'tests'))
+    assert os.path.isfile(os.path.join(role_directory, 'molecule.yml'))
+    assert os.path.isfile(os.path.join(role_directory, 'playbook.yml'))
 
 
 def test_create_role_in_existing_directory(temp_dir, init_command_args):
@@ -50,7 +53,11 @@ def test_create_role_in_existing_directory(temp_dir, init_command_args):
     with pytest.raises(SystemExit):
         i.execute()
 
-    assert os.path.isdir(os.path.join(temp_dir))
+    role_directory = os.path.join(temp_dir)
+    assert os.path.isdir(role_directory)
+    assert os.path.isdir(os.path.join(role_directory, 'tests'))
+    assert os.path.isfile(os.path.join(role_directory, 'molecule.yml'))
+    assert os.path.isfile(os.path.join(role_directory, 'playbook.yml'))
 
 
 def test_create_role_existing_dir_error(temp_dir, init_command_args):


### PR DESCRIPTION
The test skeleton was not created when initializing a role in
current directory.

Fixes: #666