### PR TITLE
Sanitize user provided config options

### DIFF
--- a/test/unit/provisioner/test_ansible.py
+++ b/test/unit/provisioner/test_ansible.py
@@ -865,3 +865,24 @@ def test_sanitize_env(mocker, ansible_instance, patched_logger_warn):
         mocker.call(msg.format('ANSIBLE_BECOME_USER'))
     ]
     assert x == patched_logger_warn.mock_calls
+
+
+def test_sanitize_config_options(mocker, ansible_instance,
+                                 patched_logger_warn):
+    options = {
+        'privilege_escalation': {
+            'become_user': 'root',
+            'become': True,
+            'become_method': 'sudo'
+        },
+        'foo': 'bar',
+    }
+
+    x = {
+        'foo': 'bar',
+    }
+    assert x == ansible_instance._sanitize_config_options(options)
+
+    msg = "Disallowed user provided config option '{}'.  Removing.".format(
+        'privilege_escalation')
+    patched_logger_warn.assert_called_once_with(msg)


### PR DESCRIPTION
The user can provide config options which prevent molecule from
working properly.  Sanitize the user provided config of such
options.

    Disallowed user provided config option 'privilege_escalation'.
    Removing.

Fixes: #982