### PR TITLE
Added shell friendly env output

### DIFF
--- a/molecule/util.py
+++ b/molecule/util.py
@@ -65,8 +65,15 @@ def print_environment_vars(env):
     """
     ansible_env = {k: v for (k, v) in env.items() if 'ANSIBLE_' in k}
     print_debug('ANSIBLE ENVIRONMENT', safe_dump(ansible_env))
+
     molecule_env = {k: v for (k, v) in env.items() if 'MOLECULE_' in k}
     print_debug('MOLECULE ENVIRONMENT', safe_dump(molecule_env))
+
+    combined_env = ansible_env.copy()
+    combined_env.update(molecule_env)
+    print_debug('SHELL REPLAY', " ".join(
+        ["{}={}".format(k, v) for (k, v) in sorted(combined_env.items())]))
+    print()
 
 
 def sysexit(code=1):
@@ -91,6 +98,7 @@ def run_command(cmd, debug=False):
         # the environment out of the ``sh.command`` object.
         print_environment_vars(cmd._partial_call_args.get('env', {}))
         print_debug('COMMAND', str(cmd))
+        print()
     return cmd()
 
 

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -97,6 +97,21 @@ def test_print_environment_vars(capsys):
     ]
     print(''.join(data))
 
+    # Shell Replay
+    title = [
+        colorama.Back.WHITE, colorama.Style.BRIGHT, colorama.Fore.BLACK,
+        'DEBUG: SHELL REPLAY', colorama.Fore.RESET, colorama.Back.RESET,
+        colorama.Style.RESET_ALL
+    ]
+    print(''.join(title))
+    data = [
+        colorama.Fore.BLACK, colorama.Style.BRIGHT,
+        'ANSIBLE_BAR=bar ANSIBLE_FOO=foo MOLECULE_BAR=bar MOLECULE_FOO=foo',
+        colorama.Style.RESET_ALL, colorama.Fore.RESET
+    ]
+    print(''.join(data))
+    print()
+
     x, _ = capsys.readouterr()
     assert x == result
 
@@ -146,6 +161,7 @@ def test_run_command_with_debug(mocker, patched_print_debug):
     x = [
         mocker.call('ANSIBLE ENVIRONMENT', '---\nANSIBLE_FOO: foo\n'),
         mocker.call('MOLECULE ENVIRONMENT', '---\nMOLECULE_BAR: bar\n'),
+        mocker.call('SHELL REPLAY', 'ANSIBLE_FOO=foo MOLECULE_BAR=bar'),
         mocker.call('COMMAND', sh.which('ls'))
     ]
 
@@ -158,6 +174,7 @@ def test_run_command_with_debug_handles_no_env(mocker, patched_print_debug):
     x = [
         mocker.call('ANSIBLE ENVIRONMENT', '--- {}\n'),
         mocker.call('MOLECULE ENVIRONMENT', '--- {}\n'),
+        mocker.call('SHELL REPLAY', ''),
         mocker.call('COMMAND', sh.which('ls'))
     ]
 


### PR DESCRIPTION
Will allow the developer to cut and paste the environment vars
molecule sets, to manually re-run the provided command.