### PR TITLE
Correct testinfra tests discovered twice

### DIFF
--- a/molecule/verifier/testinfra.py
+++ b/molecule/verifier/testinfra.py
@@ -107,7 +107,11 @@ class Testinfra(base.Base):
                 break
             verbose = verbose + 'v'
 
-        cmd = sh.testinfra.bake(tests, verbose_flag, **kwargs)
+        cmd = sh.testinfra.bake(tests)
+        if verbose_flag:
+            cmd = cmd.bake(verbose_flag)
+        cmd = cmd.bake(**kwargs)
+
         return util.run_command(cmd, debug=self._debug)
 
     def _flake8(self, tests, out=util.callback_info, err=util.callback_error):

--- a/test/unit/verifier/test_testinfra.py
+++ b/test/unit/verifier/test_testinfra.py
@@ -82,7 +82,7 @@ def test_testinfra(patched_run_command, patched_get_tests, testinfra_instance):
     kwargs = {'debug': False, '_out': None, '_err': None}
     testinfra_instance._testinfra(*args, **kwargs)
 
-    x = sh.testinfra.bake('/tmp/ansible-inventory ')
+    x = sh.testinfra.bake('/tmp/ansible-inventory')
     patched_run_command.assert_called_once_with(x, debug=None)
 
 


### PR DESCRIPTION
When executing testinfra via Molecule, tests would be discovered twice.
This was happening b/c an empty string was being passed to the testinfra
bake command.

Fixes: #744
Introduced In: #736