### PR TITLE
Don't hard code platform_box in vagrant destroy.yml

### DIFF
--- a/molecule/cookiecutter/scenario/driver/vagrant/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/vagrant/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -10,7 +10,7 @@
     - name: Destroy molecule instance(s)
       molecule_vagrant:
         instance_name: "{{ item.name | molecule_instance_with_scenario_name(molecule_yml.scenario.name) }}"
-        platform_box: ubuntu/trusty64
+        platform_box: "{{ item.box }}"
         molecule_file: "{{ molecule_file }}"
         state: destroy
       with_items: "{{ molecule_yml.platforms }}"


### PR DESCRIPTION
It is dynamic in create.yml, also it is set to ubuntu/xenial64 by default in molecule.yml