### PR TITLE
Handle verbose flags

### DIFF
--- a/molecule/verifier/testinfra.py
+++ b/molecule/verifier/testinfra.py
@@ -96,7 +96,18 @@ class Testinfra(base.Base):
             self._testinfra_dir)
         util.print_info(msg)
 
-        cmd = sh.testinfra.bake(tests, **kwargs)
+        verbose = 'v'
+        verbose_flag = str()
+        for i in range(0, 3):
+            if kwargs.get(verbose):
+                verbose_flag = '-{}'.format(verbose)
+                del kwargs[verbose]
+                if kwargs.get('verbose'):
+                    del kwargs['verbose']
+                break
+            verbose = verbose + 'v'
+
+        cmd = sh.testinfra.bake(tests, verbose_flag, **kwargs)
         return util.run_command(cmd, debug=self._debug)
 
     def _flake8(self, tests, out=util.callback_info, err=util.callback_error):


### PR DESCRIPTION
Verbose can be passed a couple of ways (`--verbose` or `-v{1,4}`).  The
sh module will properly handle single character options passed to the
verifier.  However, incorrectly creates multi-character testinfra flags.
An option of {'vv': yes} becomes `--vv` instead of `-vv`.

Fixes: #735