### PR TITLE
[v2]Fix lint environments in tox

### DIFF
--- a/molecule/provisioner/ansible.py
+++ b/molecule/provisioner/ansible.py
@@ -305,10 +305,13 @@ class Ansible(object):
             vars_target = copy.deepcopy(self.host_vars)
             # Append the scenario-name
             for instance_name, _ in self.host_vars.items():
-                instance_with_scenario_name = util.instance_with_scenario_name(
-                    instance_name, self._config.scenario.name)
-                vars_target[instance_with_scenario_name] = vars_target.pop(
-                    instance_name)
+                if instance_name == 'localhost':
+                    instance_key = instance_name
+                else:
+                    instance_key = util.instance_with_scenario_name(
+                        instance_name, self._config.scenario.name)
+
+                vars_target[instance_key] = vars_target.pop(instance_name)
 
         elif target == 'group_vars':
             vars_target = self.group_vars

--- a/test/unit/provisioner/test_ansible.py
+++ b/test/unit/provisioner/test_ansible.py
@@ -47,6 +47,9 @@ def molecule_provisioner_section_data():
                 'instance-1': [{
                     'foo': 'bar'
                 }],
+                'localhost': [{
+                    'foo': 'baz'
+                }]
             },
             'group_vars': {
                 'example_group1': [{
@@ -150,7 +153,7 @@ def test_env_property(ansible_instance):
 
 
 def test_host_vars_property(ansible_instance):
-    x = {'instance-1': [{'foo': 'bar'}]}
+    x = {'instance-1': [{'foo': 'bar'}], 'localhost': [{'foo': 'baz'}]}
 
     assert x == ansible_instance.host_vars
 
@@ -296,6 +299,9 @@ def test_add_or_update_vars(ansible_instance):
     ansible_instance.add_or_update_vars('host_vars')
     assert os.path.isdir(host_vars_directory)
     assert os.path.isfile(host_vars)
+
+    host_vars_localhost = os.path.join(host_vars_directory, 'localhost')
+    assert os.path.isfile(host_vars_localhost)
 
     group_vars_directory = os.path.join(ephemeral_directory, 'group_vars')
     group_vars_1 = os.path.join(group_vars_directory, 'example_group1')

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ commands =
     functional: py.test -vv -x test/functional/ {posargs}
     lint: flake8
     # TODO(retr0h): Implement
-    # pylint --rcfile .pylintrc molecule/
+    #lint: pylint --rcfile .pylintrc molecule/
 
 [testenv:format]
 deps =


### PR DESCRIPTION
With the change to prefixing the lint env, the lint commands needed to be moved to the [testenv] stanza.