### PR TITLE
Implemented scenario_name filtering sub commands

### DIFF
--- a/molecule/command/base.py
+++ b/molecule/command/base.py
@@ -103,6 +103,26 @@ def get_configs(args, command_args):
             configs=[local_config, _load_config(c)])
         for c in util.os_walk(current_directory, 'molecule.yml')
     ]
+
+    scenario_name = command_args.get('scenario_name')
+    if scenario_name:
+        configs = _filter_configs_for_scenario(scenario_name, configs)
+
     _verify_configs(configs)
 
     return configs
+
+
+def _filter_configs_for_scenario(scenario_name, configs):
+    """
+    Find the config matching the provided scenario name and return a list.
+
+    :param scenario_name: A string representing the name of the scenario's
+     config to return
+    :param configs: A list containing Molecule config instances.
+    :return: list
+    """
+
+    return [
+        config for config in configs if config.scenario.name == scenario_name
+    ]

--- a/molecule/command/converge.py
+++ b/molecule/command/converge.py
@@ -35,6 +35,10 @@ class Converge(base.Base):
 
         >>> molecule converge
 
+        Targeting a specific scenario:
+
+        >>> molecule converge --scenario-name foo
+
         Executing with `debug`:
 
         >>> molecule --debug converge
@@ -56,10 +60,11 @@ class Converge(base.Base):
 
 @click.command()
 @click.pass_context
-def converge(ctx):  # pragma: no cover
+@click.option('--scenario-name', help='Name of the scenario to target.')
+def converge(ctx, scenario_name):  # pragma: no cover
     """ Use a provisioner to configure instances. """
     args = ctx.obj.get('args')
-    command_args = {'subcommand': __name__}
+    command_args = {'subcommand': __name__, 'scenario_name': scenario_name}
 
     for config in base.get_configs(args, command_args):
         for task in config.scenario.converge_sequence:

--- a/molecule/command/create.py
+++ b/molecule/command/create.py
@@ -34,6 +34,10 @@ class Create(base.Base):
 
         >>> molecule create
 
+        Targeting a specific scenario:
+
+        >>> molecule create --scenario-name foo
+
         Executing with `debug`:
 
         >>> molecule --debug create
@@ -55,10 +59,11 @@ class Create(base.Base):
 
 @click.command()
 @click.pass_context
-def create(ctx):  # pragma: no cover
+@click.option('--scenario-name', help='Name of the scenario to target.')
+def create(ctx, scenario_name):  # pragma: no cover
     """ Start instances. """
     args = ctx.obj.get('args')
-    command_args = {'subcommand': __name__}
+    command_args = {'subcommand': __name__, 'scenario_name': scenario_name}
 
     for config in base.get_configs(args, command_args):
         c = Create(config)

--- a/molecule/command/dependency.py
+++ b/molecule/command/dependency.py
@@ -32,6 +32,10 @@ class Dependency(base.Base):
 
         >>> molecule dependency
 
+        Targeting a specific scenario:
+
+        >>> molecule dependency --scenario-name foo
+
         Executing with `debug`:
 
         >>> molecule --debug dependency
@@ -48,10 +52,11 @@ class Dependency(base.Base):
 
 @click.command()
 @click.pass_context
-def dependency(ctx):  # pragma: no cover
+@click.option('--scenario-name', help='Name of the scenario to target.')
+def dependency(ctx, scenario_name):  # pragma: no cover
     """ Start instances. """
     args = ctx.obj.get('args')
-    command_args = {'subcommand': __name__}
+    command_args = {'subcommand': __name__, 'scenario_name': scenario_name}
 
     for config in base.get_configs(args, command_args):
         d = Dependency(config)

--- a/molecule/command/destroy.py
+++ b/molecule/command/destroy.py
@@ -34,6 +34,10 @@ class Destroy(base.Base):
 
         >>> molecule destroy
 
+        Targeting a specific scenario:
+
+        >>> molecule destroy --scenario-name foo
+
         Executing with `debug`:
 
         >>> molecule --debug destroy
@@ -55,10 +59,11 @@ class Destroy(base.Base):
 
 @click.command()
 @click.pass_context
-def destroy(ctx):  # pragma: no cover
+@click.option('--scenario-name', help='Name of the scenario to target.')
+def destroy(ctx, scenario_name):  # pragma: no cover
     """ Destroy instances. """
     args = ctx.obj.get('args')
-    command_args = {'subcommand': __name__}
+    command_args = {'subcommand': __name__, 'scenario_name': scenario_name}
 
     for config in base.get_configs(args, command_args):
         d = Destroy(config)

--- a/molecule/command/lint.py
+++ b/molecule/command/lint.py
@@ -32,6 +32,10 @@ class Lint(base.Base):
 
         >>> molecule lint
 
+        Targeting a specific scenario:
+
+        >>> molecule lint --scenario-name foo
+
         Executing with `debug`:
 
         >>> molecule --debug lint
@@ -48,10 +52,11 @@ class Lint(base.Base):
 
 @click.command()
 @click.pass_context
-def lint(ctx):  # pragma: no cover
+@click.option('--scenario-name', help='Name of the scenario to target.')
+def lint(ctx, scenario_name):  # pragma: no cover
     """ Lint the role. """
     args = ctx.obj.get('args')
-    command_args = {'subcommand': __name__}
+    command_args = {'subcommand': __name__, 'scenario_name': scenario_name}
 
     for config in base.get_configs(args, command_args):
         l = Lint(config)

--- a/molecule/command/test.py
+++ b/molecule/command/test.py
@@ -32,6 +32,10 @@ class Test(base.Base):
 
         >>> molecule test
 
+        Targeting a specific scenario:
+
+        >>> molecule test --scenario-name foo
+
         Executing with `debug`:
 
         >>> molecule --debug test
@@ -42,10 +46,11 @@ class Test(base.Base):
 
 @click.command()
 @click.pass_context
-def test(ctx):  # pragma: no cover
+@click.option('--scenario-name', help='Name of the scenario to target.')
+def test(ctx, scenario_name):  # pragma: no cover
     """ Test (destroy, create, converge, lint, verify, destroy) """
     args = ctx.obj.get('args')
-    command_args = {'subcommand': __name__}
+    command_args = {'subcommand': __name__, 'scenario_name': scenario_name}
 
     for config in base.get_configs(args, command_args):
         for task in config.scenario.test_sequence:

--- a/molecule/command/verify.py
+++ b/molecule/command/verify.py
@@ -32,6 +32,10 @@ class Verify(base.Base):
 
         >>> molecule verify
 
+        Targeting a specific scenario:
+
+        >>> molecule verify --scenario-name foo
+
         Executing with `debug`:
 
         >>> molecule --debug verify
@@ -48,10 +52,11 @@ class Verify(base.Base):
 
 @click.command()
 @click.pass_context
-def verify(ctx):  # pragma: no cover
+@click.option('--scenario-name', help='Name of the scenario to target.')
+def verify(ctx, scenario_name):  # pragma: no cover
     """ Run automated tests against instances. """
     args = ctx.obj.get('args')
-    command_args = {'subcommand': __name__}
+    command_args = {'subcommand': __name__, 'scenario_name': scenario_name}
 
     for config in base.get_configs(args, command_args):
         v = Verify(config)

--- a/test/unit/command/conftest.py
+++ b/test/unit/command/conftest.py
@@ -54,3 +54,8 @@ def patched_ansible_galaxy(mocker):
 @pytest.fixture
 def patched_testinfra(mocker):
     return mocker.patch('molecule.verifier.testinfra.Testinfra.execute')
+
+
+@pytest.fixture
+def patched_verify_configs(mocker):
+    return mocker.patch('molecule.command.base._verify_configs')

--- a/test/unit/command/test_base.py
+++ b/test/unit/command/test_base.py
@@ -101,3 +101,27 @@ def test_get_configs(temp_dir):
     assert 1 == len(result)
     assert isinstance(result, list)
     assert isinstance(result[0], config.Config)
+
+
+def test_get_configs_verify_configs(patched_verify_configs, temp_dir):
+    base.get_configs({}, {})
+
+    patched_verify_configs.assert_called_once_with([])
+
+
+def test_get_configs_filter_configs_for_scenario(
+        mocker, patched_verify_configs, temp_dir):
+    m = mocker.patch('molecule.command.base._filter_configs_for_scenario')
+    base.get_configs({}, {'scenario_name': 'default'})
+
+    m.assert_called_with('default', [])
+
+
+def test_filter_configs_for_scenario(config_instance):
+    configs = [config_instance, config_instance]
+
+    result = base._filter_configs_for_scenario('default', configs)
+    assert 2 == len(result)
+
+    result = base._filter_configs_for_scenario('invalid', configs)
+    assert [] == result


### PR DESCRIPTION
Sub commands will execute all scenarios, unless the `--scenario-name`
flag is passed.

Fixes: #680