### PR TITLE
fix python 3 compatibility checker

### DIFF
--- a/molecule/shell.py
+++ b/molecule/shell.py
@@ -51,16 +51,18 @@ def _supported_python3_version():  # pragma: no cover
 
 
 def _supported_ansible_version():  # pragma: no cover
-    if _supported_python2_version():
+    if _supported_python2_version() or _supported_python3_version():
         if (distutils.version.LooseVersion(_get_ansible_version()) <=
                 distutils.version.LooseVersion('2.2')):
             msg = ("Ansible version '{}' not supported.  "
                    'Molecule only supports Ansible versions '
                    '>= 2.2.').format(_get_ansible_version())
             util.sysexit_with_message(msg)
-    elif _supported_python3_version():
-        msg = ("Python version '{}' not supported.  Molecule only supports "
-               'python version = 2.7.').format(platform.python_version())
+    else:
+        msg = (
+            "Python version '{}' not supported.  Molecule only supports python"
+            'version = 2.7 or 3.6.'
+        ).format(platform.python_version())
         util.sysexit_with_message(msg)
 
 


### PR DESCRIPTION
Hi folks,
Looks like there is a little bug in the Python 3 check. Every time I try to run with Python 3 it says my Python is incompatibile. It seems like it is though, and Python 3.6 is mentioned in the setup.cfg. I made a couple tiny changes that I think makes it work more as it was intended. The pseudocode:
```
if using a supported python version:
    if not using a supported ansible version:
        show the appropriate error and exit
else:
    # not using a supported python version
    show the appropriate error and exit
```