### PR TITLE
Correct left-over references to docker-py.

### DIFF
--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -9,7 +9,7 @@ Install Molecule using pip:
 .. code-block:: bash
 
     $ pip install ansible
-    $ pip install docker-py
+    $ pip install docker
     $ pip install molecule --pre
 
 Create a new role:

--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
@@ -42,5 +42,5 @@ Install using pip:
 .. code-block:: bash
 
   $ sudo pip install ansible
-  $ sudo pip install docker-py
+  $ sudo pip install docker
   $ sudo pip install molecule --pre

--- a/molecule/driver/dockr.py
+++ b/molecule/driver/dockr.py
@@ -38,7 +38,7 @@ class Dockr(base.Base):
 
     .. code-block:: bash
 
-        $ sudo pip install docker-py
+        $ sudo pip install docker
 
     Provide the files Molecule will preserve upon each subcommand execution.
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 apache-libcloud
 boto
-docker-py
+docker
 # lxc-python2
 mock
 # pytest==3.1.0 issues with pytest-verbose-parametrize


### PR DESCRIPTION
`docker-py` has been deprecated as referenced in [Molecule changelog 1.21](https://github.com/metacloud/molecule/blob/master/CHANGELOG.rst#breaking-changes-1).