### PR TITLE
Make Dockerfile templated, reducing the default configuration

### DIFF
--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/Dockerfile-template
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/Dockerfile-template
@@ -1,0 +1,11 @@
+{% raw -%}
+FROM {{ item.image }}
+
+RUN /bin/sh -c 'if [ -x "$(command -v apt-get)" ]; then apt-get update && apt-get upgrade -y && apt-get install -y python sudo bash; fi'
+RUN /bin/sh -c 'if [ -x "$(command -v yum)" ]; then touch /var/lib/rpm/* && yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf; fi'
+RUN /bin/sh -c 'if [ -x "$(command -v zypper)" ]; then zypper refresh && zypper update -y && zypper install -y python sudo bash; fi'
+RUN /bin/sh -c 'if [ -x "$(command -v apk)" ]; then apk update && apk add python sudo bash; fi'
+RUN /bin/sh -c 'if [ -x "$(command -v pacman)" ]; then pacman --sync --noconfirm --refresh python2 bash; fi'
+RUN /bin/sh -c 'if [ -x "$(command -v dnf)" ]; then dnf makecache fast; dnf --assumeyes install python python-devel python2-dnf bash; fi'
+RUN /bin/sh -c 'if [ -x "$(command -v emerge)" ]; then emerge --ask n =dev-lang/python-2\* gentoolkit; fi'
+{% endraw %}

--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -8,21 +8,30 @@
     molecule_scenario_directory: "{{ lookup('env','MOLECULE_SCENARIO_DIRECTORY') }}"
     molecule_yml: "{{ lookup('file', molecule_file) | from_yaml }}"
   tasks:
+    - name: Create Dockerfiles from image names
+      template:
+        src: "{{ molecule_scenario_directory }}/Dockerfile-template"
+        dest: "{{ molecule_scenario_directory }}/Dockerfile_{{ item.image | regex_replace('[^a-zA-Z0-9_]', '_') }}"
+      with_items: "{{ molecule_yml.platforms }}"
+      register: platforms
     - name: Build an Ansible compatible image
       docker_image:
         path: "{{ molecule_scenario_directory }}"
-        name: "{{ item.image }}"
-        dockerfile: "{{ item.dockerfile }}"
-      with_items: "{{ molecule_yml.platforms | molecule_dict_at_index(0) }}"
+        name: "molecule_local/{{ item.item.image }}"
+        dockerfile: "{{ item.item.dockerfile | default(item.invocation.module_args.dest) }}"
+      with_items: "{{ platforms.results }}"
 
     - name: Create molecule instance(s)
       docker_container:
         name: "{{ item.name }}-{{ molecule_yml.scenario.name }}"
         hostname: "{{ item.name }}"
-        image: "{{ item.image }}"
+        image: "molecule_local/{{ item.image }}"
         state: started
         recreate: False
         log_driver: syslog
-        command: "{{ item.command }}"
+        command: "{{ item.command | default('sleep infinity') }}"
+        privileged: "{{ item.privileged | default(omit) }}"
+        volumes: "{{ item.volumes | default(omit) }}"
+        capabilities: "{{ item.capabilities | default(omit) }}"
       with_items: "{{ molecule_yml.platforms }}"
 {%- endraw %}

--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
@@ -8,8 +8,6 @@ lint:
 platforms:
   - name: instance-1
     image: centos:7
-    #command: sleep infinity
-    #dockerfile: Dockerfile
 provisioner:
   name: {{ cookiecutter.provisioner_name }}
   lint:

--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
@@ -7,9 +7,9 @@ lint:
   name: {{ cookiecutter.lint_name }}
 platforms:
   - name: instance-1
-    image: molecule_local/centos:7
-    command: sleep infinity
-    dockerfile: Dockerfile
+    image: centos:7
+    #command: sleep infinity
+    #dockerfile: Dockerfile
 provisioner:
   name: {{ cookiecutter.provisioner_name }}
   lint:


### PR DESCRIPTION
Using default(omit) in docker create.yml, we have less configuration in
mlecule.yml.
The Dockerfile was not explicit when we want to build image because of
the "FROM centos:7".