### PR TITLE
[v2] allow tests to run on python35

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
   - sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y docker-engine
 python:
   - "2.7"
+  - "3.5"
   - "3.6"
 install: pip install tox-travis
 script: tox

--- a/molecule/ansible_playbook.py
+++ b/molecule/ansible_playbook.py
@@ -60,10 +60,13 @@ class AnsiblePlaybook(object):
         :return: None
         """
         self.add_cli_arg('inventory', self._inventory)
+        options = self._cli
+        verbose_flag = util.verbose_flag(options)
 
         self._ansible_playbook_command = sh.ansible_playbook.bake(
-            self._cli,
+            options,
             self._playbook,
+            *verbose_flag,
             _cwd=self._config.scenario.directory,
             _env=self._env,
             _out=self._out,

--- a/molecule/util.py
+++ b/molecule/util.py
@@ -191,3 +191,18 @@ def instance_with_scenario_name(instance_name, scenario_name):
 
 def ansi_escape(string):
     return re.sub(r'\x1b[^m]*m', '', string)
+
+
+def verbose_flag(options):
+    verbose = 'v'
+    verbose_flag = []
+    for i in range(0, 3):
+        if options.get(verbose):
+            verbose_flag = ['-{}'.format(verbose)]
+            del options[verbose]
+            if options.get('verbose'):
+                del options['verbose']
+            break
+        verbose = verbose + 'v'
+
+    return verbose_flag

--- a/molecule/verifier/testinfra.py
+++ b/molecule/verifier/testinfra.py
@@ -103,9 +103,14 @@ class Testinfra(base.Base):
 
         :return: None
         """
+
+        options = self.options
+        verbose_flag = util.verbose_flag(options)
+
         self._testinfra_command = sh.testinfra.bake(
-            self.options,
+            options,
             self._tests,
+            *verbose_flag,
             _cwd=self._config.scenario.directory,
             _env=self.env,
             _out=util.callback_info,

--- a/test/unit/dependency/test_ansible_galaxy.py
+++ b/test/unit/dependency/test_ansible_galaxy.py
@@ -171,7 +171,7 @@ def test_execute_bakes(patched_run_command, ansible_galaxy_instance, role_file,
     ansible_galaxy_instance.execute()
     assert ansible_galaxy_instance._ansible_galaxy_command is not None
 
-    patched_run_command.assert_called_once
+    assert 1 == patched_run_command.call_count
 
 
 def test_executes_catches_and_exits_return_code(

--- a/test/unit/dependency/test_gilt.py
+++ b/test/unit/dependency/test_gilt.py
@@ -142,7 +142,7 @@ def test_execute_bakes(patched_run_command, gilt_config,
     gilt_instance.execute()
     assert gilt_instance._gilt_command is not None
 
-    patched_run_command.assert_called_once
+    assert 1 == patched_run_command.call_count
 
 
 def test_executes_catches_and_exits_return_code(

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -228,3 +228,24 @@ def test_ansi_escape():
     string = 'ls\r\n\x1b[00m\x1b[01;31mfoo\x1b[00m\r\n\x1b[01;31m'
 
     assert 'ls\r\nfoo\r\n' == util.ansi_escape(string)
+
+
+def test_verbose_flag():
+    options = {'verbose': True, 'v': True}
+
+    assert ['-v'] == util.verbose_flag(options)
+    assert {} == options
+
+
+def test_verbose_flag_extra_verbose():
+    options = {'verbose': True, 'vvv': True}
+
+    assert ['-vvv'] == util.verbose_flag(options)
+    assert {} == options
+
+
+def test_verbose_flag_preserves_verbose_option():
+    options = {'verbose': True}
+
+    assert [] == util.verbose_flag(options)
+    assert {'verbose': True} == options

--- a/test/unit/verifier/conftest.py
+++ b/test/unit/verifier/conftest.py
@@ -27,10 +27,12 @@ def molecule_verifier_section_data():
         'verifier': {
             'name': 'testinfra',
             'options': {
-                'foo': 'bar'
+                'foo': 'bar',
+                'vvv': True,
+                'verbose': True,
             },
             'env': {
-                'foo': 'bar'
+                'foo': 'bar',
             }
         }
     }

--- a/test/unit/verifier/test_flake8.py
+++ b/test/unit/verifier/test_flake8.py
@@ -56,12 +56,22 @@ def test_directory_property(flake8_instance):
 
 
 def test_options_property(flake8_instance):
-    assert {'foo': 'bar'} == flake8_instance.options
+    x = {
+        'foo': 'bar',
+        'vvv': True,
+        'verbose': True,
+    }
+
+    assert x == flake8_instance.options
 
 
 def test_options_property_handles_cli_args(flake8_instance):
     flake8_instance._config.args = {'debug': True}
-    x = {'foo': 'bar'}
+    x = {
+        'foo': 'bar',
+        'vvv': True,
+        'verbose': True,
+    }
 
     # Does nothing.  The `flake8` command does not support
     # a `debug` flag.

--- a/test/unit/verifier/test_testinfra.py
+++ b/test/unit/verifier/test_testinfra.py
@@ -167,7 +167,7 @@ def test_execute_bakes(patched_flake8, patched_run_command,
     assert testinfra_instance._testinfra_command is not None
 
     patched_flake8.assert_called_once_with()
-    patched_run_command.assert_called_once
+    assert 1 == patched_run_command.call_count
 
 
 def test_executes_catches_and_exits_return_code(

--- a/test/unit/verifier/test_testinfra.py
+++ b/test/unit/verifier/test_testinfra.py
@@ -89,7 +89,9 @@ def test_options_property(testinfra_instance):
     assert {
         'connection': 'ansible',
         'ansible-inventory': '.molecule/ansible_inventory.yml',
-        'foo': 'bar'
+        'foo': 'bar',
+        'vvv': True,
+        'verbose': True,
     } == testinfra_instance.options
 
 
@@ -100,7 +102,9 @@ def test_options_property_handles_cli_args(testinfra_instance):
         'connection': 'ansible',
         'ansible-inventory': '.molecule/ansible_inventory.yml',
         'foo': 'bar',
-        'debug': True
+        'debug': True,
+        'vvv': True,
+        'verbose': True,
     } == testinfra_instance.options
 
 
@@ -110,7 +114,7 @@ def test_bake(testinfra_instance):
     x = [
         str(sh.testinfra),
         '--ansible-inventory=.molecule/ansible_inventory.yml',
-        '--connection=ansible', '--foo=bar', 'test1', 'test2', 'test3'
+        '--connection=ansible', '-vvv', '--foo=bar', 'test1', 'test2', 'test3'
     ]
     result = str(testinfra_instance._testinfra_command).split()
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,13 @@
 [tox]
 minversion = 1.8
 envlist =
-    lint
-    py{27}-ansible{22}-{unit,functional}
-    py{36}-ansible{22}-{unit}
+    py{27}-ansible{22}-{functional}
+    py{27,35,36}-ansible{22}-{unit}
+    py{27,35,36}-lint
     doc
+    format
 skipdist = True
+skip_missing_interpreters=True
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
- add python35 targets to travis and tox
- update tox to run linter for all python versions
- update tests that use asssert_called_once to test against call_count
  instead (assert_called_once is only supported for python < 3 and >= 3.6)
- update tox config to not fail if a target interpreter is missing