### PR TITLE
Remove vm.hostname from vagrantfile

### DIFF
--- a/molecule/cookiecutter/driver/vagrant-runtime/{{cookiecutter.repo_name}}/vagrantfile
+++ b/molecule/cookiecutter/driver/vagrant-runtime/{{cookiecutter.repo_name}}/vagrantfile
@@ -217,10 +217,6 @@ Vagrant.configure('2') do |config|
     if driver_config['instances']
         driver_config['instances'].each { |instance|
             config.vm.define instance['vm_name'] do |c|
-                if driver_config['current_provider'] != 'libvirt'
-                    c.vm.hostname = instance['vm_name']
-                end
-
                 if instance['platform']
                     c.vm.box = instance['platform']
                 end


### PR DESCRIPTION
Parameter vm.hostname is not required, vagrant can run without it.
Removing this will make vagrant stop adding 127.0.0.1 on guest /etc/hosts file.
Fixes #758.