### PR TITLE
Ansible v2 has deprecated ansible_ssh_{host,port,user}

### DIFF
--- a/molecule/driver/openstackdriver.py
+++ b/molecule/driver/openstackdriver.py
@@ -384,8 +384,8 @@ class OpenstackDriver(basedriver.BaseDriver):
                 os.remove(publoc)
 
     def _host_template(self):
-        return ('{hostname} ansible_ssh_host={interface_ip_address} '
-                'ansible_ssh_user={ssh_username} '
+        return ('{hostname} ansible_host={interface_ip_address} '
+                'ansible_user={ssh_username} '
                 'ansible_ssh_private_key_file="{ssh_key_filename}" '
                 'ansible_ssh_extra_args="-o ConnectionAttempts=5"\n')
 

--- a/molecule/driver/vagrantdriver.py
+++ b/molecule/driver/vagrantdriver.py
@@ -172,9 +172,8 @@ class VagrantDriver(basedriver.BaseDriver):
             return self._vagrant.conf(vm_name=vm_name)
 
     def inventory_entry(self, instance):
-        # TODO: for Ansiblev2, the following line must have s/ssh_//
-        template = ('{} ansible_ssh_host={} ansible_ssh_port={} '
-                    'ansible_ssh_private_key_file="{}" ansible_ssh_user={}\n')
+        template = ('{} ansible_host={} ansible_port={} '
+                    'ansible_ssh_private_key_file="{}" ansible_user={}\n')
 
         if not self._updated_multiplatform:
             ssh = self.conf(vm_name=util.format_instance_name(


### PR DESCRIPTION
from [Ansible Document](http://docs.ansible.com/ansible/intro_inventory.html):

> Note
Ansible 2.0 has deprecated the “ssh” from ansible_ssh_user, ansible_ssh_host, and ansible_ssh_port to become ansible_user, ansible_host, and ansible_port. If you are using a version of Ansible prior to 2.0, you should continue using the older style variables (ansible_ssh_*). These shorter variables are ignored, without warning, in older versions of Ansible.

This will drop the support ansible<2.0 (we already done now?), but i think ansible>=2.0 is very popular now.

P.S. If really not able to avoid supporting old deprecated behaviors, we still could define both ansible_* and ansible_ssh_*, but the generated code is not clean.