### PR TITLE
Fix path searching to remain in the repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ sudo: false
 language: python
 services:
   - docker
-branches:
-  only:
-    - v2
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y docker-engine

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y docker-engine
+  - sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y docker-ce
 python:
   - "2.7"
   - "3.5"

--- a/molecule/provisioner/ansible.py
+++ b/molecule/provisioner/ansible.py
@@ -125,13 +125,13 @@ class Ansible(base.Base):
 
         This is feature should be considered experimental.
 
-    Environment variables.  Molecule does it's best to handle common Ansible
+    Environment variables.  Molecule does its best to handle common Ansible
     paths.  The defaults are as follows.
 
     ::
 
         ANSIBLE_ROLES_PATH:
-          $project_root/../:$ephemeral_directory/roles/
+          $project_root/:$ephemeral_directory/roles/
         ANSIBLE_LIBRARY:
           $project_root/library/:$ephemeral_directory/library/
         ANSIBLE_FILTER_PLUGINS:
@@ -303,9 +303,7 @@ class Ansible(base.Base):
             self._config.provisioner.config_file,
             'ANSIBLE_ROLES_PATH':
             ':'.join([
-                util.abs_path(
-                    os.path.join(self._config.project_directory,
-                                 os.path.pardir)),
+                util.abs_path(self._config.project_directory),
                 util.abs_path(
                     os.path.join(self._config.scenario.ephemeral_directory,
                                  'roles'))

--- a/test/unit/provisioner/test_ansible.py
+++ b/test/unit/provisioner/test_ansible.py
@@ -239,7 +239,7 @@ def test_env_appends_env_property(ansible_instance):
     x = [
         util.abs_path(
             os.path.join(ansible_instance._config.project_directory,
-                         os.path.pardir)),
+                         os.path.curdir)),
         util.abs_path(
             os.path.join(ansible_instance._config.scenario.ephemeral_directory,
                          'roles')),


### PR DESCRIPTION
Searching in the parent directory is pretty dangerous considering that molecule exists at the root of a git repo, and many other projects that are ansible roles may live right alongside it. It also seems like setting the `ANSIBLE_ROLES_PATH` in molecule.yml just appends to the path, doesn't actually override it. I'm not arguing to change that per se, just that searching outside of the repo it's in seems dangerous, and cost me a bunch of hours of troubleshooting.

Given this molecule.yml
```
$ cat molecule/default/molecule.yml
---
dependency:
  name: galaxy
  options:
    ignore-certs: True
    ignore-errors: True
driver:
  name: vagrant
  provider:
    name: virtualbox
platforms:
  - name: orgname-jenkins6
    box: centos/6
    memory: 2048
    cpus: 2
    instance_raw_config_args:
      - "vm.network 'forwarded_port', guest: 8080, host: 8081"
      - "vm.network 'forwarded_port', guest: 80, host: 8000"
      - "vm.synced_folder '../../..', '/vagrant', type: 'virtualbox'"
    groups:
      - all
      - local
lint:
  name: yamllint
  enabled: True
provisioner:
  name: ansible
  lint:
    name: ansible-lint
    options:
      excludes:
        - .venv/*
        - molecule/default/.molecule
  inventory:
    links:
      group_vars: ../../../inventory/group_vars/
  env:
    ANSIBLE_ROLES_PATH:
      ../../orgname_roles
  options:
    vault-password-file: ../../vault.txt
scenario:
  name: default
  converge_sequence:
    - create
    - dependency
    - converge
verifier:
  name: testinfra
  options: {}
  env:
    ANSIBLE_VAULT_PASSWORD_FILE: ../../vault.txt
  lint:
    name: flake8
```

Here is the molecule --debug converge output

```
---
ANSIBLE_CONFIG: /Users/username/ORGNAME/orgname-jenkins-provisioning/molecule/default/.molecule/ansible.cfg
ANSIBLE_FILTER_PLUGINS: /Users/username/ORGNAME/orgname-jenkins-provisioning/.venv/lib/python2.7/site-packages/molecule/provisioner/ansible/plugins/filters:/Users/username/ORGNAME/orgname-jenkins-provisioning/plugins/filters:/Users/username/ORGNAME/orgname-jenkins-provisioning/molecule/default/.molecule/plugins/filters
ANSIBLE_LIBRARY: /Users/username/ORGNAME/orgname-jenkins-provisioning/.venv/lib/python2.7/site-packages/molecule/provisioner/ansible/plugins/libraries:/Users/username/ORGNAME/orgname-jenkins-provisioning/library:/Users/username/ORGNAME/orgname-jenkins-provisioning/molecule/default/.molecule/library
ANSIBLE_ROLES_PATH: /Users/username/ORGNAME:/Users/username/ORGNAME/orgname-jenkins-provisioning/molecule/default/.molecule/roles:/Users/username/ORGNAME/orgname-jenkins-provisioning/orgname_roles
```

I think a sane default might be to remove the parent directory from where molecule is run and replace it with the current directory.