### PR TITLE
Changed testinfra command to py.test

### DIFF
--- a/molecule/verifier/testinfra.py
+++ b/molecule/verifier/testinfra.py
@@ -130,7 +130,7 @@ class Testinfra(base.Base):
         verbose_flag = util.verbose_flag(options)
         args = verbose_flag + self.additional_files_or_dirs
 
-        self._testinfra_command = sh.testinfra.bake(
+        self._testinfra_command = sh.Command('py.test').bake(
             options,
             self._tests,
             *args,

--- a/test/unit/verifier/test_testinfra.py
+++ b/test/unit/verifier/test_testinfra.py
@@ -216,7 +216,7 @@ def test_options_property_handles_cli_args(inventory_file, testinfra_instance):
 def test_bake(patched_testinfra_get_tests, inventory_file, testinfra_instance):
     testinfra_instance.bake()
     x = [
-        str(sh.testinfra),
+        str(sh.Command('py.test')),
         '--ansible-inventory={}'.format(inventory_file),
         '--connection=ansible',
         '-vvv',


### PR DESCRIPTION
Remove the warnings which occur after running `testinfra`.
The testinfra command is a wrapper to pytest, which is deprecated
and should simply use `py.test`.

Fixes: #974