### PR TITLE
Clarify which versions of Ansible are supported

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,8 +64,7 @@ Forums
 Ansible Support
 ===============
 
-* 2.2.3.0
-* 2.3.1.0
+Molecule requires Ansible version 2.2 or later.
 
 .. _`Ansible`: https://docs.ansible.com
 

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -18,8 +18,8 @@ through their respective CLI.
 
 .. _`direct consumption`: http://docs.ansible.com/ansible/dev_guide/developing_api.html
 
-Why does Molecule only support ansible 2.2 and 2.3?
-===================================================
+Why does Molecule only support Ansible versions 2.2 and later?
+==============================================================
 
 * Ansible 2.2 is the first good release in the Ansible 2 lineup.
 * The modules needed to support the drivers did not exist pre 2.2 or were not


### PR DESCRIPTION
As far as I can tell, Molecule supports all versions of Ansible at or after 2.2, including the new minor version (2.4). This minor PR updates the documentation to reflect this.