### PR TITLE
support expose_ports option in docker driver

### DIFF
--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -45,5 +45,6 @@
         privileged: "{{ item.privileged | default(omit) }}"
         volumes: "{{ item.volumes | default(omit) }}"
         capabilities: "{{ item.capabilities | default(omit) }}"
+        ports: "{{ item.exposed_ports | default(omit) }}"
       with_items: "{{ molecule_yml.platforms }}"
 {%- endraw %}

--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -43,4 +43,5 @@
         privileged: "{{ item.privileged | default(omit) }}"
         volumes: "{{ item.volumes | default(omit) }}"
         capabilities: "{{ item.capabilities | default(omit) }}"
+        ports: "{{ item.exposed_ports | default(omit) }}"
       with_items: "{{ molecule_yml.platforms }}"


### PR DESCRIPTION
While this is more or less on the end user to change their `create.yml` I think that these changes make it a little bit more ergonomic, so that those using molecule don't have to fiddle too much with files outside of the `molecule.yml`.

After reading through [this](https://github.com/metacloud/molecule/issues/953) I'm okay with changing the key name to `published_ports` if that's preferred.