### PR TITLE
Fix #901: output of vagrant.up() can't be JSON doc

### DIFF
--- a/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
+++ b/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
@@ -294,7 +294,9 @@ class VagrantClient(object):
         cd = self._created()
         if not cd:
             changed = True
-            self._vagrant.up(no_provision)
+            for line in self._vagrant.up(no_provision, stream_output=True):
+              # Add prefix to ensure that output of 'vagrant up' doesn't start with one of the JSON start characters { or ]
+              print ('<vagrant_output> {}'.format(line))
 
         self._module.exit_json(changed=changed, **self._conf())
 


### PR DESCRIPTION
Ansible analyses stdout of each module to detect and JSON document.

It may happen that the output of vagrant.up() contains a JSON start delimiter: { or [
This fix rewrites vagrant.up() output to ensure that it does not start with { or [