### PR TITLE
Openstack: Allow using ssh keys from ssh-agent

### DIFF
--- a/test/unit/driver/test_openstackdriver.py
+++ b/test/unit/driver/test_openstackdriver.py
@@ -92,7 +92,7 @@ def test_serverspec_args(openstack_instance):
 
 
 def test_login_cmd(openstack_instance):
-    assert 'ssh {} -l {} -i {}' == openstack_instance.login_cmd('aio-01')
+    assert 'ssh {} -l {} {}' == openstack_instance.login_cmd('aio-01')
 
 
 def test_login_args(openstack_instance):


### PR DESCRIPTION
Currently, the Openstack driver creates a temporary
keypair if one of keypair and keyfile is undefined.
This patch changes that behavior to only create a keypair
if keypair is undefined.