### PR TITLE
Corrected molecule error in dev env

### DIFF
--- a/molecule/command/base.py
+++ b/molecule/command/base.py
@@ -20,6 +20,7 @@
 
 import abc
 import collections
+import glob
 import os
 
 import yaml
@@ -98,11 +99,11 @@ def get_configs(args, command_args):
     current_directory = os.path.join(os.getcwd(), 'molecule')
     configs = [
         config.Config(
-            molecule_file=c,
+            molecule_file=os.path.abspath(c),
             args=args,
             command_args=command_args,
             configs=[_load_config(c)])
-        for c in util.os_walk(current_directory, 'molecule.yml')
+        for c in glob.glob('molecule/*/molecule.yml')
     ]
 
     scenario_name = command_args.get('scenario_name')

--- a/test/unit/provisioner/test_ansible.py
+++ b/test/unit/provisioner/test_ansible.py
@@ -209,7 +209,7 @@ def test_check(ansible_instance, mocker, patched_ansible_playbook):
 def test_write_inventory(temp_dir, ansible_instance):
     ansible_instance.write_inventory()
 
-    assert os.path.exists(ansible_instance.inventory_file)
+    assert os.path.isfile(ansible_instance.inventory_file)
 
     with open(ansible_instance.inventory_file, 'r') as stream:
         data = yaml.load(stream)
@@ -246,7 +246,7 @@ def test_write_inventory(temp_dir, ansible_instance):
 def test_write_config(temp_dir, ansible_instance):
     ansible_instance.write_config()
 
-    assert os.path.exists(ansible_instance.config_file)
+    assert os.path.isfile(ansible_instance.config_file)
 
 
 def test_setup(mocker, temp_dir, ansible_instance):
@@ -256,7 +256,7 @@ def test_setup(mocker, temp_dir, ansible_instance):
         'molecule.provisioner.ansible.Ansible.write_config')
     ansible_instance._setup()
 
-    assert os.path.exists(os.path.dirname(ansible_instance.inventory_file))
+    assert os.path.isdir(os.path.dirname(ansible_instance.inventory_file))
 
     patched_provisioner_write_inventory.assert_called_once_with()
     patched_provisioner_write_config.assert_called_once_with()


### PR DESCRIPTION
When developing molecule, any molecule command will fail when executing
from the project root, since os_walk detects the cookiecutter templates
as a scenario.

Updated with an intelligent glob to find scenarios.

Fixes: #705