### PR TITLE
Use 'become' options instead of 'sudo' options

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -46,7 +46,7 @@ may look something like this:
   ansible:
     inventory_file: ../../inventory/
     diff: False
-    sudo: True
+    become: True
     vault_password_file: ~/.vault
 
 As you can see, the names of these values correspond to what the underlying

--- a/doc/source/provider/virtualbox.rst
+++ b/doc/source/provider/virtualbox.rst
@@ -26,8 +26,8 @@ of options that you probably don't want to set.
   ---
   ansible:
     playbook: playbook.yml
-    sudo: True
-    sudo_user: False
+    become: True
+    become_user: False
     verbose: vvvv
 
   vagrant:

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -106,8 +106,10 @@ class ConfigV1(Config):
     def _get_defaults(self):
         return {
             'ansible': {
-                'ask_sudo_pass': False,
+                'ask_become_pass': False,
                 'ask_vault_pass': False,
+                'become': True,
+                'become_user': False,
                 'config_file': 'ansible.cfg',
                 'diff': True,
                 'host_key_checking': False,
@@ -118,8 +120,6 @@ class ConfigV1(Config):
                     '-o UserKnownHostsFile=/dev/null', '-o IdentitiesOnly=yes',
                     '-o ControlMaster=auto', '-o ControlPersist=60s'
                 ],
-                'sudo': True,
-                'sudo_user': False,
                 'tags': False,
                 'timeout': 30,
                 'vault_password_file': False,

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -244,9 +244,9 @@ def ansible_v1_section_data(playbook):
     return {
         'ansible': {
             'timeout': 30,
-            'sudo': True,
-            'sudo_user': False,
-            'ask_sudo_pass': False,
+            'become': True,
+            'become_user': False,
+            'ask_become_pass': False,
             'ask_vault_pass': False,
             'vault_password_file': False,
             'limit': 'all',

--- a/test/unit/test_ansible_playbook.py
+++ b/test/unit/test_ansible_playbook.py
@@ -40,7 +40,7 @@ def test_init_arg_loading_bool_true(ansible_playbook_instance):
 
 
 def test_init_arg_loading_bool_false_not_added(ansible_playbook_instance):
-    assert ansible_playbook_instance._cli.get('sudo_user') is None
+    assert ansible_playbook_instance._cli.get('become_user') is None
 
 
 def test_init_connection_params(ansible_v1_section_data,
@@ -144,7 +144,7 @@ def test_bake(ansible_playbook_instance):
     ansible_playbook_instance.bake()
     executable = sh.ansible_playbook
     expected = [
-        '--diff', '--inventory-file=inventory_file', '--limit=all', '--sudo',
+        '--become', '--diff', '--inventory-file=inventory_file', '--limit=all',
         '--timeout=30', '-vvvv', executable,
         ansible_playbook_instance._playbook
     ]


### PR DESCRIPTION
As of Ansible 1.9, `sudo` options are deprecated for achieving
privelege escalation in favor of the `become` options.
This change will cause the generated `ansible-playbook` command to
use the following options in favor of their deprecated counterparts.

* `become` instead of `sudo`
* `become_user` instead of `sudo_user`
* `ask_become_pass` instead of `ask_sudo_pass`