### PR TITLE
Corrected molecule.yml's group_vars/host_vars

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -99,14 +99,14 @@ in this situation - simply add the `host_vars` and/or `group_vars` to the
     playbook: playbook.yml
     group_vars:
       foo1:
-        - test: key
-          var2: value
+        foo: bar
+        baz:
+          key: value
       foo2:
-        - test: key
-          var: value
+        foo: bar
     host_vars:
       foo1-01:
-        - set_this_value: True
+        set_this_value: True
 
 This example will set the variables for the Ansible groups `foo1` and `foo2`.
 For hosts `foo1-01` the value `set_this_value` will be set to True.

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -324,7 +324,7 @@ class Molecule(object):
             os.mkdir(os.path.abspath(target_vars_path))
 
         for target in vars_target.keys():
-            target_var_content = vars_target[target][0]
+            target_var_content = vars_target[target]
             path = os.path.join(os.path.abspath(target_vars_path), target)
 
             util.write_file(

--- a/test/scenarios/group_host_vars/molecule.yml
+++ b/test/scenarios/group_host_vars/molecule.yml
@@ -6,12 +6,13 @@ driver:
 ansible:
   group_vars:
     example:
-      - group_host_vars_example_group_molecule_yml: foo
+      group_host_vars_example_group_one_molecule_yml: foo
+      group_host_vars_example_group_two_molecule_yml: foo
     example2:
-      - group_host_vars_example2_group_molecule_yml: foo
+      group_host_vars_example2_group_molecule_yml: foo
   host_vars:
     group-vars-scenario:
-      - group_host_vars_host_molecule_yml: bar
+      group_host_vars_host_molecule_yml: bar
 docker:
   containers:
     - name: group-vars-scenario

--- a/test/scenarios/group_host_vars/playbook.yml
+++ b/test/scenarios/group_host_vars/playbook.yml
@@ -7,7 +7,7 @@
       tags: foo
 
     - name: Group host vars scenario test example group vars from molecule.yml
-      command: echo "{{ group_host_vars_example_group_molecule_yml }}"
+      command: echo "{{ group_host_vars_example_group_one_molecule_yml }} {{ group_host_vars_example_group_two_molecule_yml }}"
       changed_when: False
       tags:
         - foo


### PR DESCRIPTION
This is a Breaking Change.
The host_vars and group_vars section of molecule.yml takes a list.
However, it only operates on the first element of the list.  Updated
the syntax to match Ansible's own use of vars in a playbook[1].

[1] http://docs.ansible.com/ansible/playbooks_variables.html#variables-defined-in-a-playbook

Fixes: #721