### PR TITLE
Fix UnicodeEncodeError

### DIFF
--- a/molecule/ansible_playbook.py
+++ b/molecule/ansible_playbook.py
@@ -183,8 +183,8 @@ class AnsiblePlaybook(object):
             self.bake()
 
         try:
-            return None, util.run_command(
-                self._ansible, debug=self._debug).stdout
+            return None, unicode(util.run_command(
+                self._ansible, debug=self._debug))
         except sh.ErrorReturnCode as e:
             if not hide_errors:
                 util.print_error(str(e))

--- a/molecule/command/idempotence.py
+++ b/molecule/command/idempotence.py
@@ -103,7 +103,7 @@ class Idempotence(base.Base):
             elif line.startswith('changed'):
                 host_name = re.search(r'\[(.*)\]', line).groups()[0]
                 task_name = re.search(r'\[(.*)\]', task_line).groups()[0]
-                res.append('* [{}] => {}'.format(host_name, task_name))
+                res.append(u'* [{}] => {}'.format(host_name, task_name))
 
         return res
 


### PR DESCRIPTION
When rôle task names contain unicode characters, Molecule fails with an UnicodeEncodeError.

```
Traceback (most recent call last):
  File "/usr/local/bin/molecule", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python2.7/site-packages/molecule/cli.py", line 41, in main
    cli(obj={})
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/molecule/command/test.py", line 96, in test
    util.sysexit(t.execute()[0])
  File "/usr/local/lib/python2.7/site-packages/molecule/command/test.py", line 44, in execute
    status, output = c.execute(exit=False)
  File "/usr/local/lib/python2.7/site-packages/molecule/command/idempotence.py", line 60, in execute
    util.print_error('\n'.join(self._non_idempotent_tasks(output)))
  File "/usr/local/lib/python2.7/site-packages/molecule/util.py", line 68, in print_error
    print_msg(template, msg)
  File "/usr/local/lib/python2.7/site-packages/molecule/util.py", line 75, in print_msg
    print(template.format(msg.rstrip().encode('utf-8')))
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 30: ordinal not in range(128)
```