### PR TITLE
use become=True when using the vagrant driver

### DIFF
--- a/molecule/cookiecutter/molecule/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
+++ b/molecule/cookiecutter/molecule/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
@@ -37,6 +37,10 @@ platforms:
 {%- endif %}
 provisioner:
   name: {{ cookiecutter.provisioner_name }}
+{%- if cookiecutter.driver_name == 'vagrant' %}
+  options:
+    become: True
+{%- endif %}
   lint:
     name: {{ cookiecutter.provisioner_lint_name }}
 scenario:


### PR DESCRIPTION
I have started to test molecule and I found that when using the Vagrant driver my roles were not working unless I use `become: True` with ansible because the ssh connection is done as the vagrant user. 

This patch updates the cookiecutter template so when the Vagrant driver is used the `become: True` option is added by default to `molecule.yml`
