### PR TITLE
Add a destroy strategy to the `test` action

### DIFF
--- a/test/functional/docker/test_scenarios.py
+++ b/test/functional/docker/test_scenarios.py
@@ -229,6 +229,52 @@ def test_command_test_builds_local_molecule_image(
 
 @pytest.mark.parametrize(
     'scenario_to_test, driver_name, scenario_name', [
+        ('test_destroy_strategy', 'docker', 'default'),
+    ],
+    indirect=[
+        'scenario_to_test',
+        'driver_name',
+        'scenario_name',
+    ])
+def test_command_test_destroy_strategy_always(scenario_to_test, with_scenario,
+                                              scenario_name, driver_name):
+    options = {
+        'destroy': 'always',
+    }
+    try:
+        cmd = sh.molecule.bake('test', **options)
+        pytest.helpers.run_command(cmd, log=False)
+    except sh.ErrorReturnCode as e:
+        msg = 'An error occured during the test sequence.  Cleaning up.'
+        assert msg in e.stdout
+
+        assert 'PLAY [Destroy]' in e.stdout
+        assert 1 == e.exit_code
+
+
+@pytest.mark.parametrize(
+    'scenario_to_test, driver_name, scenario_name', [
+        ('test_destroy_strategy', 'docker', 'default'),
+    ],
+    indirect=[
+        'scenario_to_test',
+        'driver_name',
+        'scenario_name',
+    ])
+def test_command_test_destroy_strategy_never(scenario_to_test, with_scenario,
+                                             scenario_name, driver_name):
+    try:
+        cmd = sh.molecule.bake('test')
+        pytest.helpers.run_command(cmd, log=False)
+    except sh.ErrorReturnCode as e:
+        msg = 'An error occured during the test sequence.  Cleaning up.'
+        assert msg not in e.stdout
+
+        assert 1 == e.exit_code
+
+
+@pytest.mark.parametrize(
+    'scenario_to_test, driver_name, scenario_name', [
         ('host_group_vars', 'docker', 'default'),
     ],
     indirect=[

--- a/test/scenarios/test_destroy_strategy/molecule/default/molecule.yml
+++ b/test/scenarios/test_destroy_strategy/molecule/default/molecule.yml
@@ -1,0 +1,25 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+  options:
+    config-file: ../../../resources/.yamllint
+platforms:
+  - name: instance
+    image: centos:latest
+provisioner:
+  name: ansible
+  playbooks:
+    create: ../../../../resources/playbooks/docker/create.yml
+    destroy: ../../../../resources/playbooks/docker/destroy.yml
+  lint:
+    name: ansible-lint
+scenario:
+  name: default
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/test/scenarios/test_destroy_strategy/molecule/default/playbook.yml
+++ b/test/scenarios/test_destroy_strategy/molecule/default/playbook.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  become: True
+  tasks:
+    - name: Force a converge failure
+      command: /bin/false

--- a/test/scenarios/test_destroy_strategy/molecule/default/tests/test_default.py
+++ b/test/scenarios/test_destroy_strategy/molecule/default/tests/test_default.py
@@ -1,0 +1,28 @@
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+def test_hostname(host):
+    assert 'instance' == host.system_info.hostname
+
+
+def test_etc_molecule_directory(host):
+    f = host.file('/etc/molecule')
+
+    assert f.is_directory
+    assert f.user == 'root'
+    assert f.group == 'root'
+    assert f.mode == 0o755
+
+
+def test_etc_molecule_ansible_hostname_file(host):
+    f = host.file('/etc/molecule/instance')
+
+    assert f.is_file
+    assert f.user == 'root'
+    assert f.group == 'root'
+    assert f.mode == 0o644


### PR DESCRIPTION
Molecule by default will never destroy instances when a failure
occurs on the `test` action.  However, the ability to pass
the `--destroy=always` flag, will cleanup instances upon failure.

Fixes: #945