### PR TITLE
Any chance of Testinfra being bumped to latest?

### DIFF
--- a/molecule/cookiecutter/verifier/testinfra/{{cookiecutter.repo_name}}/tests/test_default.py
+++ b/molecule/cookiecutter/verifier/testinfra/{{cookiecutter.repo_name}}/tests/test_default.py
@@ -4,8 +4,8 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     '.molecule/ansible_inventory').get_hosts('all')
 
 
-def test_hosts_file(File):
-    f = File('/etc/hosts')
+def test_hosts_file(host):
+    f = host.file('/etc/hosts')
 
     assert f.exists
     assert f.user == 'root'

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ pexpect==4.2.1
 PyYAML==3.12
 sh==1.12.13
 tabulate==0.7.7
-testinfra==1.5.5
+testinfra==1.6.3

--- a/test/scenarios/command_check/tests/test_default.py
+++ b/test/scenarios/command_check/tests/test_default.py
@@ -4,7 +4,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     '.molecule/ansible_inventory').get_hosts('all')
 
 
-def test_hosts_file(File):
-    f = File('/tmp/check')
+def test_hosts_file(host):
+    f = host.file('/tmp/check')
 
     assert not f.exists

--- a/test/scenarios/command_test/tests/test_default.py
+++ b/test/scenarios/command_test/tests/test_default.py
@@ -4,8 +4,8 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     '.molecule/ansible_inventory').get_hosts('all')
 
 
-def test_hosts_file(File):
-    f = File('/etc/hosts')
+def test_hosts_file(host):
+    f = host.file('/etc/hosts')
 
     assert f.user == 'root'
     assert f.group == 'root'

--- a/test/scenarios/command_test/tests/test_example-group1.py
+++ b/test/scenarios/command_test/tests/test_example-group1.py
@@ -4,8 +4,8 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     '.molecule/ansible_inventory').get_hosts('example-group1')
 
 
-def test_etc_molecule_example_group1(File):
-    f = File('/etc/molecule/example-group1')
+def test_etc_molecule_example_group1(host):
+    f = host.file('/etc/molecule/example-group1')
 
     assert f.is_file
     assert f.user == 'root'
@@ -14,7 +14,7 @@ def test_etc_molecule_example_group1(File):
     assert f.contains('molecule example-group1 file')
 
 
-def test_etc_molecule_example_group2(File):
-    f = File('/etc/molecule/example-group2')
+def test_etc_molecule_example_group2(host):
+    f = host.file('/etc/molecule/example-group2')
 
     assert not f.exists

--- a/test/scenarios/command_test/tests/test_example-group2.py
+++ b/test/scenarios/command_test/tests/test_example-group2.py
@@ -4,8 +4,8 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     '.molecule/ansible_inventory').get_hosts('example-group2')
 
 
-def test_etc_molecule_example_group2(File):
-    f = File('/etc/molecule/example-group2')
+def test_etc_molecule_example_group2(host):
+    f = host.file('/etc/molecule/example-group2')
 
     assert f.is_file
     assert f.user == 'root'
@@ -14,7 +14,7 @@ def test_etc_molecule_example_group2(File):
     assert f.contains('molecule example-group2 file')
 
 
-def test_etc_molecule_example_group1(File):
-    f = File('/etc/molecule/example-group1')
+def test_etc_molecule_example_group1(host):
+    f = host.file('/etc/molecule/example-group1')
 
     assert not f.exists

--- a/test/scenarios/docker_cluster/tests/test_group1.py
+++ b/test/scenarios/docker_cluster/tests/test_group1.py
@@ -4,13 +4,13 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     '.molecule/ansible_inventory').get_hosts('group1')
 
 
-def test_resolve(Command):
+def test_resolve(host):
     group1 = ['instance1', 'instance2']
     group2 = ['instance3', 'instance4']
 
-    for host in group1:
-        cmd = Command('getent ahostsv4 {}'.format(host))
+    for instance in group1:
+        cmd = host.run('getent ahostsv4 {}'.format(instance))
         assert cmd.rc == 0
-    for host in group2:
-        cmd = Command('getent ahostsv4 {}'.format(host))
+    for instance in group2:
+        cmd = host.run('getent ahostsv4 {}'.format(instance))
         assert cmd.rc != 0

--- a/test/scenarios/docker_cluster/tests/test_group2.py
+++ b/test/scenarios/docker_cluster/tests/test_group2.py
@@ -4,13 +4,13 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     '.molecule/ansible_inventory').get_hosts('group2')
 
 
-def test_resolve(Command):
+def test_resolve(host):
     group1 = ['instance1', 'instance2']
     group2 = ['instance3', 'instance4']
 
-    for host in group1:
-        cmd = Command('getent ahostsv4 {}'.format(host))
+    for instance in group1:
+        cmd = host.run('getent ahostsv4 {}'.format(instance))
         assert cmd.rc != 0
-    for host in group2:
-        cmd = Command('getent ahostsv4 {}'.format(host))
+    for instance in group2:
+        cmd = host.run('getent ahostsv4 {}'.format(instance))
         assert cmd.rc == 0


### PR DESCRIPTION
Any chance Testinfra could be updated to the latest version?  The main reason being that 1.6 and onwards introduced [New ‘host’ fixture as a replacement for all other fixtures](https://testinfra.readthedocs.io/en/latest/changelog.html#id4).  This makes tests a little nicer to write but also it means that the Testinfra docs now follow this style.

Apologies if there is more to this than what I've done here.  I have tested several of my Molecule projects by manually updating Testinfra within the virtualenv and continuing to work without a problem.

I have also tried to run the `tox` test suites although I'm a newbie to that.  I seemed to get a single error on each suite (example follows).  It seem to be an idempotence test failure and I'm assuming it is unrelated to my change.  I've also tried to verify this by doing a completely fresh clone of `master` and running `tox` and again I was getting the same failures.

Many thanks for Molecule, it is awesome.

Example of test failure:

```
/Users/ross.timson/code/python/molecule/test/unit/command/test_idempotence.py:47: AssertionError
========================================================= 1 failed, 104 passed, 1 skipped in 5.29 seconds =========================================================
Traceback (most recent call last):
  File "/Users/ross.timson/code/python/molecule/.tox/py27-ansible21-unit/bin/py.test", line 11, in <module>
    sys.exit(main())
  File "/Users/ross.timson/code/python/molecule/.tox/py27-ansible21-unit/lib/python2.7/site-packages/_pytest/config.py", line 58, in main
    return config.hook.pytest_cmdline_main(config=config)
  File "/Users/ross.timson/code/python/molecule/.tox/py27-ansible21-unit/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 745, in __call__
    return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
  File "/Users/ross.timson/code/python/molecule/.tox/py27-ansible21-unit/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 339, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/Users/ross.timson/code/python/molecule/.tox/py27-ansible21-unit/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 334, in <lambda>
    _MultiCall(methods, kwargs, hook.spec_opts).execute()
  File "/Users/ross.timson/code/python/molecule/.tox/py27-ansible21-unit/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 614, in execute
    res = hook_impl.function(*args)
  File "/Users/ross.timson/code/python/molecule/.tox/py27-ansible21-unit/lib/python2.7/site-packages/_pytest/main.py", line 134, in pytest_cmdline_main
    return wrap_session(config, _main)
  File "/Users/ross.timson/code/python/molecule/.tox/py27-ansible21-unit/lib/python2.7/site-packages/_pytest/main.py", line 105, in wrap_session
    session.exitstatus = doit(config, session) or 0
  File "/Users/ross.timson/code/python/molecule/.tox/py27-ansible21-unit/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 745, in __call__
    return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
  File "/Users/ross.timson/code/python/molecule/.tox/py27-ansible21-unit/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 339, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/Users/ross.timson/code/python/molecule/.tox/py27-ansible21-unit/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 334, in <lambda>
    _MultiCall(methods, kwargs, hook.spec_opts).execute()
  File "/Users/ross.timson/code/python/molecule/.tox/py27-ansible21-unit/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 614, in execute
    res = hook_impl.function(*args)
  File "/Users/ross.timson/code/python/molecule/.tox/py27-ansible21-unit/lib/python2.7/site-packages/_pytest/terminal.py", line 405, in pytest_keyboard_interrupt
    self._keyboardinterrupt_memo = excinfo.getrepr(funcargs=True)
  File "/Users/ross.timson/code/python/molecule/.tox/py27-ansible21-unit/lib/python2.7/site-packages/_pytest/_code/code.py", line 429, in getrepr
    return fmt.repr_excinfo(self)
  File "/Users/ross.timson/code/python/molecule/.tox/py27-ansible21-unit/lib/python2.7/site-packages/_pytest/_code/code.py", line 623, in repr_excinfo
    reprtraceback = self.repr_traceback(excinfo)
  File "/Users/ross.timson/code/python/molecule/.tox/py27-ansible21-unit/lib/python2.7/site-packages/_pytest/_code/code.py", line 613, in repr_traceback
    reprentry = self.repr_traceback_entry(entry, einfo)
  File "/Users/ross.timson/code/python/molecule/.tox/py27-ansible21-unit/lib/python2.7/site-packages/_pytest/_code/code.py", line 581, in repr_traceback_entry
    path = self._makepath(entry.path)
  File "/Users/ross.timson/code/python/molecule/.tox/py27-ansible21-unit/lib/python2.7/site-packages/_pytest/_code/code.py", line 594, in _makepath
    np = py.path.local().bestrelpath(path)
  File "/Users/ross.timson/code/python/molecule/.tox/py27-ansible21-unit/lib/python2.7/site-packages/py/_path/local.py", line 149, in __init__
    self.strpath = py.error.checked_call(os.getcwd)
  File "/Users/ross.timson/code/python/molecule/.tox/py27-ansible21-unit/lib/python2.7/site-packages/py/_error.py", line 85, in checked_call
    raise cls("%s%r" % (func.__name__, args))
py.error.ENOENT: [No such file or directory]: getcwd()
ERROR: InvocationError: '/Users/ross.timson/code/python/molecule/.tox/py27-ansible21-unit/bin/py.test -vv -x --cov=/Users/ross.timson/code/python/molecule/molecule/'
```

