### PR TITLE
No merging of local config onto scenario config

### DIFF
--- a/molecule/command/base.py
+++ b/molecule/command/base.py
@@ -47,19 +47,6 @@ class Base(object):
         pass
 
 
-def _get_local_config():
-    """
-    Load and return Molecule's local config and returns a dict.
-
-    :return: dict
-    """
-    expanded_path = os.path.expanduser(config.MOLECULE_LOCAL_CONFIG)
-    try:
-        return _load_config(expanded_path)
-    except IOError:
-        return {}
-
-
 def _load_config(config):
     """
     Open and YAML parse the provided file and returns a dict.
@@ -94,13 +81,12 @@ def get_configs(args, command_args):
     :return: list
     """
     current_directory = os.path.join(os.getcwd(), 'molecule')
-    local_config = _get_local_config()
     configs = [
         config.Config(
             molecule_file=c,
             args=args,
             command_args=command_args,
-            configs=[local_config, _load_config(c)])
+            configs=[_load_config(c)])
         for c in util.os_walk(current_directory, 'molecule.yml')
     ]
 

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -30,7 +30,6 @@ from molecule.driver import docker
 from molecule.lint import ansible_lint
 from molecule.verifier import testinfra
 
-MOLECULE_LOCAL_CONFIG = '~/.config/molecule/config.yml'
 MOLECULE_DIRECTORY = 'molecule'
 MOLECULE_EPHEMERAL_DIRECTORY = '.molecule'
 MOLECULE_FILE = 'molecule.yml'

--- a/test/unit/command/test_base.py
+++ b/test/unit/command/test_base.py
@@ -44,22 +44,6 @@ def test_config_private_member(base_instance):
     assert isinstance(base_instance._config, config.Config)
 
 
-def test_get_local_config(mocker):
-    m = mocker.patch('molecule.command.base._load_config')
-    m.return_value = {'foo': 'bar'}
-
-    assert {'foo': 'bar'} == base._get_local_config()
-
-
-def test_get_local_config_returns_empty_dict_on_ioerror(monkeypatch):
-    def mockreturn(path):
-        return '/foo/bar/baz'
-
-    monkeypatch.setattr('os.path.expanduser', mockreturn)
-
-    assert {} == base._get_local_config()
-
-
 def test_load_config(temp_dir):
     inventory_file = os.path.join(temp_dir.strpath, 'inventory_file')
     with open(inventory_file, 'w') as outfile:


### PR DESCRIPTION
It no longer makes sense to merge the local config onto the scenario
config since a scenario can be anything.  In an attempt to keep things
simple, removed this functionality.

Partial-Fix: #684