### PR TITLE
Support for new docker sdk (quick fix)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,7 @@ Install Molecule using pip:
 .. code-block:: bash
 
   $ pip install ansible
-  $ pip install docker-py
+  $ pip install docker
   $ pip install molecule
 
 Create a new role with the docker driver:

--- a/doc/source/driver/docker/index.rst
+++ b/doc/source/driver/docker/index.rst
@@ -27,7 +27,7 @@ Options
   privileged mode.
 * ``registry`` - **(default='')** the registry to obtain the image.
 * ``port_bindings`` - **(default={})** the port mapping between the Docker host
-  and the container.  This is passed to docker-py as the port_bindings
+  and the container.  This is passed to docker as the port_bindings
   `host config`_.
 * ``volume_mounts`` - **(default=[])** the volume mappings between the Docker
   host and the container.
@@ -53,5 +53,5 @@ The available param for the Docker driver itself is:
 * ``dockerfile`` - **(default=dockerfile)** supply a custom Dockerfile instead
   of Molecule provided image.
 
-.. _`host config`: https://github.com/docker/docker-py/blob/master/docs/port-bindings.md
+.. _`host config`: https://docker-py.readthedocs.io/en/stable/api.html#docker.api.container.ContainerApiMixin.create_host_config
 .. _`capability`: https://docs.docker.com/engine/reference/run/#/runtime-privilege-and-linux-capabilities

--- a/doc/source/driver/docker/usage.rst
+++ b/doc/source/driver/docker/usage.rst
@@ -7,7 +7,7 @@ Usage
 
 .. code-block:: bash
 
-  $ pip install docker-py
+  $ pip install docker
 
 .. code-block:: yaml
 

--- a/molecule/driver/dockerdriver.py
+++ b/molecule/driver/dockerdriver.py
@@ -26,7 +26,7 @@ import sys
 try:
     import docker
 except ImportError:  # pragma: no cover
-    sys.exit('ERROR: Driver missing, install docker-py.')
+    sys.exit('ERROR: python docker driver missing, install the docker package.')
 
 from molecule import util
 from molecule.driver import basedriver

--- a/molecule/driver/dockerdriver.py
+++ b/molecule/driver/dockerdriver.py
@@ -35,7 +35,7 @@ from molecule.driver import basedriver
 class DockerDriver(basedriver.BaseDriver):
     def __init__(self, molecule):
         super(DockerDriver, self).__init__(molecule)
-        self._docker = docker.Client(
+        self._docker = docker.APIClient(
             version='auto', **docker.utils.kwargs_from_env())
         self._containers = self.molecule.config.config['docker']['containers']
         self._provider = self._get_provider()

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-docker-py==1.10.3
+docker==2.1.0
 mock
 pytest
 pytest-cov


### PR DESCRIPTION
In regards to #743 

This is a quick fix to alleviate the issue with the SDK changes.  I can spend more time to utilize the abstraction layer built on top of the 'low-level API' if desired. 
