### PR TITLE
Switched out from_yaml with molecule_from_yaml

### DIFF
--- a/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -9,7 +9,7 @@
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
     molecule_ephemeral_directory: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}"
     molecule_scenario_directory: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | from_yaml }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     # Developer must implement.
 

--- a/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -8,7 +8,7 @@
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
     molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | from_yaml }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     # Developer must implement.
 

--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -9,7 +9,7 @@
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
     molecule_ephemeral_directory: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}"
     molecule_scenario_directory: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | from_yaml }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - name: Create Dockerfiles from image names
       template:

--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -7,7 +7,7 @@
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | from_yaml }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - name: Destroy molecule instance(s)
       docker_container:

--- a/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -8,7 +8,7 @@
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
     molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | from_yaml }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
 
     ssh_port: 22
     security_group_name: molecule
@@ -77,7 +77,7 @@
         search_regex: SSH
         delay: 10
         timeout: 320
-      with_items: "{{ lookup('file', molecule_instance_config) | from_yaml }}"
+      with_items: "{{ lookup('file', molecule_instance_config) | molecule_from_yaml }}"
 
     - name: Wait for boot process to finish
       pause:

--- a/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -8,12 +8,12 @@
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
     molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | from_yaml }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - block:
         - name: Populate instance config
           set_fact:
-            instance_conf: "{{ lookup('file', molecule_instance_config) | from_yaml }}"
+            instance_conf: "{{ lookup('file', molecule_instance_config) | molecule_from_yaml }}"
             skip_instances: False
       rescue:
         - name: Populate instance config when file missing

--- a/molecule/cookiecutter/scenario/driver/gce/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/gce/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -8,7 +8,7 @@
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
     molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | from_yaml }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
 
     ssh_port: 22
     ssh_user: "{{ lookup('env', 'USER') }}"
@@ -59,5 +59,5 @@
         host: "{{ item.address }}"
         search_regex: SSH
         delay: 10
-      with_items: "{{ lookup('file', molecule_instance_config) | from_yaml }}"
+      with_items: "{{ lookup('file', molecule_instance_config) | molecule_from_yaml }}"
 {%- endraw %}

--- a/molecule/cookiecutter/scenario/driver/gce/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/gce/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -8,7 +8,7 @@
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
     molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | from_yaml }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - name: Destroy molecule instance(s)
       gce:

--- a/molecule/cookiecutter/scenario/driver/lxc/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/lxc/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -7,7 +7,7 @@
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | from_yaml }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - name: Create molecule instance(s)
       lxc_container:

--- a/molecule/cookiecutter/scenario/driver/lxc/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/lxc/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -7,7 +7,7 @@
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | from_yaml }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - name: Destroy molecule instance(s)
       lxc_container:

--- a/molecule/cookiecutter/scenario/driver/lxd/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/lxd/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -7,7 +7,7 @@
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | from_yaml }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - name: Create molecule instance(s)
       lxd_container:

--- a/molecule/cookiecutter/scenario/driver/lxd/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/lxd/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -7,7 +7,7 @@
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | from_yaml }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - name: Destroy molecule instance(s)
       lxd_container:

--- a/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -8,7 +8,7 @@
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
     molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | from_yaml }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
 
     user: cloud-user
     ssh_port: 22
@@ -77,5 +77,5 @@
         host: "{{ item.address }}"
         search_regex: SSH
         delay: 10
-      with_items: "{{ lookup('file', molecule_instance_config) | from_yaml }}"
+      with_items: "{{ lookup('file', molecule_instance_config) | molecule_from_yaml }}"
 {%- endraw %}

--- a/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -8,7 +8,7 @@
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
     molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | from_yaml }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - name: Destroy molecule instance(s)
       os_server:

--- a/molecule/cookiecutter/scenario/driver/vagrant/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/vagrant/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -8,7 +8,7 @@
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
     molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | from_yaml }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - name: Create molecule instance(s)
       molecule_vagrant:

--- a/molecule/cookiecutter/scenario/driver/vagrant/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/vagrant/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -8,7 +8,7 @@
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
     molecule_instance_config: "{{ lookup('env',' MOLECULE_INSTANCE_CONFIG') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | from_yaml }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - name: Destroy molecule instance(s)
       molecule_vagrant:


### PR DESCRIPTION
This was meant to happen back in July, somehow I missed the cookiecutter
templates.

Fixes: #996