### PR TITLE
Update for python 2 and 3

### DIFF
--- a/molecule/ansible_playbook.py
+++ b/molecule/ansible_playbook.py
@@ -19,6 +19,8 @@
 #  DEALINGS IN THE SOFTWARE.
 
 import os
+
+import six
 import sh
 
 from molecule import util
@@ -56,7 +58,7 @@ class AnsiblePlaybook(object):
         self._env = _env if _env else os.environ.copy()
         self._debug = debug
 
-        for k, v in args.iteritems():
+        for k, v in args.items():
             self.parse_arg(k, v)
 
         for k, v in connection_params.items():
@@ -94,9 +96,9 @@ class AnsiblePlaybook(object):
         """
 
         if name == 'raw_env_vars':
-            for k, v in value.iteritems():
-                if not isinstance(v, basestring):
-                    v = unicode(v)
+            for k, v in value.items():
+                if not type(v) in six.string_types:
+                    v = six.u(v)
                 self.add_env_arg(k, v)
             return
 

--- a/molecule/command/base.py
+++ b/molecule/command/base.py
@@ -19,6 +19,7 @@
 #  DEALINGS IN THE SOFTWARE.
 
 import abc
+import six
 
 from molecule import config
 from molecule import core
@@ -32,11 +33,10 @@ class InvalidHost(Exception):
     pass
 
 
-class Base(object):
+class Base(six.with_metaclass(abc.ABCMeta)):
     """
     An abstract base class used to define the command interface.
     """
-    __metaclass__ = abc.ABCMeta
 
     def __init__(self, args, command_args, molecule=None):
         """

--- a/molecule/command/login.py
+++ b/molecule/command/login.py
@@ -44,7 +44,7 @@ class Login(base.Base):
         """
         # get list of running hosts from state
         if self.molecule.state.hosts:
-            hosts = [k for k, v in self.molecule.state.hosts.iteritems()]
+            hosts = [k for k, v in self.molecule.state.hosts.items()]
         else:
             hosts = []
 

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -24,6 +24,7 @@ import os.path
 
 import anyconfig
 import m9dicts
+import six
 
 from re import sub
 
@@ -34,8 +35,7 @@ LOCAL_CONFIG = os.path.expanduser('~/.config/molecule/config.yml')
 MERGE_STRATEGY = anyconfig.MS_DICTS
 
 
-class Config(object):
-    __metaclass__ = abc.ABCMeta
+class Config(six.with_metaclass(abc.ABCMeta)):
 
     def __init__(self, configs=[LOCAL_CONFIG, PROJECT_CONFIG]):
         """
@@ -125,7 +125,7 @@ class ConfigV1(Config):
             return os.environ.get(matchobj.group(1), '')
 
         def __replace_matches(line):
-            if not isinstance(line, basestring):
+            if not type(line) in six.string_types:
                 return line
             return sub('\$\{([^\}]*)\}', __get_env_var, line)
 
@@ -139,7 +139,7 @@ class ConfigV1(Config):
                         del config[i]
                         config[new_name] = val
                 # Replace dict values
-                for k, v in config.iteritems():
+                for k, v in config.items():
                     if isinstance(v, (dict, list)):
                         __recursive_string_replace(v)
                     else:

--- a/molecule/core.py
+++ b/molecule/core.py
@@ -18,6 +18,8 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
+
 import collections
 import os
 import shutil
@@ -205,7 +207,7 @@ class Molecule(object):
                             groups[group] = []
                         groups[group].append(instance['name'])
                     elif isinstance(group, dict):
-                        for group_name, group_list in group.iteritems():
+                        for group_name, group_list in group.items():
                             for g in group_list:
                                 if group_name not in groups:
                                     groups[group_name] = []
@@ -214,7 +216,7 @@ class Molecule(object):
         if self.args.get('platform') == 'all':
             self.driver.platform = 'all'
 
-        for group, subgroups in groups.iteritems():
+        for group, subgroups in groups.items():
             inventory += '\n[{}]\n'.format(group)
             for subgroup in subgroups:
                 instance_name = util.format_instance_name(
@@ -371,7 +373,7 @@ class Molecule(object):
                     if isinstance(group, str):
                         groups.add(group)
                     elif isinstance(group, dict):
-                        for group_name, _ in group.iteritems():
+                        for group_name, _ in group.items():
                             groups.add(group_name.split(':')[0])
 
             instances[instance_name]['groups'] = sorted(list(groups))
@@ -390,7 +392,7 @@ class Molecule(object):
 
     def _dict_to_inisection_string(self, data, padding=15):
         result = ''
-        for key, value in data.iteritems():
+        for key, value in data.items():
             result += '\n%s = %s' % (key.ljust(padding), value)
 
         return result

--- a/molecule/driver/basedriver.py
+++ b/molecule/driver/basedriver.py
@@ -19,6 +19,7 @@
 #  DEALINGS IN THE SOFTWARE.
 
 import abc
+import six
 
 
 class InvalidDriverSpecified(Exception):
@@ -42,8 +43,7 @@ class InvalidPlatformSpecified(Exception):
     pass
 
 
-class BaseDriver(object):
-    __metaclass__ = abc.ABCMeta
+class BaseDriver(six.with_metaclass(abc.ABCMeta)):
 
     def __init__(self, molecule):
         """

--- a/molecule/driver/dockerdriver.py
+++ b/molecule/driver/dockerdriver.py
@@ -286,7 +286,7 @@ class DockerDriver(basedriver.BaseDriver):
             environment = container.get('environment')
             if environment:
                 environment = '\n'.join('ENV {} {}'.format(k, v)
-                                        for k, v in environment.iteritems())
+                                        for k, v in environment.items())
             else:
                 environment = ''
 
@@ -310,7 +310,8 @@ class DockerDriver(basedriver.BaseDriver):
         if tag_string not in available_images or 'dockerfile' in container:
             util.print_info('Building ansible compatible image...')
             previous_line = ''
-            for line in self._docker.build(fileobj=f, tag=tag_string, nocache=nocache):
+            for line in self._docker.build(
+                    fileobj=f, tag=tag_string, nocache=nocache):
                 for line_split in line.split('\n'):
                     if len(line_split) > 0:
                         line = json.loads(line_split)

--- a/molecule/verifier/base.py
+++ b/molecule/verifier/base.py
@@ -19,10 +19,10 @@
 #  DEALINGS IN THE SOFTWARE.
 
 import abc
+import six
 
 
-class Base(object):
-    __metaclass__ = abc.ABCMeta
+class Base(six.with_metaclass(abc.ABCMeta)):
 
     def __init__(self, molecule):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ PyYAML==3.12
 sh==1.12.13
 tabulate==0.7.7
 testinfra==1.5.5
+six


### PR DESCRIPTION
This change moves metaclasses, string checks, and unicode casting to six
and also moves from iteritems to items.

**Note**: I found unittests fail with and without this patch.