### PR TITLE
Idempotence errors if not already converged

### DIFF
--- a/molecule/command/idempotence.py
+++ b/molecule/command/idempotence.py
@@ -54,6 +54,11 @@ class Idempotence(base.Base):
             os.path.basename(self._config.scenario.converge))
         util.print_info(msg)
 
+        if not self._config.state.converged:
+            msg = 'Instances not converged.  Please converge instances first.'
+            util.print_error(msg)
+            util.sysexit()
+
         output = self._config.provisioner.converge(
             self._config.provisioner.inventory_file,
             self._config.scenario.converge,
@@ -129,8 +134,5 @@ def idempotence(ctx, scenario_name):  # pragma: no cover
     command_args = {'subcommand': __name__, 'scenario_name': scenario_name}
 
     for config in base.get_configs(args, command_args):
-        for task in config.scenario.idempotence_sequence:
-            command_module = getattr(molecule.command, task)
-            command = getattr(command_module, task.capitalize())
-            c = command(config)
-            c.execute()
+        i = Idempotence(config)
+        i.execute()

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -166,7 +166,6 @@ class Config(object):
                 'converge_sequence': ['create', 'converge'],
                 'test_sequence':
                 ['destroy', 'create', 'converge', 'lint', 'verify', 'destroy'],
-                'idempotence_sequence': ['create', 'converge', 'idempotence'],
             },
             'verifier': {
                 'name': 'testinfra',

--- a/molecule/scenario.py
+++ b/molecule/scenario.py
@@ -94,7 +94,3 @@ class Scenario(object):
     @property
     def test_sequence(self):
         return self._config.config['scenario']['test_sequence']
-
-    @property
-    def idempotence_sequence(self):
-        return self._config.config['scenario']['idempotence_sequence']

--- a/test/unit/test_scenario.py
+++ b/test/unit/test_scenario.py
@@ -74,9 +74,3 @@ def test_test_sequence_property(scenario_instance):
     x = ['destroy', 'create', 'converge', 'lint', 'verify', 'destroy']
 
     assert x == scenario_instance.test_sequence
-
-
-def test_idempotence_sequence_property(scenario_instance):
-    x = ['create', 'converge', 'idempotence']
-
-    assert x == scenario_instance.idempotence_sequence


### PR DESCRIPTION
Idempotence should only be run when instances have already
been converged.

Fixes: #694