### PR TITLE
Add feature #884, add an option to avoid adding scenario name to the hostname

### DIFF
--- a/molecule/driver/static.py
+++ b/molecule/driver/static.py
@@ -83,6 +83,21 @@ class Static(base.Base):
         Molecule automatically appends the scenario name to the instances it is
         testing.  It doesn't seem useful to converge each scenario against the
         same static host.
+        But, if you need to avoid this feature, you can add the append_scenario
+        to False.
+
+    .. code-block:: yaml
+
+        driver:
+          name: static
+          options:
+            login_cmd_template: 'ssh {instance} -F /tmp/ssh-config'
+            ansible_connection_options:
+              connection: ssh
+              ansible_ssh_common_args -F /path/to/ssh-config
+        platforms:
+          - name: static-instance-vagrant
+            append_scenario: False
 
     Provide the files Molecule will preserve upon each subcommand execution.
 

--- a/molecule/model/schema.py
+++ b/molecule/model/schema.py
@@ -59,6 +59,7 @@ class PlatformsBaseSchema(marshmallow.Schema):
     groups = marshmallow.fields.List(marshmallow.fields.Str())
     children = marshmallow.fields.List(marshmallow.fields.Str())
     state = marshmallow.fields.List(marshmallow.fields.Str())
+    append_scenario = marshmallow.fields.Bool()
 
 
 class PlatformsSchema(PlatformsBaseSchema):
@@ -84,7 +85,7 @@ class PlatformsVagrantSchema(PlatformsBaseSchema):
     cpus = marshmallow.fields.Int()
     raw_config_args = marshmallow.fields.List(marshmallow.fields.Str())
     interfaces = marshmallow.fields.List(
-        marshmallow.fields.Nested(InterfaceSchema()))
+    marshmallow.fields.Nested(InterfaceSchema()))
     provider = marshmallow.fields.Str()
 
 

--- a/molecule/platforms.py
+++ b/molecule/platforms.py
@@ -87,7 +87,8 @@ class Platforms(object):
         for instance in instances:
             instance_name = instance['name']
             scenario_name = self._config.scenario.name
-            instance['name'] = util.instance_with_scenario_name(
-                instance_name, scenario_name)
+            if 'append_scenario' not in instance or instance['append_scenario']:
+                instance['name'] = util.instance_with_scenario_name(
+                    instance_name, scenario_name)
 
         return instances

--- a/test/unit/command/test_list.py
+++ b/test/unit/command/test_list.py
@@ -39,6 +39,13 @@ def test_execute(capsys, config_instance):
             scenario_name='default',
             created='False',
             converged='False'),
+        base.Status(
+            instance_name='instance-3',
+            driver_name='Docker',
+            provisioner_name='Ansible',
+            scenario_name='default',
+            created='False',
+            converged='False'),
     ]
 
     assert x == l.execute()

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -87,6 +87,12 @@ def molecule_platforms_section_data():
             'name': 'instance-2',
             'groups': ['baz', 'foo'],
             'children': ['child2'],
+        },
+        {
+            'name': 'instance-3',
+            'groups': ['baz', 'foo'],
+            'children': ['child3'],
+            'append_scenario': False
         }],
     }
 

--- a/test/unit/driver/test_dockr.py
+++ b/test/unit/driver/test_dockr.py
@@ -105,7 +105,7 @@ def test_ssh_connection_options_property(docker_instance):
 def test_status(mocker, docker_instance):
     result = docker_instance.status()
 
-    assert 2 == len(result)
+    assert 3 == len(result)
 
     assert result[0].instance_name == 'instance-1-default'
     assert result[0].driver_name == 'Docker'
@@ -120,3 +120,10 @@ def test_status(mocker, docker_instance):
     assert result[1].scenario_name == 'default'
     assert result[1].created == 'False'
     assert result[1].converged == 'False'
+
+    assert result[2].instance_name == 'instance-3'
+    assert result[2].driver_name == 'Docker'
+    assert result[2].provisioner_name == 'Ansible'
+    assert result[2].scenario_name == 'default'
+    assert result[2].created == 'False'
+    assert result[2].converged == 'False'

--- a/test/unit/driver/test_ec2.py
+++ b/test/unit/driver/test_ec2.py
@@ -170,7 +170,7 @@ def test_ansible_connection_options(mocker, ec2_instance):
 
 
 def test_ansible_connection_options_handles_missing_instance_config(
-        mocker, ec2_instance):
+    mocker, ec2_instance):
     m = mocker.patch('molecule.util.safe_load_file')
     m.side_effect = IOError
 
@@ -178,7 +178,7 @@ def test_ansible_connection_options_handles_missing_instance_config(
 
 
 def test_ansible_connection_options_handles_missing_results_key(
-        mocker, ec2_instance):
+    mocker, ec2_instance):
     m = mocker.patch('molecule.util.safe_load_file')
     m.side_effect = StopIteration
 
@@ -208,7 +208,7 @@ def test_ssh_connection_options_property(ec2_instance):
 def test_status(mocker, ec2_instance):
     result = ec2_instance.status()
 
-    assert 2 == len(result)
+    assert 3 == len(result)
 
     assert result[0].instance_name == 'instance-1-default'
     assert result[0].driver_name == 'Ec2'
@@ -223,3 +223,10 @@ def test_status(mocker, ec2_instance):
     assert result[1].scenario_name == 'default'
     assert result[1].created == 'False'
     assert result[1].converged == 'False'
+
+    assert result[2].instance_name == 'instance-3'
+    assert result[2].driver_name == 'Ec2'
+    assert result[2].provisioner_name == 'Ansible'
+    assert result[2].scenario_name == 'default'
+    assert result[2].created == 'False'
+    assert result[2].converged == 'False'

--- a/test/unit/driver/test_gce.py
+++ b/test/unit/driver/test_gce.py
@@ -208,7 +208,7 @@ def test_ssh_connection_options_property(gce_instance):
 def test_status(mocker, gce_instance):
     result = gce_instance.status()
 
-    assert 2 == len(result)
+    assert 3 == len(result)
 
     assert result[0].instance_name == 'instance-1-default'
     assert result[0].driver_name == 'Gce'
@@ -223,3 +223,10 @@ def test_status(mocker, gce_instance):
     assert result[1].scenario_name == 'default'
     assert result[1].created == 'False'
     assert result[1].converged == 'False'
+
+    assert result[2].instance_name == 'instance-3'
+    assert result[2].driver_name == 'Gce'
+    assert result[2].provisioner_name == 'Ansible'
+    assert result[2].scenario_name == 'default'
+    assert result[2].created == 'False'
+    assert result[2].converged == 'False'

--- a/test/unit/driver/test_lxc.py
+++ b/test/unit/driver/test_lxc.py
@@ -103,7 +103,7 @@ def test_ssh_connection_options_property(lxc_instance):
 def test_status(mocker, lxc_instance):
     result = lxc_instance.status()
 
-    assert 2 == len(result)
+    assert 3 == len(result)
 
     assert result[0].instance_name == 'instance-1-default'
     assert result[0].driver_name == 'Lxc'
@@ -118,3 +118,10 @@ def test_status(mocker, lxc_instance):
     assert result[1].scenario_name == 'default'
     assert result[1].created == 'False'
     assert result[1].converged == 'False'
+
+    assert result[2].instance_name == 'instance-3'
+    assert result[2].driver_name == 'Lxc'
+    assert result[2].provisioner_name == 'Ansible'
+    assert result[2].scenario_name == 'default'
+    assert result[2].created == 'False'
+    assert result[2].converged == 'False'

--- a/test/unit/driver/test_lxd.py
+++ b/test/unit/driver/test_lxd.py
@@ -103,7 +103,7 @@ def test_ssh_connection_options_property(lxd_instance):
 def test_status(mocker, lxd_instance):
     result = lxd_instance.status()
 
-    assert 2 == len(result)
+    assert 3 == len(result)
 
     assert result[0].instance_name == 'instance-1-default'
     assert result[0].driver_name == 'Lxd'
@@ -118,3 +118,10 @@ def test_status(mocker, lxd_instance):
     assert result[1].scenario_name == 'default'
     assert result[1].created == 'False'
     assert result[1].converged == 'False'
+
+    assert result[2].instance_name == 'instance-3'
+    assert result[2].driver_name == 'Lxd'
+    assert result[2].provisioner_name == 'Ansible'
+    assert result[2].scenario_name == 'default'
+    assert result[2].created == 'False'
+    assert result[2].converged == 'False'

--- a/test/unit/driver/test_openstack.py
+++ b/test/unit/driver/test_openstack.py
@@ -209,7 +209,7 @@ def test_ssh_connection_options_property(openstack_instance):
 def test_status(mocker, openstack_instance):
     result = openstack_instance.status()
 
-    assert 2 == len(result)
+    assert 3 == len(result)
 
     assert result[0].instance_name == 'instance-1-default'
     assert result[0].driver_name == 'Openstack'
@@ -224,3 +224,10 @@ def test_status(mocker, openstack_instance):
     assert result[1].scenario_name == 'default'
     assert result[1].created == 'False'
     assert result[1].converged == 'False'
+
+    assert result[2].instance_name == 'instance-3'
+    assert result[2].driver_name == 'Openstack'
+    assert result[2].provisioner_name == 'Ansible'
+    assert result[2].scenario_name == 'default'
+    assert result[2].created == 'False'
+    assert result[2].converged == 'False'

--- a/test/unit/driver/test_static.py
+++ b/test/unit/driver/test_static.py
@@ -117,7 +117,7 @@ def test_ssh_connection_options_property(static_instance):
 def test_status(mocker, static_instance):
     result = static_instance.status()
 
-    assert 2 == len(result)
+    assert 3 == len(result)
 
     assert result[0].instance_name == 'instance-1-default'
     assert result[0].driver_name == 'Static'
@@ -132,3 +132,10 @@ def test_status(mocker, static_instance):
     assert result[1].scenario_name == 'default'
     assert result[1].created == 'False'
     assert result[1].converged == 'False'
+
+    assert result[2].instance_name == 'instance-3'
+    assert result[2].driver_name == 'Static'
+    assert result[2].provisioner_name == 'Ansible'
+    assert result[2].scenario_name == 'default'
+    assert result[2].created == 'False'
+    assert result[2].converged == 'False'

--- a/test/unit/driver/test_vagrant.py
+++ b/test/unit/driver/test_vagrant.py
@@ -217,7 +217,7 @@ def test_ssh_connection_options_property(vagrant_instance):
 def test_status(mocker, vagrant_instance):
     result = vagrant_instance.status()
 
-    assert 2 == len(result)
+    assert 3 == len(result)
 
     assert result[0].instance_name == 'instance-1-default'
     assert result[0].driver_name == 'Vagrant'
@@ -232,3 +232,10 @@ def test_status(mocker, vagrant_instance):
     assert result[1].scenario_name == 'default'
     assert result[1].created == 'False'
     assert result[1].converged == 'False'
+
+    assert result[2].instance_name == 'instance-3'
+    assert result[2].driver_name == 'Vagrant'
+    assert result[2].provisioner_name == 'Ansible'
+    assert result[2].scenario_name == 'default'
+    assert result[2].created == 'False'
+    assert result[2].converged == 'False'

--- a/test/unit/provisioner/test_ansible.py
+++ b/test/unit/provisioner/test_ansible.py
@@ -386,6 +386,10 @@ def test_inventory_property(ansible_instance):
                 'instance-2-default': {
                     'ansible_connection': 'docker',
                     'foo': 'bar'
+                },
+                'instance-3': {
+                    'ansible_connection': 'docker',
+                    'foo': 'bar'
                 }
             }
         },
@@ -416,6 +420,10 @@ def test_inventory_property(ansible_instance):
                 'instance-2-default': {
                     'ansible_connection': 'docker',
                     'foo': 'bar'
+                },
+                'instance-3': {
+                    'ansible_connection': 'docker',
+                    'foo': 'bar'
                 }
             },
             'children': {
@@ -434,6 +442,14 @@ def test_inventory_property(ansible_instance):
                             'foo': 'bar'
                         }
                     }
+                },
+                'child3': {
+                    'hosts': {
+                        'instance-3': {
+                            'ansible_connection': 'docker',
+                            'foo': 'bar'
+                        }
+                    }
                 }
             }
         },
@@ -442,12 +458,24 @@ def test_inventory_property(ansible_instance):
                 'instance-2-default': {
                     'ansible_connection': 'docker',
                     'foo': 'bar'
+                },
+                'instance-3': {
+                    'ansible_connection': 'docker',
+                    'foo': 'bar'
                 }
             },
             'children': {
                 'child2': {
                     'hosts': {
                         'instance-2-default': {
+                            'ansible_connection': 'docker',
+                            'foo': 'bar'
+                        }
+                    }
+                },
+                'child3': {
+                    'hosts': {
+                        'instance-3': {
                             'ansible_connection': 'docker',
                             'foo': 'bar'
                         }
@@ -717,6 +745,10 @@ def test_write_inventory(temp_dir, ansible_instance):
                 'instance-2-default': {
                     'ansible_connection': 'docker',
                     'foo': 'bar'
+                },
+                'instance-3': {
+                    'ansible_connection': 'docker',
+                    'foo': 'bar'
                 }
             }
         },
@@ -747,6 +779,10 @@ def test_write_inventory(temp_dir, ansible_instance):
                 'instance-2-default': {
                     'ansible_connection': 'docker',
                     'foo': 'bar'
+                },
+                'instance-3': {
+                    'ansible_connection': 'docker',
+                    'foo': 'bar'
                 }
             },
             'children': {
@@ -765,6 +801,14 @@ def test_write_inventory(temp_dir, ansible_instance):
                             'foo': 'bar'
                         }
                     }
+                },
+                'child3': {
+                    'hosts': {
+                        'instance-3': {
+                            'ansible_connection': 'docker',
+                            'foo': 'bar'
+                        }
+                    }
                 }
             }
         },
@@ -773,12 +817,24 @@ def test_write_inventory(temp_dir, ansible_instance):
                 'instance-2-default': {
                     'ansible_connection': 'docker',
                     'foo': 'bar'
+                },
+                'instance-3': {
+                    'ansible_connection': 'docker',
+                    'foo': 'bar'
                 }
             },
             'children': {
                 'child2': {
                     'hosts': {
                         'instance-2-default': {
+                            'ansible_connection': 'docker',
+                            'foo': 'bar'
+                        }
+                    }
+                },
+                'child3': {
+                    'hosts': {
+                        'instance-3': {
                             'ansible_connection': 'docker',
                             'foo': 'bar'
                         }

--- a/test/unit/test_platforms.py
+++ b/test/unit/test_platforms.py
@@ -37,6 +37,11 @@ def test_instances_property(platform_instance):
         'groups': ['baz', 'foo'],
         'name': 'instance-2',
         'children': ['child2'],
+    }, {
+        'groups': ['baz', 'foo'],
+        'name': 'instance-3',
+        'children': ['child3'],
+        'append_scenario': False
     }]
 
     assert x == platform_instance.instances
@@ -51,6 +56,10 @@ def test_platforms_with_scenario_name(platform_instance):
         'groups': ['baz', 'foo'],
         'name': 'instance-2-default',
         'children': ['child2'],
+    }, {
+        'groups': ['baz', 'foo'],
+        'name': 'instance-3',
+        'children': ['child3'],
+        'append_scenario': False,
     }]
-
     assert x == platform_instance.instances_with_scenario_name


### PR DESCRIPTION
- Add a boolean into the platform configuration `append_scenario` to let the user choose if he wants a different host for each of his scenario
- Update the documentation
- Update unit test for this new functionality

