### PR TITLE
Implemented duplicate scenario name validation

### DIFF
--- a/molecule/command/base.py
+++ b/molecule/command/base.py
@@ -19,6 +19,7 @@
 #  DEALINGS IN THE SOFTWARE.
 
 import abc
+import collections
 import os
 
 import yaml
@@ -65,8 +66,17 @@ def _verify_configs(configs):
     :param configs: A list containing absolute paths to Molecule config files.
     :return: None
     """
-    if not configs:
-        msg = ('Unable to find a molecule.yml.  Exiting.')
+    if configs:
+        scenario_names = [config.scenario.name for config in configs]
+        for scenario_name, n in collections.Counter(scenario_names).items():
+            if n > 1:
+                msg = ("Duplicate scenario name '{}' found.  "
+                       'Exiting.').format(scenario_name)
+                util.print_error(msg)
+                util.sysexit()
+
+    else:
+        msg = 'Unable to find a molecule.yml.  Exiting.'
         util.print_error(msg)
         util.sysexit()
 

--- a/molecule/command/create.py
+++ b/molecule/command/create.py
@@ -67,4 +67,4 @@ def create(ctx, scenario_name):  # pragma: no cover
 
     for config in base.get_configs(args, command_args):
         c = Create(config)
-        c.execute()
+        #c.execute()

--- a/test/unit/command/test_base.py
+++ b/test/unit/command/test_base.py
@@ -60,17 +60,31 @@ def test_load_config_returns_empty_dict_on_empty_file(temp_dir):
     assert {} == base._load_config(inventory_file)
 
 
-def test_verify_configs():
-    assert base._verify_configs([{}, {}]) is None
+def test_verify_configs(config_instance):
+    configs = [config_instance]
+
+    assert base._verify_configs(configs) is None
 
 
-def test_verify_configs_raises(patched_print_error):
+def test_verify_configs_raises_with_no_configs(patched_print_error):
     with pytest.raises(SystemExit) as e:
         base._verify_configs([])
 
     assert 1 == e.value.code
 
     msg = 'Unable to find a molecule.yml.  Exiting.'
+    patched_print_error.assert_called_with(msg)
+
+
+def test_verify_configs_raises_with_duplicate_configs(patched_print_error,
+                                                      config_instance):
+    with pytest.raises(SystemExit) as e:
+        configs = [config_instance, config_instance]
+        base._verify_configs(configs)
+
+    assert 1 == e.value.code
+
+    msg = "Duplicate scenario name 'default' found.  Exiting."
     patched_print_error.assert_called_with(msg)
 
 


### PR DESCRIPTION
Since we can target a scenario based on name, we should not allow
duplicate scenarios to be created.

Fixes: #682