### PR TITLE
Get rid of terminal warnings issue while running apt

### DIFF
--- a/molecule/driver/dockerdriver.py
+++ b/molecule/driver/dockerdriver.py
@@ -236,7 +236,7 @@ class DockerDriver(basedriver.BaseDriver):
             dockerfile = '''
             FROM {container_image}:{container_version}
             {container_environment}
-            RUN bash -c 'if [ -x "$(command -v apt-get)" ]; then apt-get update && apt-get install -y python sudo; fi'
+            RUN bash -c 'if [ -x "$(command -v apt-get)" ]; then apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y python sudo; fi'
             RUN bash -c 'if [ -x "$(command -v yum)" ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf; fi'
             RUN bash -c 'if [ -x "$(command -v zypper)" ]; then zypper refresh && zypper update -y && zypper install -y python sudo; fi'
 


### PR DESCRIPTION
Let's get rid of some warnings during packages installation on
ubuntu, e.g:

   debconf: unable to initialize frontend: Dialog
   debconf: (TERM is not set, so the dialog frontend is not usable.)
   debconf: falling back to frontend: Readline