### PR TITLE
Galaxy dependencies file can be the role meta file

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -226,6 +226,12 @@ override the defaults.
         ignore-certs: True
         ignore-errors: True
 
+
+The requirements file can be in a form that can be read directly by ``ansible-galaxy``, or it can be a `Ansible role meta file`_ (`meta/main.yml`) containing a `dependencies` key.
+
+.. _`Ansible role meta file`: http://docs.ansible.com/ansible/playbooks_roles.html#role-dependencies
+
+
 Shell
 ^^^^^
 

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -353,6 +353,11 @@ def state_data():
 
 
 @pytest.fixture()
+def galaxy_meta_file():
+    return {'dependencies': [{'role': 'molecule'}]}
+
+
+@pytest.fixture()
 def state_path_with_data(temp_files):
     return temp_files(fixtures=['state_data'])[0]
 

--- a/test/unit/dependency/test_ansible_galaxy.py
+++ b/test/unit/dependency/test_ansible_galaxy.py
@@ -18,8 +18,10 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 
+import os
 import pytest
 import sh
+import yaml
 
 from molecule import config
 from molecule.dependency import ansible_galaxy
@@ -38,6 +40,19 @@ def test_add_env_arg(ansible_galaxy_instance):
     ansible_galaxy_instance.add_env_arg('MOLECULE_1', 'test')
 
     assert 'test' == ansible_galaxy_instance._env['MOLECULE_1']
+
+
+def test_check_meta_requirements(temp_dir, temp_files,
+                                 ansible_galaxy_instance):
+    requirements_file = temp_files(fixtures=['galaxy_meta_file'])[0]
+    roles_directory = os.path.join(temp_dir, 'roles')
+
+    expected_yaml = [{'role': 'molecule'}]
+    expected_file = os.path.join(roles_directory, 'requirements.yml')
+    assert expected_file == ansible_galaxy_instance.check_meta_requirements(
+        requirements_file, roles_directory)
+    with open(expected_file) as f:
+        assert expected_yaml == yaml.load(f)
 
 
 def test_execute(patched_ansible_galaxy, ansible_galaxy_instance):


### PR DESCRIPTION
Many ansible roles contain a `meta/main.yml` file with a dependency key similar to a plain `requirements.yml` file. This PR adds support for using this file as the molecule galaxy `requirements_file` instead of having to create a redundant `requirements.yml` file, e.g.
```
dependency:
  name: galaxy
  requirements_file: meta/main.yml
```

Background: I've recently started using molecule for testing Ansible roles, and noticed the duplication in the dependencies, e.g.:
- https://github.com/openmicroscopy/ansible-role-omero-server/blob/master/meta/main.yml#L13
- https://github.com/openmicroscopy/ansible-role-omero-server/blob/master/tests/requirements.yml