### PR TITLE
Basic docker network handling for cluster setups

### DIFF
--- a/doc/source/driver/docker/index.rst
+++ b/doc/source/driver/docker/index.rst
@@ -48,12 +48,19 @@ Options
   existing Docker network.
 * ``build_image`` - **(default=None)** override global driver value
   to build (or not) an image for use with Molecule.
+* ``hostname`` - **(default=None)** name set in **/etc/hosts**
+  inside the container. If not set the container ID is used.
 
 The available param for the Docker driver itself is:
 
 * ``build_image`` - **(default=True)** build images for use with Molecule.
 * ``dockerfile`` - **(default=dockerfile)** supply a custom Dockerfile instead
   of Molecule provided image.
+* ``network`` - **(default=None)** list of docker networks managed by Molecule.
+  The networks are created before the containers are started and removed during
+  the destroy phase. The network names can be used in ``network_mode`` of a
+  container to make clusters of docker containers. A ``driver`` can be specified
+  for a network **(default='bridge')**.
 
 .. _`host config`: https://docker-py.readthedocs.io/en/stable/api.html#docker.api.container.ContainerApiMixin.create_host_config
 .. _`capability`: https://docs.docker.com/engine/reference/run/#/runtime-privilege-and-linux-capabilities

--- a/doc/source/driver/docker/usage.rst
+++ b/doc/source/driver/docker/usage.rst
@@ -43,3 +43,30 @@ not a number, it does not need to be in quotes.
 A specific registry can also be defined with the ``registry`` option in the
 container.  When accessing a private registry, ensure your Docker client is
 logged into whichever registry you are trying to access.
+
+In order to create a cluster of docker containers with functional DNS lookup
+use the ``network`` handler of the docker driver
+
+.. code-block:: yaml
+
+  ---
+  docker:
+    network:
+      - name: docker-cluster-network
+        driver: bridge
+    containers:
+      - name: node1.mycluster
+        hostname: node1.mycluster
+        image: ubuntu
+        image_version: latest
+        network_mode: docker-cluster-network
+      - name: node2.mycluster
+        hostname: node2.mycluster
+        image: ubuntu
+        image_version: latest
+        network_mode: docker-cluster-network
+      - name: node3.mycluster
+        hostname: node3.mycluster
+        image: ubuntu
+        image_version: latest
+        network_mode: docker-cluster-network

--- a/molecule/driver/dockerdriver.py
+++ b/molecule/driver/dockerdriver.py
@@ -132,6 +132,7 @@ class DockerDriver(basedriver.BaseDriver):
             cap_drop = container.get('cap_drop', [])
             command = container.get('command', '')
             environment = container.get('environment')
+            hostname = container.get('hostname')
 
             docker_host_config = self._docker.create_host_config(
                 privileged=privileged,
@@ -157,7 +158,8 @@ class DockerDriver(basedriver.BaseDriver):
                     ports=port_bindings.keys(),
                     host_config=docker_host_config,
                     environment=environment,
-                    command=command)
+                    command=command,
+                    hostname=hostname)
                 self._docker.start(container=container.get('Id'))
                 container['created'] = True
 

--- a/molecule/driver/dockerdriver.py
+++ b/molecule/driver/dockerdriver.py
@@ -206,7 +206,7 @@ class DockerDriver(basedriver.BaseDriver):
 
     def status(self):
         Status = collections.namedtuple(
-            'Status', ['name', 'state', 'provider', 'ports'])
+            'Status', ['name', 'state', 'provider', 'ports', 'networks'])
         status_list = []
         for container in self.instances:
             name = container.get('name')
@@ -214,6 +214,7 @@ class DockerDriver(basedriver.BaseDriver):
                 d = self._docker.containers(filters={'name': name})[0]
                 state = d.get('Status')
                 ports = d.get('Ports')
+                networks = d['NetworkSettings']['Networks'].keys()
             except IndexError:
                 state = 'not_created'
                 ports = []
@@ -222,7 +223,8 @@ class DockerDriver(basedriver.BaseDriver):
                     name=name,
                     state=state,
                     provider=self.provider,
-                    ports=ports))
+                    ports=ports,
+                    networks=networks))
 
         return status_list
 

--- a/molecule/driver/dockerdriver.py
+++ b/molecule/driver/dockerdriver.py
@@ -251,8 +251,8 @@ class DockerDriver(basedriver.BaseDriver):
 
     def _build_ansible_compatible_image(self, container):
         available_images = [
-            tag.encode('utf-8')
-            for image in self._docker.images() if image.get('RepoTags') is not None
+            tag.encode('utf-8') for image in self._docker.images()
+            if image.get('RepoTags') is not None
             for tag in image.get('RepoTags')
         ]
 

--- a/molecule/driver/dockerdriver.py
+++ b/molecule/driver/dockerdriver.py
@@ -41,7 +41,7 @@ class DockerDriver(basedriver.BaseDriver):
         self._containers = self.molecule.config.config['docker']['containers']
         self._provider = self._get_provider()
         self._platform = self._get_platform()
-        self._network = self.molecule.config.config['docker']['network']
+        self._network = self.molecule.config.config['docker'].get('network')
 
         if 'build_image' not in self.molecule.config.config['docker']:
             self.molecule.config.config['docker']['build_image'] = True
@@ -218,6 +218,7 @@ class DockerDriver(basedriver.BaseDriver):
             except IndexError:
                 state = 'not_created'
                 ports = []
+                networks = {}
             status_list.append(
                 Status(
                     name=name,

--- a/molecule/driver/dockerdriver.py
+++ b/molecule/driver/dockerdriver.py
@@ -214,7 +214,7 @@ class DockerDriver(basedriver.BaseDriver):
                 d = self._docker.containers(filters={'name': name})[0]
                 state = d.get('Status')
                 ports = d.get('Ports')
-                networks = d['NetworkSettings']['Networks'].keys()
+                networks = d['NetworkSettings']['Networks']
             except IndexError:
                 state = 'not_created'
                 ports = []

--- a/test/functional/test_docker_scenarios.py
+++ b/test/functional/test_docker_scenarios.py
@@ -160,3 +160,9 @@ def test_group_host_vars(scenario_setup):
     'scenario_setup', ['requirements_file'], indirect=['scenario_setup'])
 def test_requirements_file(scenario_setup):
     sh.molecule('test')
+
+
+@pytest.mark.parametrize(
+    'scenario_setup', ['docker_cluster'], indirect=['scenario_setup'])
+def test_docker_cluster(scenario_setup):
+    sh.molecule('test')

--- a/test/scenarios/docker_cluster/molecule.yml
+++ b/test/scenarios/docker_cluster/molecule.yml
@@ -1,0 +1,40 @@
+driver:
+  name: docker
+docker:
+  network:
+    - name: docker-cluster-test-nw
+    - name: docker-cluster-test-second-nw
+  containers:
+    - name: test1.mycluster
+      hostname: test1.mycluster
+      image: ubuntu
+      image_version: latest
+      network_mode: docker-cluster-test-nw
+      ansible_groups:
+        - group1
+
+    - name: test2.mycluster
+      hostname: test2.mycluster
+      image: ubuntu
+      image_version: latest
+      network_mode: docker-cluster-test-nw
+      ansible_groups:
+        - group1
+
+    - name: test3.mycluster
+      hostname: test3.mycluster
+      image: ubuntu
+      image_version: latest
+      network_mode: docker-cluster-test-second-nw
+      ansible_groups:
+        - group2
+
+    - name: test4.mycluster
+      hostname: test4.mycluster
+      image: ubuntu
+      image_version: latest
+      network_mode: docker-cluster-test-second-nw
+      ansible_groups:
+        - group2
+verifier:
+  name: testinfra

--- a/test/scenarios/docker_cluster/playbook.yml
+++ b/test/scenarios/docker_cluster/playbook.yml
@@ -1,0 +1,6 @@
+---
+- hosts: all
+  tasks:
+    - name: Dockerfile functional scenario
+      command: /bin/true
+      changed_when: False

--- a/test/scenarios/docker_cluster/tests/test_default.py
+++ b/test/scenarios/docker_cluster/tests/test_default.py
@@ -1,0 +1,11 @@
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    '.molecule/ansible_inventory').get_hosts('all')
+
+
+def test_hosts_file(File):
+    f = File('/etc/hosts')
+
+    assert f.user == 'root'
+    assert f.group == 'root'

--- a/test/scenarios/docker_cluster/tests/test_group1.py
+++ b/test/scenarios/docker_cluster/tests/test_group1.py
@@ -1,0 +1,16 @@
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    '.molecule/ansible_inventory').get_hosts('group1')
+
+
+def test_resolve(Command):
+    group1 = ['test1.mycluster', 'test2.mycluster']
+    group2 = ['test3.mycluster', 'test4.mycluster']
+
+    for host in group1:
+        cmd = Command('getent ahostsv4 {}'.format(host))
+        assert cmd.rc == 0
+    for host in group2:
+        cmd = Command('getent ahostsv4 {}'.format(host))
+        assert cmd.rc != 0

--- a/test/scenarios/docker_cluster/tests/test_group2.py
+++ b/test/scenarios/docker_cluster/tests/test_group2.py
@@ -1,0 +1,16 @@
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    '.molecule/ansible_inventory').get_hosts('group2')
+
+
+def test_resolve(Command):
+    group1 = ['test1.mycluster', 'test2.mycluster']
+    group2 = ['test3.mycluster', 'test4.mycluster']
+
+    for host in group1:
+        cmd = Command('getent ahostsv4 {}'.format(host))
+        assert cmd.rc != 0
+    for host in group2:
+        cmd = Command('getent ahostsv4 {}'.format(host))
+        assert cmd.rc == 0

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -94,7 +94,8 @@ def docker_molecule_instance(temp_dir, temp_files, state_path_without_data):
 
 
 @pytest.fixture()
-def docker_cluster_molecule_instance(temp_dir, temp_files, state_path_without_data):
+def docker_cluster_molecule_instance(temp_dir, temp_files,
+                                     state_path_without_data):
     c = temp_files(fixtures=['molecule_docker_cluster_v1_config'])
     m = core.Molecule(config.ConfigV1(configs=c), {})
     m.state = state.State(state_file=state_path_without_data)
@@ -154,8 +155,8 @@ def molecule_docker_v1_config(molecule_v1_section_data, docker_v1_section_data,
 
 @pytest.fixture()
 def molecule_docker_cluster_v1_config(molecule_v1_section_data,
-                              docker_cluster_v1_section_data,
-                              ansible_v1_section_data):
+                                      docker_cluster_v1_section_data,
+                                      ansible_v1_section_data):
     return reduce(lambda x, y: config.merge_dicts(x, y), [
         molecule_v1_section_data, docker_cluster_v1_section_data,
         ansible_v1_section_data
@@ -341,12 +342,15 @@ def docker_v1_section_data():
 def docker_cluster_v1_section_data():
     return {
         'docker': {
-            'network': [{
-                'name': 'docker-cluster-test-nw',
-                'driver': 'bridge'
-            }, {
-                'name': 'docker-cluster-test-second-nw'
-            },],
+            'network': [
+                {
+                    'name': 'docker-cluster-test-nw',
+                    'driver': 'bridge'
+                },
+                {
+                    'name': 'docker-cluster-test-second-nw'
+                },
+            ],
             'containers': [{
                 'name': 'test1.mycluster',
                 'image': 'ubuntu',
@@ -382,7 +386,6 @@ def docker_cluster_v1_section_data():
                 'hostname': 'test3.mycluster',
                 'network_mode': 'docker-cluster-test-second-nw',
                 'command': '/bin/sh',
-
             }, {
                 'name': 'test4.mycluster',
                 'image': 'ubuntu',

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -94,6 +94,16 @@ def docker_molecule_instance(temp_dir, temp_files, state_path_without_data):
 
 
 @pytest.fixture()
+def docker_cluster_molecule_instance(temp_dir, temp_files, state_path_without_data):
+    c = temp_files(fixtures=['molecule_docker_cluster_v1_config'])
+    m = core.Molecule(config.ConfigV1(configs=c), {})
+    m.state = state.State(state_file=state_path_without_data)
+    m.main()
+
+    return m
+
+
+@pytest.fixture()
 def openstack_molecule_instance(temp_dir, temp_files, state_path_without_data):
     c = temp_files(fixtures=['molecule_openstack_v1_config'])
     m = core.Molecule(config.ConfigV1(configs=c), {})
@@ -138,6 +148,16 @@ def molecule_docker_v1_config(molecule_v1_section_data, docker_v1_section_data,
                               ansible_v1_section_data):
     return reduce(lambda x, y: config.merge_dicts(x, y), [
         molecule_v1_section_data, docker_v1_section_data,
+        ansible_v1_section_data
+    ])
+
+
+@pytest.fixture()
+def molecule_docker_cluster_v1_config(molecule_v1_section_data,
+                              docker_cluster_v1_section_data,
+                              ansible_v1_section_data):
+    return reduce(lambda x, y: config.merge_dicts(x, y), [
+        molecule_v1_section_data, docker_cluster_v1_section_data,
         ansible_v1_section_data
     ])
 
@@ -312,6 +332,65 @@ def docker_v1_section_data():
                 'options': {
                     'append_platform_to_hostname': True
                 }
+            }]
+        }
+    }
+
+
+@pytest.fixture()
+def docker_cluster_v1_section_data():
+    return {
+        'docker': {
+            'network': [{
+                'name': 'docker-cluster-test-nw',
+                'driver': 'bridge'
+            }, {
+                'name': 'docker-cluster-test-second-nw'
+            },],
+            'containers': [{
+                'name': 'test1.mycluster',
+                'image': 'ubuntu',
+                'image_version': 'latest',
+                'port_bindings': {
+                    80: 80,
+                    443: 443
+                },
+                'environment': {
+                    'FOO': 'BAR',
+                    'BAZ': 'QUX'
+                },
+                'volume_mounts': ['/tmp/test1:/inside:rw'],
+                'cap_add': ['SYS_ADMIN', 'SETPCAP'],
+                'cap_drop': ['MKNOD'],
+                'ansible_groups': ['group1'],
+                'hostname': 'test1.mycluster',
+                'network_mode': 'docker-cluster-test-nw',
+            }, {
+                'name': 'test2.mycluster',
+                'image': 'ubuntu',
+                'image_version': 'latest',
+                'ansible_groups': ['group2'],
+                'network_mode': 'docker-cluster-test-nw',
+                'command': '/bin/sh',
+                'hostname': 'test2.mycluster',
+                'network_mode': 'docker-cluster-test-nw',
+            }, {
+                'name': 'test3.mycluster',
+                'image': 'ubuntu',
+                'image_version': 'latest',
+                'ansible_groups': ['group1'],
+                'hostname': 'test3.mycluster',
+                'network_mode': 'docker-cluster-test-second-nw',
+                'command': '/bin/sh',
+
+            }, {
+                'name': 'test4.mycluster',
+                'image': 'ubuntu',
+                'image_version': 'latest',
+                'ansible_groups': ['group2'],
+                'hostname': 'test4.mycluster',
+                'network_mode': 'docker-cluster-test-second-nw',
+                'command': '/bin/sh',
             }]
         }
     }

--- a/test/unit/driver/test_dockerdriver.py
+++ b/test/unit/driver/test_dockerdriver.py
@@ -281,15 +281,15 @@ def test_network_mode_host(docker_instance):
 
 def test_network_mode_cluster(docker_cluster_instance):
     docker_cluster_instance.up()
-    d1 = docker_cluster_instance._docker.inspect_container('test1.mycluster')['HostConfig'][
-        'NetworkMode']
+    d1 = docker_cluster_instance._docker.inspect_container('test1.mycluster')[
+        'HostConfig']['NetworkMode']
     assert 'docker-cluster-test-nw' in d1
-    d2 = docker_cluster_instance._docker.inspect_container('test2.mycluster')['HostConfig'][
-        'NetworkMode']
+    d2 = docker_cluster_instance._docker.inspect_container('test2.mycluster')[
+        'HostConfig']['NetworkMode']
     assert 'docker-cluster-test-nw' in d2
-    d3 = docker_cluster_instance._docker.inspect_container('test3.mycluster')['HostConfig'][
-        'NetworkMode']
+    d3 = docker_cluster_instance._docker.inspect_container('test3.mycluster')[
+        'HostConfig']['NetworkMode']
     assert 'docker-cluster-test-second-nw' in d3
-    d4 = docker_cluster_instance._docker.inspect_container('test4.mycluster')['HostConfig'][
-        'NetworkMode']
+    d4 = docker_cluster_instance._docker.inspect_container('test4.mycluster')[
+        'HostConfig']['NetworkMode']
     assert 'docker-cluster-test-second-nw' in d4

--- a/test/unit/driver/test_dockerdriver.py
+++ b/test/unit/driver/test_dockerdriver.py
@@ -37,6 +37,18 @@ def docker_instance(docker_molecule_instance, request):
     return d
 
 
+@pytest.fixture()
+def docker_cluster_instance(docker_cluster_molecule_instance, request):
+    d = dockerdriver.DockerDriver(docker_cluster_molecule_instance)
+
+    def cleanup():
+        d.destroy()
+
+    request.addfinalizer(cleanup)
+
+    return d
+
+
 def test_name(docker_instance):
     assert 'docker' == docker_instance.name
 
@@ -248,7 +260,7 @@ def test_network_mode_bridge(docker_instance):
     d1 = docker_instance._docker.inspect_container('test1')['HostConfig'][
         'NetworkMode']
     assert 'bridge' in d1
-    d2 = docker_instance._docker.inspect_container('test1')['HostConfig'][
+    d2 = docker_instance._docker.inspect_container('test2')['HostConfig'][
         'NetworkMode']
     assert 'bridge' in d2
 
@@ -265,3 +277,19 @@ def test_network_mode_host(docker_instance):
     d1 = docker_instance._docker.inspect_container('test4')['HostConfig'][
         'NetworkMode']
     assert 'host' in d1
+
+
+def test_network_mode_cluster(docker_cluster_instance):
+    docker_cluster_instance.up()
+    d1 = docker_cluster_instance._docker.inspect_container('test1.mycluster')['HostConfig'][
+        'NetworkMode']
+    assert 'docker-cluster-test-nw' in d1
+    d2 = docker_cluster_instance._docker.inspect_container('test2.mycluster')['HostConfig'][
+        'NetworkMode']
+    assert 'docker-cluster-test-nw' in d2
+    d3 = docker_cluster_instance._docker.inspect_container('test3.mycluster')['HostConfig'][
+        'NetworkMode']
+    assert 'docker-cluster-test-second-nw' in d3
+    d4 = docker_cluster_instance._docker.inspect_container('test4.mycluster')['HostConfig'][
+        'NetworkMode']
+    assert 'docker-cluster-test-second-nw' in d4


### PR DESCRIPTION
Allow a "network" section in the docker driver for basic handling of docker networks which enables testing of cluster setups with docker (#748). Requires docker >= 1.10
Also allow setting "hostname" for docker containers

Tests pass except py27-ansible19-unit which fails due to low unit test coverage but I'm not sure what to do about that when it skips large parts of the test suites 