### PR TITLE
Remove exception for setting the hostname on libvirt

### DIFF
--- a/molecule/cookiecutter/driver/vagrant-runtime/{{cookiecutter.repo_name}}/vagrantfile
+++ b/molecule/cookiecutter/driver/vagrant-runtime/{{cookiecutter.repo_name}}/vagrantfile
@@ -217,9 +217,7 @@ Vagrant.configure('2') do |config|
     if driver_config['instances']
         driver_config['instances'].each { |instance|
             config.vm.define instance['vm_name'] do |c|
-                if driver_config['current_provider'] != 'libvirt'
-                    c.vm.hostname = instance['vm_name']
-                end
+                c.vm.hostname = instance['vm_name']
 
                 if instance['platform']
                     c.vm.box = instance['platform']


### PR DESCRIPTION
This PR reverts the exception for setting the hostname when using libvirt in vagrant.

It was introduced back in [655d20b0bd6ebf995915f33b06d16bd338e0bc52](https://github.com/metacloud/molecule/commit/655d20b0bd6ebf995915f33b06d16bd338e0bc52) which claims that the vagrant-libvirt backend doesn't support it.
I don't know which version @conorsch tested against but vagrant-libvirt has supported setting the hostname since the [0.0.5 release](https://github.com/vagrant-libvirt/vagrant-libvirt/blob/master/CHANGELOG.md#005-may-10-2013) which came out in 2013.
Can we have it removed? It messes up integration with the landrush dns for vagrant.