### PR TITLE
Run dependency managers only when config present

### DIFF
--- a/molecule/config.py
+++ b/molecule/config.py
@@ -26,6 +26,7 @@ from molecule import provisioner
 from molecule import scenario
 from molecule import state
 from molecule.dependency import ansible_galaxy
+from molecule.dependency import gilt
 from molecule.driver import docker
 from molecule.lint import ansible_lint
 from molecule.verifier import testinfra
@@ -64,6 +65,8 @@ class Config(object):
     def dependency(self):
         if self.config['dependency']['name'] == 'galaxy':
             return ansible_galaxy.AnsibleGalaxy(self)
+        elif self.config['dependency']['name'] == 'gilt':
+            return gilt.Gilt(self)
 
     @property
     def driver(self):

--- a/molecule/dependency/ansible_galaxy.py
+++ b/molecule/dependency/ansible_galaxy.py
@@ -96,6 +96,9 @@ class AnsibleGalaxy(base.Base):
         if not self.enabled:
             return
 
+        if not self._has_requirements_file():
+            return
+
         if self._ansible_galaxy_command is None:
             self.bake()
 
@@ -117,3 +120,8 @@ class AnsibleGalaxy(base.Base):
                                       self.options['roles-path'])
         if not os.path.isdir(role_directory):
             os.makedirs(role_directory)
+
+    def _has_requirements_file(self):
+        role_file = self.options.get('role-file')
+
+        return role_file and os.path.isfile(role_file)

--- a/molecule/dependency/gilt.py
+++ b/molecule/dependency/gilt.py
@@ -92,6 +92,9 @@ class Gilt(base.Base):
         if not self.enabled:
             return
 
+        if not self._has_requirements_file():
+            return
+
         if self._gilt_command is None:
             self.bake()
 
@@ -100,3 +103,8 @@ class Gilt(base.Base):
                 self._gilt_command, debug=self._config.args.get('debug'))
         except sh.ErrorReturnCode as e:
             util.sysexit(e.exit_code)
+
+    def _has_requirements_file(self):
+        config_file = self.options.get('config')
+
+        return config_file and os.path.isfile(config_file)

--- a/test/unit/dependency/conftest.py
+++ b/test/unit/dependency/conftest.py
@@ -1,0 +1,38 @@
+#  Copyright (c) 2015-2017 Cisco Systems, Inc.
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to
+#  deal in the Software without restriction, including without limitation the
+#  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+#  sell copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#  DEALINGS IN THE SOFTWARE.
+
+import pytest
+
+
+@pytest.fixture
+def patched_ansible_galaxy_has_requirements_file(mocker):
+    m = mocker.patch('molecule.dependency.ansible_galaxy.'
+                     'AnsibleGalaxy._has_requirements_file')
+    m.return_value = True
+
+    return m
+
+
+@pytest.fixture
+def patched_gilt_has_requirements_file(mocker):
+    m = mocker.patch('molecule.dependency.gilt.Gilt._has_requirements_file')
+    m.return_value = True
+
+    return m

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -27,6 +27,7 @@ from molecule import provisioner
 from molecule import scenario
 from molecule import state
 from molecule.dependency import ansible_galaxy
+from molecule.dependency import gilt
 from molecule.driver import docker
 from molecule.lint import ansible_lint
 from molecule.verifier import testinfra
@@ -76,6 +77,14 @@ def test_ephemeral_directory_property(config_instance):
 
 def test_dependency_property(config_instance):
     assert isinstance(config_instance.dependency, ansible_galaxy.AnsibleGalaxy)
+
+
+def test_dependency_property_is_gilt(config_instance, molecule_file):
+    gilt_data = {'dependency': {'name': 'gilt'}}
+    configs = [gilt_data]
+    c = config.Config(molecule_file, configs=configs)
+
+    assert isinstance(c.dependency, gilt.Gilt)
 
 
 def test_driver_property(config_instance):


### PR DESCRIPTION
Molecule should automatically install dependencies, when the
requirements file is present.

Fixes: #695