### PR TITLE
Fix crash on converge errors

### DIFF
--- a/molecule/command/idempotence.py
+++ b/molecule/command/idempotence.py
@@ -43,7 +43,7 @@ class Idempotence(base.Base):
 
         c = converge.Converge(self.args, self.command_args, self.molecule)
         status, output = c.execute(
-            idempotent=True, exit=False, hide_errors=True)
+            idempotent=True, exit=False, hide_errors=False)
         if status is not None:
             msg = 'Skipping due to errors during converge.'
             util.print_info(msg)

--- a/molecule/command/idempotence.py
+++ b/molecule/command/idempotence.py
@@ -47,7 +47,6 @@ class Idempotence(base.Base):
         if status is not None:
             msg = 'Skipping due to errors during converge.'
             util.print_info(msg)
-            util.print_info(output)
             return status, None
 
         idempotent = self._is_idempotent(output)


### PR DESCRIPTION
Molecule will crash if an idempotence converge fails.
Tested on molecule 1.25.0 with python 2.7.13.

> --> Idempotence test in progress (can take a few minutes)...
--> Starting Ansible Run...
--> Skipping due to errors during converge.
Traceback (most recent call last):
  File ".../bin/molecule", line 11, in <module>
    sys.exit(main())
  File ".../lib/python2.7/site-packages/molecule/cli.py", line 41, in main
    cli(obj={})
  File ".../lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File ".../lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File ".../lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File ".../lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File ".../lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File ".../lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File ".../lib/python2.7/site-packages/molecule/command/test.py", line 96, in test
    util.sysexit(t.execute()[0])
  File ".../lib/python2.7/site-packages/molecule/command/test.py", line 44, in execute
    status, output = c.execute(exit=False)
  File ".../lib/python2.7/site-packages/molecule/command/idempotence.py", line 50, in execute
    util.print_info(output)
  File ".../lib/python2.7/site-packages/molecule/util.py", line 42, in print_info
    print_msg(template, msg)
  File ".../lib/python2.7/site-packages/molecule/util.py", line 75, in print_msg
    print(template.format(msg.rstrip().encode('utf-8')))
AttributeError: 'NoneType' object has no attribute 'rstrip'

This PR contains a propsed fix.