### PR TITLE
Delegated driver may or may not manage instances

### DIFF
--- a/molecule/command/create.py
+++ b/molecule/command/create.py
@@ -57,7 +57,7 @@ class Create(base.Base):
         self.print_info()
         self._config.state.change_state('driver', self._config.driver.name)
 
-        if self._config.driver.delegated:
+        if self._config.driver.delegated and not self._config.driver.managed:
             msg = 'Skipping, instances are delegated.'
             LOG.warn(msg)
             return

--- a/molecule/command/destroy.py
+++ b/molecule/command/destroy.py
@@ -61,7 +61,7 @@ class Destroy(base.Base):
         self.print_info()
         self.prune()
 
-        if self._config.driver.delegated:
+        if self._config.driver.delegated and not self._config.driver.managed:
             msg = 'Skipping, instances are delegated.'
             LOG.warn(msg)
             return

--- a/molecule/command/login.py
+++ b/molecule/command/login.py
@@ -67,7 +67,8 @@ class Login(base.Base):
         :return: None
         """
         c = self._config
-        if not c.state.created and not c.driver.delegated:
+        if not c.state.created and (c.driver.delegated and
+                                    not c.driver.managed):
             msg = 'Instances not created.  Please create instances first.'
             util.sysexit_with_message(msg)
 

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -265,7 +265,9 @@ class Config(object):
                 'provider': {
                     'name': None
                 },
-                'options': {},
+                'options': {
+                    'managed': True,
+                },
                 'ssh_connection_options': [],
                 'safe_files': [],
             },

--- a/molecule/cookiecutter/scenario/driver/delegated/cookiecutter.json
+++ b/molecule/cookiecutter/scenario/driver/delegated/cookiecutter.json
@@ -1,0 +1,5 @@
+{
+    "molecule_directory": "molecule",
+    "role_name": "OVERRIDEN",
+    "scenario_name": "OVERRIDEN"
+}

--- a/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -1,0 +1,43 @@
+---
+{% raw -%}
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: False
+  no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
+  vars:
+    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
+    molecule_ephemeral_directory: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}"
+    molecule_scenario_directory: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | from_yaml }}"
+  tasks:
+    # Developer must implement.
+
+    # Developer must map instance config.
+    # Mandatory configuration for Molecule to function.
+
+    - name: Populate instance config dict
+      set_fact:
+        instance_conf_dict: {
+          'instance': "{{ }}",
+          'address': "{{ }}",
+          'user': {{ }},
+          'port': "{{ }}",
+          'identity_file': "{{ }}",
+      with_items: "{{ server.results }}"
+      register: instance_config_dict
+      when: server.changed | bool
+
+    - name: Convert instance config dict to a list
+      set_fact:
+        instance_conf: "{{ instance_config_dict.results | map(attribute='ansible_facts.instance_conf_dict') | list }}"
+      when: server.changed | bool
+
+    - name: Dump instance config
+      copy:
+        # NOTE(retr0h): Workaround for Ansible 2.2.
+        #               https://github.com/ansible/ansible/issues/20885
+        content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
+        dest: "{{ molecule_instance_config }}"
+      when: server.changed | bool
+{%- endraw %}

--- a/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -1,0 +1,28 @@
+---
+{% raw -%}
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: False
+  no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
+  vars:
+    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
+    molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | from_yaml }}"
+  tasks:
+    # Developer must implement.
+
+    # Mandatory configuration for Molecule to function.
+
+    - name: Populate instance config
+      set_fact:
+        instance_conf: {}
+
+    - name: Dump instance config
+      copy:
+        # NOTE(retr0h): Workaround for Ansible 2.2.
+        #               https://github.com/ansible/ansible/issues/20885
+        content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
+        dest: "{{ molecule_instance_config }}"
+      when: server.changed | bool
+{%- endraw %}

--- a/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/playbook.yml
+++ b/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/playbook.yml
@@ -1,0 +1,5 @@
+---
+- name: Converge
+  hosts: all
+  roles:
+    - role: {{ cookiecutter.role_name }}

--- a/molecule/driver/base.py
+++ b/molecule/driver/base.py
@@ -148,6 +148,15 @@ class Base(object):
         """
         return self.name == 'delegated'
 
+    @property
+    def managed(self):
+        """
+        Is the driver is managed and returns a bool.
+
+        :returns: bool
+        """
+        return self.options['managed']
+
     def status(self):
         """
         Collects the instances state and returns a list.

--- a/molecule/driver/delegated.py
+++ b/molecule/driver/delegated.py
@@ -29,16 +29,29 @@ class Delegated(base.Base):
     The class responsible for managing delegated instances.  Delegated is `not`
     the default driver used in Molecule.
 
-    Under this driver, Molecule skips the provisioning/deprovisioning steps.
-    It is the developers responsibility to manage the instances, and properly
-    configure Molecule to connect to said instances.
+    Under this driver, it is the developers responsibility to implement the
+    create and destroy actions.
 
     .. code-block:: yaml
 
         driver:
           name: delegated
 
-    Use Molecule with delegated Docker instances.
+    Molecule can also skip the provisioning/deprovisioning steps.  It is the
+    developers responsibility to manage the instances, and properly configure
+    Molecule to connect to said instances.
+
+    .. code-block:: yaml
+
+        driver:
+          name: delegated
+          options:
+            managed: False
+            login_cmd_template: 'docker exec -ti {instance} bash'
+            ansible_connection_options:
+              connection: docker
+        platforms:
+          - name: instance-docker
 
     .. code-block:: bash
 
@@ -47,17 +60,6 @@ class Delegated(base.Base):
             --name instance-docker \\
             --hostname instance-docker \\
             -it molecule_local/ubuntu:latest sleep infinity & wait
-
-    .. code-block:: yaml
-
-        driver:
-          name: delegated
-          options:
-            login_cmd_template: 'docker exec -ti {instance} bash'
-            ansible_connection_options:
-              connection: docker
-        platforms:
-          - name: instance-docker
 
     Use Molecule with delegated instances, which are accessible over ssh.
 
@@ -70,6 +72,7 @@ class Delegated(base.Base):
         driver:
           name: delegated
           options:
+            managed: False
             login_cmd_template: 'ssh {instance} -F /tmp/ssh-config'
             ansible_connection_options:
               connection: ssh

--- a/test/scenarios/driver/delegated/molecule/docker/molecule.yml
+++ b/test/scenarios/driver/delegated/molecule/docker/molecule.yml
@@ -4,6 +4,7 @@ dependency:
 driver:
   name: delegated
   options:
+    managed: False
     login_cmd_template: 'docker exec -ti {instance} bash'
     ansible_connection_options:
       ansible_connection: docker

--- a/test/scenarios/driver/delegated/molecule/ec2/molecule.yml
+++ b/test/scenarios/driver/delegated/molecule/ec2/molecule.yml
@@ -4,6 +4,7 @@ dependency:
 driver:
   name: delegated
   options:
+    managed: False
     login_cmd_template: 'ssh {instance} -F /tmp/ssh-config-ec2'
     ansible_connection_options:
       connection: ssh

--- a/test/scenarios/driver/delegated/molecule/gce/molecule.yml
+++ b/test/scenarios/driver/delegated/molecule/gce/molecule.yml
@@ -4,6 +4,7 @@ dependency:
 driver:
   name: delegated
   options:
+    managed: False
     login_cmd_template: 'ssh {instance} -F /tmp/ssh-config-gce'
     ansible_connection_options:
       connection: ssh

--- a/test/scenarios/driver/delegated/molecule/openstack/molecule.yml
+++ b/test/scenarios/driver/delegated/molecule/openstack/molecule.yml
@@ -4,6 +4,7 @@ dependency:
 driver:
   name: delegated
   options:
+    managed: False
     login_cmd_template: 'ssh {instance} -F /tmp/ssh-config-openstack'
     ansible_connection_options:
       connection: ssh

--- a/test/scenarios/driver/delegated/molecule/vagrant/molecule.yml
+++ b/test/scenarios/driver/delegated/molecule/vagrant/molecule.yml
@@ -4,6 +4,7 @@ dependency:
 driver:
   name: delegated
   options:
+    managed: False
     login_cmd_template: 'ssh {instance} -F /tmp/ssh-config-vagrant'
     ansible_connection_options:
       connection: ssh

--- a/test/unit/command/test_login.py
+++ b/test/unit/command/test_login.py
@@ -24,8 +24,26 @@ from molecule.command import login
 
 
 @pytest.fixture
-def login_instance(config_instance):
+def molecule_driver_delegated_section_data():
+    return {
+        'driver': {
+            'name': 'delegated',
+            'options': {
+                'managed': False,
+                'login_cmd_template': 'docker exec -ti {instance} bash',
+                'ansible_connection_options': {
+                    'ansible_connection': 'docker'
+                }
+            }
+        }
+    }
+
+
+@pytest.fixture
+def login_instance(molecule_driver_delegated_section_data, config_instance):
     config_instance.state.change_state('created', True)
+    config_instance.merge_dicts(config_instance.config,
+                                molecule_driver_delegated_section_data)
 
     return login.Login(config_instance)
 

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -62,7 +62,10 @@ def molecule_driver_section_data():
 def molecule_driver_delegated_section_data():
     return {
         'driver': {
-            'name': 'delegated'
+            'name': 'delegated',
+            'options': {
+                'managed': False,
+            },
         },
     }
 

--- a/test/unit/driver/test_delegated.py
+++ b/test/unit/driver/test_delegated.py
@@ -70,7 +70,8 @@ def test_options_property(delegated_instance):
         'ansible_connection_options': {
             'ansible_connection': 'docker'
         },
-        'login_cmd_template': 'docker exec -ti {instance} bash'
+        'login_cmd_template': 'docker exec -ti {instance} bash',
+        'managed': True,
     }
 
     assert x == delegated_instance.options
@@ -90,8 +91,12 @@ def test_default_safe_files_property(delegated_instance):
     assert [] == delegated_instance.default_safe_files
 
 
-def test_delegated(delegated_instance):
+def test_delegated_property(delegated_instance):
     assert delegated_instance.delegated
+
+
+def test_managed_property(delegated_instance):
+    assert delegated_instance.managed
 
 
 def test_default_ssh_connection_options_property(delegated_instance):

--- a/test/unit/driver/test_docker.py
+++ b/test/unit/driver/test_docker.py
@@ -60,7 +60,9 @@ def test_name_property(docker_instance):
 
 
 def test_options_property(docker_instance):
-    assert {} == docker_instance.options
+    x = {'managed': True}
+
+    assert x == docker_instance.options
 
 
 def test_login_cmd_template_property(docker_instance):
@@ -87,8 +89,12 @@ def test_default_safe_files_property(docker_instance):
     assert x == docker_instance.default_safe_files
 
 
-def test_delegated(docker_instance):
+def test_delegated_property(docker_instance):
     assert not docker_instance.delegated
+
+
+def test_managed_property(docker_instance):
+    assert docker_instance.managed
 
 
 def test_default_ssh_connection_options_property(docker_instance):

--- a/test/unit/driver/test_ec2.py
+++ b/test/unit/driver/test_ec2.py
@@ -60,7 +60,9 @@ def test_name_property(ec2_instance):
 
 
 def test_options_property(ec2_instance):
-    assert {} == ec2_instance.options
+    x = {'managed': True}
+
+    assert x == ec2_instance.options
 
 
 def test_login_cmd_template_property(ec2_instance):
@@ -92,8 +94,12 @@ def test_default_safe_files_property(ec2_instance):
     assert x == ec2_instance.default_safe_files
 
 
-def test_delegated(ec2_instance):
+def test_delegated_property(ec2_instance):
     assert not ec2_instance.delegated
+
+
+def test_managed_property(ec2_instance):
+    assert ec2_instance.managed
 
 
 def test_default_ssh_connection_options_property(ec2_instance):

--- a/test/unit/driver/test_gce.py
+++ b/test/unit/driver/test_gce.py
@@ -60,7 +60,9 @@ def test_name_property(gce_instance):
 
 
 def test_options_property(gce_instance):
-    assert {} == gce_instance.options
+    x = {'managed': True}
+
+    assert x == gce_instance.options
 
 
 def test_login_cmd_template_property(gce_instance):
@@ -92,8 +94,12 @@ def test_default_safe_files_property(gce_instance):
     assert x == gce_instance.default_safe_files
 
 
-def test_delegated(gce_instance):
+def test_delegated_property(gce_instance):
     assert not gce_instance.delegated
+
+
+def test_managed_property(gce_instance):
+    assert gce_instance.managed
 
 
 def test_default_ssh_connection_options_property(gce_instance):

--- a/test/unit/driver/test_lxc.py
+++ b/test/unit/driver/test_lxc.py
@@ -60,7 +60,9 @@ def test_name_property(lxc_instance):
 
 
 def test_options_property(lxc_instance):
-    assert {} == lxc_instance.options
+    x = {'managed': True}
+
+    assert x == lxc_instance.options
 
 
 def test_login_cmd_template_property(lxc_instance):
@@ -75,8 +77,12 @@ def test_default_safe_files_property(lxc_instance):
     assert [] == lxc_instance.default_safe_files
 
 
-def test_delegated(lxc_instance):
+def test_delegated_property(lxc_instance):
     assert not lxc_instance.delegated
+
+
+def test_managed_property(lxc_instance):
+    assert lxc_instance.managed
 
 
 def test_default_ssh_connection_options_property(lxc_instance):

--- a/test/unit/driver/test_lxd.py
+++ b/test/unit/driver/test_lxd.py
@@ -60,7 +60,9 @@ def test_name_property(lxd_instance):
 
 
 def test_options_property(lxd_instance):
-    assert {} == lxd_instance.options
+    x = {'managed': True}
+
+    assert x == lxd_instance.options
 
 
 def test_login_cmd_template_property(lxd_instance):
@@ -75,8 +77,12 @@ def test_default_safe_files_property(lxd_instance):
     assert [] == lxd_instance.default_safe_files
 
 
-def test_delegated(lxd_instance):
+def test_delegated_property(lxd_instance):
     assert not lxd_instance.delegated
+
+
+def test_managed_property(lxd_instance):
+    assert lxd_instance.managed
 
 
 def test_default_ssh_connection_options_property(lxd_instance):

--- a/test/unit/driver/test_openstack.py
+++ b/test/unit/driver/test_openstack.py
@@ -61,7 +61,9 @@ def test_name_property(openstack_instance):
 
 
 def test_options_property(openstack_instance):
-    assert {} == openstack_instance.options
+    x = {'managed': True}
+
+    assert x == openstack_instance.options
 
 
 def test_login_cmd_template_property(openstack_instance):
@@ -93,8 +95,12 @@ def test_default_safe_files_property(openstack_instance):
     assert x == openstack_instance.default_safe_files
 
 
-def test_delegated(openstack_instance):
+def test_delegated_property(openstack_instance):
     assert not openstack_instance.delegated
+
+
+def test_managed_property(openstack_instance):
+    assert openstack_instance.managed
 
 
 def test_default_ssh_connection_options_property(openstack_instance):

--- a/test/unit/driver/test_vagrant.py
+++ b/test/unit/driver/test_vagrant.py
@@ -65,7 +65,9 @@ def test_name_property(vagrant_instance):
 
 
 def test_options_property(vagrant_instance):
-    assert {} == vagrant_instance.options
+    x = {'managed': True}
+
+    assert x == vagrant_instance.options
 
 
 def test_login_cmd_template_property(vagrant_instance):
@@ -105,8 +107,12 @@ def test_default_safe_files_property(vagrant_instance):
     assert x == vagrant_instance.default_safe_files
 
 
-def test_delegated(vagrant_instance):
+def test_delegated_property(vagrant_instance):
     assert not vagrant_instance.delegated
+
+
+def test_managed_property(vagrant_instance):
+    assert vagrant_instance.managed
 
 
 def test_default_ssh_connection_options_property(vagrant_instance):


### PR DESCRIPTION
Reworked the delegated to fully delegate to the developer.

1. Developer may delegate the instance create/destroy to the delegate
   driver.
2. Developer may not use create/destroy and delegate to a manual
   process.

Fixes: #936