### PR TITLE
Correct env path qualification

### DIFF
--- a/molecule/provisioner/ansible.py
+++ b/molecule/provisioner/ansible.py
@@ -346,19 +346,19 @@ class Ansible(base.Base):
         filter_plugins_path = default_env['ANSIBLE_FILTER_PLUGINS']
 
         try:
-            path = self.get_abs_path(env['ANSIBLE_ROLES_PATH'])
+            path = self._absolute_path_for(env, 'ANSIBLE_ROLES_PATH')
             roles_path = '{}:{}'.format(roles_path, path)
         except KeyError:
             pass
 
         try:
-            path = self.get_abs_path(env['ANSIBLE_LIBRARY'])
+            path = self._absolute_path_for(env, 'ANSIBLE_LIBRARY')
             library_path = '{}:{}'.format(library_path, path)
         except KeyError:
             pass
 
         try:
-            path = self.get_abs_path(env['ANSIBLE_FILTER_PLUGINS'])
+            path = self._absolute_path_for(env, 'ANSIBLE_FILTER_PLUGINS')
             filter_plugins_path = '{}:{}'.format(filter_plugins_path, path)
         except KeyError:
             pass
@@ -717,3 +717,6 @@ class Ansible(base.Base):
                 del config_options[unsafe_option]
 
         return config_options
+
+    def _absolute_path_for(self, env, key):
+        return ':'.join([self.get_abs_path(p) for p in env[key].split(':')])

--- a/test/unit/provisioner/test_ansible.py
+++ b/test/unit/provisioner/test_ansible.py
@@ -886,3 +886,20 @@ def test_sanitize_config_options(mocker, ansible_instance,
     msg = "Disallowed user provided config option '{}'.  Removing.".format(
         'privilege_escalation')
     patched_logger_warn.assert_called_once_with(msg)
+
+
+def test_absolute_path_for(ansible_instance):
+    env = {'foo': 'foo:bar'}
+    x = ':'.join([
+        os.path.join(ansible_instance._config.scenario.directory, 'foo'),
+        os.path.join(ansible_instance._config.scenario.directory, 'bar'),
+    ])
+
+    x == ansible_instance._absolute_path_for(env, 'foo')
+
+
+def test_absolute_path_for_raises_with_missing_key(ansible_instance):
+    env = {'foo': 'foo:bar'}
+
+    with pytest.raises(KeyError):
+        ansible_instance._absolute_path_for(env, 'invalid')


### PR DESCRIPTION
Molecule did not split the paths provided in env and convert them to
absolute paths.  Instead it qualified the entire string, which only
qualified the first path provided.

Fixes: #1008