### PR TITLE
force stop lxd containers on destruction

### DIFF
--- a/molecule/cookiecutter/scenario/driver/lxd/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/lxd/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -11,5 +11,6 @@
       lxd_container:
         name: "{{ molecule_file | molecule_instance_with_scenario_name(item.name) }}"
         state: absent
+        force_stop: True
       with_items: "{{ molecule_yml.platforms }}"
 {%- endraw %}

--- a/test/resources/playbooks/lxd/destroy.yml
+++ b/test/resources/playbooks/lxd/destroy.yml
@@ -10,4 +10,5 @@
       lxd_container:
         name: "{{ molecule_file | molecule_instance_with_scenario_name(item.name) }}"
         state: absent
+        force_stop: True
       with_items: "{{ molecule_yml.platforms }}"


### PR DESCRIPTION
No need to wait for timeouts or whatnot since we want to delete everything anyways.

This might also be a useful patch for upstream (set force if removing containers), but I guess in some cases people might want their systems to gracefully shut down - even if they are deleted afterwards. I doubt that this is the case for the destroy phase of molecule though.