### PR TITLE
docker driver 'build_image' added instance specific overrides applciable

### DIFF
--- a/doc/source/driver/docker/index.rst
+++ b/doc/source/driver/docker/index.rst
@@ -46,10 +46,12 @@ Options
   ``container:[name|id]`` reuses another containers network stack. ``host`` use
   the host network stack inside the container or any name that identifies an
   existing Docker network.
+* ``build_image`` - **(default=None)** override global driver value
+  to build (or not) an image for use with Molecule.
 
 The available param for the Docker driver itself is:
 
-* ``build_image`` - **(default=True)** build an image for use with Molecule.
+* ``build_image`` - **(default=True)** build images for use with Molecule.
 * ``dockerfile`` - **(default=dockerfile)** supply a custom Dockerfile instead
   of Molecule provided image.
 

--- a/molecule/driver/dockerdriver.py
+++ b/molecule/driver/dockerdriver.py
@@ -41,8 +41,6 @@ class DockerDriver(basedriver.BaseDriver):
         self._provider = self._get_provider()
         self._platform = self._get_platform()
 
-        self.image_tag = 'molecule_local/{}:{}'
-
         if 'build_image' not in self.molecule.config.config['docker']:
             self.molecule.config.config['docker']['build_image'] = True
 
@@ -109,14 +107,21 @@ class DockerDriver(basedriver.BaseDriver):
     def serverspec_args(self):
         return {}
 
-    def up(self, no_provision=True):
+    def up(self, no_provision=True, image_tag='molecule_local/{}:{}'):
+
         self.molecule.state.change_state('driver', self.name)
-        if self.molecule.config.config['docker']['build_image']:
-            self._build_ansible_compatible_image()
-        else:
-            self.image_tag = '{}:{}'
 
         for container in self.instances:
+
+            # check global docker driver or specific container config for
+            # overrides for molecule image creation
+            if (container.get('build_image') or
+                (self.molecule.config.config['docker']['build_image'] and
+                 container.get('build_image', True))):
+                container['image_tag'] = image_tag
+                self._build_ansible_compatible_image(container)
+            else:
+                container['image_tag'] = '{}:{}'
             privileged = container.get('privileged', False)
             port_bindings = container.get('port_bindings', {})
             volume_mounts = container.get('volume_mounts', [])
@@ -143,8 +148,8 @@ class DockerDriver(basedriver.BaseDriver):
                            container['image_version'])
                 util.print_warn(msg)
                 container = self._docker.create_container(
-                    image=self.image_tag.format(container['image'],
-                                                container['image_version']),
+                    image=container['image_tag'].format(
+                        container['image'], container['image_version']),
                     tty=True,
                     detach=False,
                     name=container['name'],
@@ -214,87 +219,82 @@ class DockerDriver(basedriver.BaseDriver):
     def _get_provider(self):
         return 'docker'
 
-    def _build_ansible_compatible_image(self):
+    def _build_ansible_compatible_image(self, container):
         available_images = [
             tag.encode('utf-8')
             for image in self._docker.images()
             for tag in image.get('RepoTags', [])
         ]
 
-        for container in self.instances:
-            if container.get('build_image'):
-                msg = ('Creating Ansible compatible '
-                       'image of {}:{} ...').format(container['image'],
-                                                    container['image_version'])
-                util.print_info(msg)
+        msg = ('Creating Ansible compatible '
+               'image of {}:{} ...').format(container['image'],
+                                            container['image_version'])
+        util.print_info(msg)
 
-            if 'registry' in container:
-                container['registry'] += '/'
+        if 'registry' in container:
+            container['registry'] += '/'
+        else:
+            container['registry'] = ''
+
+        dockerfile = '''
+        FROM {container_image}:{container_version}
+        {container_environment}
+        RUN bash -c 'if [ -x "$(command -v apt-get)" ]; then apt-get update && apt-get install -y python sudo; fi'
+        RUN bash -c 'if [ -x "$(command -v yum)" ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf; fi'
+        RUN bash -c 'if [ -x "$(command -v zypper)" ]; then zypper refresh && zypper update -y && zypper install -y python sudo; fi'
+        '''  # noqa
+
+        if 'dockerfile' in container:
+            dockerfile = container['dockerfile']
+            f = io.open(dockerfile)
+
+        else:
+            environment = container.get('environment')
+            if environment:
+                environment = '\n'.join('ENV {} {}'.format(k, v)
+                                        for k, v in environment.iteritems())
             else:
-                container['registry'] = ''
+                environment = ''
 
-            dockerfile = '''
-            FROM {container_image}:{container_version}
-            {container_environment}
-            RUN bash -c 'if [ -x "$(command -v apt-get)" ]; then apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y python sudo; fi'
-            RUN bash -c 'if [ -x "$(command -v yum)" ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf; fi'
-            RUN bash -c 'if [ -x "$(command -v zypper)" ]; then zypper refresh && zypper update -y && zypper install -y python sudo; fi'
+            dockerfile = dockerfile.format(
+                container_image=container['registry'] + container['image'],
+                container_version=container['image_version'],
+                container_environment=environment)
 
-            '''  # noqa
+            f = io.BytesIO(dockerfile.encode('utf-8'))
 
-            if 'dockerfile' in container:
-                dockerfile = container['dockerfile']
-                f = io.open(dockerfile)
+            container['image'] = container['registry'].replace(
+                '/', '_').replace(':', '_') + container['image']
 
+        tag_string = container['image_tag'].format(container['image'],
+                                                   container['image_version'])
+
+        errors = False
+
+        if tag_string not in available_images or 'dockerfile' in container:
+            util.print_info('Building ansible compatible image...')
+            previous_line = ''
+            for line in self._docker.build(fileobj=f, tag=tag_string):
+                for line_split in line.split('\n'):
+                    if len(line_split) > 0:
+                        line = json.loads(line_split)
+                        if 'stream' in line:
+                            msg = '\t{}'.format(line['stream'])
+                            util.print_warn(msg)
+                        if 'errorDetail' in line:
+                            ed = line['errorDetail']['message']
+                            msg = '\t{}'.format(ed)
+                            util.print_warn(msg)
+                            errors = True
+                        if 'status' in line:
+                            if previous_line not in line['status']:
+                                msg = '\t{} ...'.format(line['status'])
+                                util.print_warn(msg)
+                            previous_line = line['status']
+
+            if errors:
+                msg = 'Build failed for {}.'.format(tag_string)
+                util.print_error(msg)
+                return
             else:
-                environment = container.get('environment')
-                if environment:
-                    environment = '\n'.join(
-                        'ENV {} {}'.format(k, v)
-                        for k, v in environment.iteritems())
-                else:
-                    environment = ''
-
-                dockerfile = dockerfile.format(
-                    container_image=container['registry'] + container['image'],
-                    container_version=container['image_version'],
-                    container_environment=environment)
-
-                f = io.BytesIO(dockerfile.encode('utf-8'))
-
-                container['image'] = container['registry'].replace(
-                    '/', '_').replace(':', '_') + container['image']
-
-            tag_string = self.image_tag.format(container['image'],
-                                               container['image_version'])
-
-            errors = False
-
-            if tag_string not in available_images or 'dockerfile' in container:
-                util.print_info('Building ansible compatible image...')
-                previous_line = ''
-                for line in self._docker.build(fileobj=f, tag=tag_string):
-                    for line_split in line.split('\n'):
-                        if len(line_split) > 0:
-                            line = json.loads(line_split)
-                            if 'stream' in line:
-                                msg = '\t{}'.format(line['stream'])
-                                util.print_warn(msg)
-                            if 'errorDetail' in line:
-                                ed = line['errorDetail']['message']
-                                msg = '\t{}'.format(ed)
-                                util.print_warn(msg)
-                                errors = True
-                            if 'status' in line:
-                                if previous_line not in line['status']:
-                                    msg = '\t{} ...'.format(line['status'])
-                                    util.print_warn(msg)
-                                previous_line = line['status']
-
-                if errors:
-                    msg = 'Build failed for {}.'.format(tag_string)
-                    util.print_error(msg)
-                    return
-                else:
-                    util.print_success('Finished building {}.'.format(
-                        tag_string))
+                util.print_success('Finished building {}.'.format(tag_string))

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 testpaths = test/unit/
+addopts = --cov-report term-missing

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -301,6 +301,17 @@ def docker_v1_section_data():
                 'options': {
                     'append_platform_to_hostname': True
                 },
+            }, {
+                'name': 'test5',
+                'image': 'ubuntu',
+                'image_version': 'latest',
+                'ansible_groups': ['group2'],
+                'network_mode': 'host',
+                'command': '/bin/sh',
+                'build_image': False,
+                'options': {
+                    'append_platform_to_hostname': True
+                }
             }]
         }
     }

--- a/test/unit/core/test_core_docker.py
+++ b/test/unit/core/test_core_docker.py
@@ -84,6 +84,9 @@ def test_instances_state(docker_molecule_instance):
         },
         'test4-docker': {
             'groups': ['group2']
+        },
+        'test5-docker': {
+            'groups': ['group2']
         }
     }
 

--- a/test/unit/driver/test_dockerdriver.py
+++ b/test/unit/driver/test_dockerdriver.py
@@ -235,6 +235,14 @@ def test_links(docker_instance):
     assert '/test1:/test2/80' in d2
 
 
+def test_build_image(docker_instance):
+    docker_instance.up()
+    d1 = docker_instance._docker.inspect_container('test1')
+    d5 = docker_instance._docker.inspect_container('test5')
+    assert 'molecule_local/ubuntu:latest' == d1['Config']['Image']
+    assert 'ubuntu:latest' == d5['Config']['Image']
+
+
 def test_network_mode_bridge(docker_instance):
     docker_instance.up()
     d1 = docker_instance._docker.inspect_container('test1')['HostConfig'][


### PR DESCRIPTION
Found myself in need of using other containers as dependencies for a given scenarios and I would not create a molecule_local tagged image for a container I just need as dependency, so i gave build_image config option to be overridden by container specific configuration (with priority over driver generic config)