### PR TITLE
Bump yamllint to latest.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ PyYAML==3.12
 sh==1.12.14
 tabulate==0.7.7
 testinfra==1.6.3
-yamllint==1.7.0
+yamllint==1.8.1


### PR DESCRIPTION
yamllint 1.8.0 introduced support for ignoring paths by setting them in the `.yamllint` config file like so:

```
ignore: |
  /this/specific/file.yaml
  /all/this/directory/
  *.template.yaml
```

This is especially desirable if you use virtualenv for Molecule projects as yamllint will find errors in any yaml files in the dependencies installed in the virtualenv.