### PR TITLE
Docs: install docker package in travis usage

### DIFF
--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -60,6 +60,7 @@ A ``.travis.yml`` testing a role named foo1 with the Docker driver.
     - sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y docker-engine
   install:
     - pip install molecule
+    # - pip install required driver (e.g. docker, python-vagrant, shade)
   script:
     - molecule test
 


### PR DESCRIPTION
After 1.21 update travis builds fails with `docker-py` driver.
Related: #764, #771