### PR TITLE
Update dependency.py

### DIFF
--- a/molecule/command/dependency.py
+++ b/molecule/command/dependency.py
@@ -58,7 +58,7 @@ class Dependency(base.Base):
 @click.pass_context
 @click.option(
     '--scenario-name',
-    default='defalt',
+    default='default',
     help='Name of the scenario to target. (default)')
 def dependency(ctx, scenario_name):  # pragma: no cover
     """ Mange the role's dependencies. """


### PR DESCRIPTION
Update dependency.py

Type was causing command "molecule dependency" to fail.

```
# molecule dependency
ERROR: Scenario 'defalt' not found.  Exiting.
```

Quick change and validated on my own molecule recipe and it works. 
ran tests - before and after - there was no change in results.