### PR TITLE
update to ansible-lint 3.4.15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible-lint==3.4.13
+ansible-lint==3.4.15
 anyconfig==0.9.1
 click==6.7
 click-completion==0.2.1


### PR DESCRIPTION
This should fix some errors with Ansible 2.4.

I haven't checked the remaining versions of requirements, maybe there are more that could/should be updated.