### PR TITLE
Feature/add networking to dockerdriver

### DIFF
--- a/doc/source/driver/docker/index.rst
+++ b/doc/source/driver/docker/index.rst
@@ -40,6 +40,11 @@ Options
   container.
 * ``links`` - **(default=[])** the link mapping to allow containers to discover
   each other.
+* ``network_mode`` - **(default='bridge')** sets the Network mode for the container
+  - ``bridge'`` - creates a new network stack for the container on the Docker bridge
+  - ``none`` - no networking for this container
+  - ``container:[name|id]`` - reuses another containers network stack
+  - ``host`` -  use the host network stack inside the container or any name that identifies an existing Docker network.
 
 The available param for the Docker driver itself is:
 

--- a/doc/source/driver/docker/index.rst
+++ b/doc/source/driver/docker/index.rst
@@ -41,10 +41,10 @@ Options
 * ``links`` - **(default=[])** the link mapping to allow containers to discover
   each other.
 * ``network_mode`` - **(default='bridge')** sets the Network mode for the container
-  - ``bridge'`` - creates a new network stack for the container on the Docker bridge
-  - ``none`` - no networking for this container
-  - ``container:[name|id]`` - reuses another containers network stack
-  - ``host`` -  use the host network stack inside the container or any name that identifies an existing Docker network.
+- ``bridge'`` - creates a new network stack for the container on the Docker bridge
+- ``none`` - no networking for this container
+- ``container:[name|id]`` - reuses another containers network stack
+- ``host`` -  use the host network stack inside the container or any name that identifies an existing Docker network.
 
 The available param for the Docker driver itself is:
 

--- a/doc/source/driver/docker/index.rst
+++ b/doc/source/driver/docker/index.rst
@@ -40,11 +40,7 @@ Options
   container.
 * ``links`` - **(default=[])** the link mapping to allow containers to discover
   each other.
-* ``network_mode`` - **(default='bridge')** sets the Network mode for the container
-- ``bridge'`` - creates a new network stack for the container on the Docker bridge
-- ``none`` - no networking for this container
-- ``container:[name|id]`` - reuses another containers network stack
-- ``host`` -  use the host network stack inside the container or any name that identifies an existing Docker network.
+* ``network_mode`` - **(default='bridge')** sets the Network mode for the container. ``bridge`` creates a new network stack for the container on the Docker bridge. ``none`` no networking for this container. ``container:[name|id]`` reuses another containers network stack. ``host`` use the host network stack inside the container or any name that identifies an existing Docker network.
 
 The available param for the Docker driver itself is:
 

--- a/molecule/driver/dockerdriver.py
+++ b/molecule/driver/dockerdriver.py
@@ -121,6 +121,7 @@ class DockerDriver(basedriver.BaseDriver):
             port_bindings = container.get('port_bindings', {})
             volume_mounts = container.get('volume_mounts', [])
             links = container.get('links', {})
+            network_mode = container.get('network_mode', '')
             cap_add = container.get('cap_add', [])
             cap_drop = container.get('cap_drop', [])
             command = container.get('command', '')
@@ -131,6 +132,7 @@ class DockerDriver(basedriver.BaseDriver):
                 port_bindings=port_bindings,
                 binds=volume_mounts,
                 links=links,
+                network_mode=network_mode,
                 cap_add=cap_add,
                 cap_drop=cap_drop)
 

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -266,7 +266,8 @@ def docker_v1_section_data():
                 'volume_mounts': ['/tmp/test1:/inside:rw'],
                 'cap_add': ['SYS_ADMIN', 'SETPCAP'],
                 'cap_drop': ['MKNOD'],
-                'ansible_groups': ['group1']
+                'ansible_groups': ['group1'],
+                'network_mode': 'bridge'
             }, {
                 'name': 'test2',
                 'image': 'ubuntu',
@@ -275,6 +276,7 @@ def docker_v1_section_data():
                 },
                 'image_version': 'latest',
                 'ansible_groups': ['group2'],
+                'network_mode': 'bridge',
                 'command': '/bin/sh',
                 'options': {
                     'append_platform_to_hostname': True

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -260,14 +260,14 @@ def docker_v1_section_data():
                     'FOO': 'BAR',
                     'BAZ': 'QUX'
                 },
-                'options': {
-                    'append_platform_to_hostname': True
-                },
                 'volume_mounts': ['/tmp/test1:/inside:rw'],
                 'cap_add': ['SYS_ADMIN', 'SETPCAP'],
                 'cap_drop': ['MKNOD'],
                 'ansible_groups': ['group1'],
-                'network_mode': 'bridge'
+                'network_mode': 'bridge',
+                'options': {
+                    'append_platform_to_hostname': True
+                },
             }, {
                 'name': 'test2',
                 'image': 'ubuntu',
@@ -277,6 +277,26 @@ def docker_v1_section_data():
                 'image_version': 'latest',
                 'ansible_groups': ['group2'],
                 'network_mode': 'bridge',
+                'command': '/bin/sh',
+                'options': {
+                    'append_platform_to_hostname': True
+                },
+            }, {
+                'name': 'test3',
+                'image': 'ubuntu',
+                'image_version': 'latest',
+                'ansible_groups': ['group1'],
+                'network_mode': 'none',
+                'command': '/bin/sh',
+                'options': {
+                    'append_platform_to_hostname': True
+                },
+            }, {
+                'name': 'test4',
+                'image': 'ubuntu',
+                'image_version': 'latest',
+                'ansible_groups': ['group2'],
+                'network_mode': 'host',
                 'command': '/bin/sh',
                 'options': {
                     'append_platform_to_hostname': True

--- a/test/unit/core/test_core_docker.py
+++ b/test/unit/core/test_core_docker.py
@@ -78,6 +78,12 @@ def test_instances_state(docker_molecule_instance):
         },
         'test2-docker': {
             'groups': ['group2']
+        },
+        'test3-docker': {
+            'groups': ['group1']
+        },
+        'test4-docker': {
+            'groups': ['group2']
         }
     }
 

--- a/test/unit/driver/test_dockerdriver.py
+++ b/test/unit/driver/test_dockerdriver.py
@@ -233,3 +233,13 @@ def test_links(docker_instance):
     d2 = docker_instance._docker.inspect_container('test2')['HostConfig'][
         'Links']
     assert '/test1:/test2/80' in d2
+
+
+def test_network_mode(docker_instance):
+    docker_instance.up()
+    d1 = docker_instance._docker.inspect_container('test1')['HostConfig'][
+        'NetworkMode']
+    assert 'bridge' in d1
+    d2 = docker_instance._docker.inspect_container('test1')['HostConfig'][
+        'NetworkMode']
+    assert 'bridge' in d2

--- a/test/unit/driver/test_dockerdriver.py
+++ b/test/unit/driver/test_dockerdriver.py
@@ -235,7 +235,7 @@ def test_links(docker_instance):
     assert '/test1:/test2/80' in d2
 
 
-def test_network_mode(docker_instance):
+def test_network_mode_bridge(docker_instance):
     docker_instance.up()
     d1 = docker_instance._docker.inspect_container('test1')['HostConfig'][
         'NetworkMode']
@@ -243,3 +243,17 @@ def test_network_mode(docker_instance):
     d2 = docker_instance._docker.inspect_container('test1')['HostConfig'][
         'NetworkMode']
     assert 'bridge' in d2
+
+
+def test_network_mode_none(docker_instance):
+    docker_instance.up()
+    d1 = docker_instance._docker.inspect_container('test3')['HostConfig'][
+        'NetworkMode']
+    assert 'none' in d1
+
+
+def test_network_mode_host(docker_instance):
+    docker_instance.up()
+    d1 = docker_instance._docker.inspect_container('test4')['HostConfig'][
+        'NetworkMode']
+    assert 'host' in d1


### PR DESCRIPTION
Adds the network_mode parameter from docker-py to current implementation of dockerdriver. 

This should basically satisfy the feature requests in issue #650 