### PR TITLE
Correct too many authentication failures error

### DIFF
--- a/molecule/config.py
+++ b/molecule/config.py
@@ -174,8 +174,11 @@ class ConfigV1(Config):
                 'limit': 'all',
                 'playbook': 'playbook.yml',
                 'raw_ssh_args': [
-                    '-o UserKnownHostsFile=/dev/null', '-o IdentitiesOnly=yes',
-                    '-o ControlMaster=auto', '-o ControlPersist=60s'
+                    '-o UserKnownHostsFile=/dev/null',
+                    '-o IdentitiesOnly=yes',
+                    '-o ControlMaster=auto',
+                    '-o ControlPersist=60s',
+                    '-o IdentitiesOnly=yes',
                 ],
                 'tags': False,
                 'timeout': 30,
@@ -204,7 +207,8 @@ class ConfigV1(Config):
                 'rakefile_file': 'rakefile',
                 'raw_ssh_args': [
                     '-o StrictHostKeyChecking=no',
-                    '-o UserKnownHostsFile=/dev/null'
+                    '-o UserKnownHostsFile=/dev/null',
+                    '-o IdentitiesOnly=yes',
                 ],
                 'serverspec_dir': 'spec',
                 'state_file': 'state.yml',

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -175,7 +175,6 @@ class ConfigV1(Config):
                 'playbook': 'playbook.yml',
                 'raw_ssh_args': [
                     '-o UserKnownHostsFile=/dev/null',
-                    '-o IdentitiesOnly=yes',
                     '-o ControlMaster=auto',
                     '-o ControlPersist=60s',
                     '-o IdentitiesOnly=yes',


### PR DESCRIPTION
By default, SSH will try to offer all keys found under ~/.ssh. If it
reaches the limit of authentication failures (default=6), the connection
will be closed. This is a problem for people with many SSH keys. To work
around this issue and only use the specified IdentifyFile (-i), the
option IdentitiesOnly should be specified.

Fixes: #749