### PR TITLE
Bump ansible-lint version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible-lint==3.4.16
+ansible-lint==3.4.17
 anyconfig==0.9.1
 click==6.7
 click-completion==0.2.1


### PR DESCRIPTION
3.4.17 adds support for checking the new import/include_tasks syntax.