### PR TITLE
Cleaned up YAML syntax

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,4 +1,7 @@
 extends: default
+ignore: |
+  *.molecule/*
+  molecule/cookiecutter/
 
 rules:
   braces:
@@ -8,4 +11,3 @@ rules:
     max-spaces-inside: 1
     level: error
   line-length: disable
-  truthy: disable

--- a/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/.yamllint
+++ b/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/.yamllint
@@ -8,4 +8,6 @@ rules:
     max-spaces-inside: 1
     level: error
   line-length: disable
-  truthy: disable
+  # NOTE(retr0h): Templates no longer fail this lint rule.
+  #               Uncomment if running old Molecule templates.
+  # truthy: disable

--- a/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -3,7 +3,7 @@
 - name: Create
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"

--- a/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -3,7 +3,7 @@
 - name: Destroy
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"

--- a/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/prepare.yml
+++ b/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/prepare.yml
@@ -2,6 +2,6 @@
 {% raw -%}
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks: []
 {%- endraw %}

--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -3,7 +3,7 @@
 - name: Create
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
@@ -29,7 +29,7 @@
         path: "{{ molecule_ephemeral_directory }}"
         name: "molecule_local/{{ item.item.image }}"
         dockerfile: "{{ item.item.dockerfile | default(item.invocation.module_args.dest) }}"
-        force: "{{ item.item.force | default(True) }}"
+        force: "{{ item.item.force | default(true) }}"
       with_items: "{{ platforms.results }}"
       when: platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
 
@@ -39,7 +39,7 @@
         hostname: "{{ item.name }}"
         image: "molecule_local/{{ item.image }}"
         state: started
-        recreate: False
+        recreate: false
         log_driver: syslog
         command: "{{ item.command | default('sleep infinity') }}"
         privileged: "{{ item.privileged | default(omit) }}"

--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -3,7 +3,7 @@
 - name: Destroy
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
@@ -13,6 +13,6 @@
       docker_container:
         name: "{{ item.name }}"
         state: absent
-        force_kill: "{{ item.force_kill | default(True) }}"
+        force_kill: "{{ item.force_kill | default(true) }}"
       with_items: "{{ molecule_yml.platforms }}"
 {%- endraw %}

--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/prepare.yml
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/prepare.yml
@@ -2,6 +2,6 @@
 {% raw -%}
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks: []
 {%- endraw %}

--- a/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -3,7 +3,7 @@
 - name: Create
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
@@ -34,8 +34,8 @@
         group: "{{ security_group_name }}"
         instance_tags:
           instance: "{{ item.name }}"
-        wait: True
-        assign_public_ip: True
+        wait: true
+        assign_public_ip: true
         exact_count: 1
         count_tag:
           instance: "{{ item.name }}"

--- a/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -3,7 +3,7 @@
 - name: Destroy
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
@@ -14,12 +14,12 @@
         - name: Populate instance config
           set_fact:
             instance_conf: "{{ lookup('file', molecule_instance_config) | molecule_from_yaml }}"
-            skip_instances: False
+            skip_instances: false
       rescue:
         - name: Populate instance config when file missing
           set_fact:
             instance_conf: {}
-            skip_instances: True
+            skip_instances: true
 
     - name: Destroy molecule instance(s)
       ec2:

--- a/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/prepare.yml
+++ b/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/prepare.yml
@@ -2,10 +2,10 @@
 {% raw -%}
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks:
     - name: Install python for Ansible
       raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal python-zipstream)
-      become: True
-      changed_when: False
+      become: true
+      changed_when: false
 {%- endraw %}

--- a/molecule/cookiecutter/scenario/driver/gce/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/gce/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -3,7 +3,7 @@
 - name: Create
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"

--- a/molecule/cookiecutter/scenario/driver/gce/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/gce/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -3,7 +3,7 @@
 - name: Destroy
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"

--- a/molecule/cookiecutter/scenario/driver/gce/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/prepare.yml
+++ b/molecule/cookiecutter/scenario/driver/gce/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/prepare.yml
@@ -2,10 +2,10 @@
 {% raw -%}
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks:
     - name: Install python for Ansible
       raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal python-zipstream)
-      become: True
-      changed_when: False
+      become: true
+      changed_when: false
 {%- endraw %}

--- a/molecule/cookiecutter/scenario/driver/lxc/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/lxc/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -3,7 +3,7 @@
 - name: Create
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
@@ -12,7 +12,7 @@
     - name: Create molecule instance(s)
       lxc_container:
         name: "{{ item.name }}"
-        container_log: True
+        container_log: true
         template: ubuntu
         state: started
         template_options: --release xenial

--- a/molecule/cookiecutter/scenario/driver/lxc/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/lxc/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -3,7 +3,7 @@
 - name: Destroy
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"

--- a/molecule/cookiecutter/scenario/driver/lxc/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/prepare.yml
+++ b/molecule/cookiecutter/scenario/driver/lxc/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/prepare.yml
@@ -2,6 +2,6 @@
 {% raw -%}
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks: []
 {%- endraw %}

--- a/molecule/cookiecutter/scenario/driver/lxd/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/lxd/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -3,7 +3,7 @@
 - name: Create
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
@@ -20,7 +20,7 @@
           protocol: lxd
           alias: ubuntu/xenial/amd64
         profiles: ["default"]
-        wait_for_ipv4_addresses: True
+        wait_for_ipv4_addresses: true
         timeout: 600
       with_items: "{{ molecule_yml.platforms }}"
 {%- endraw %}

--- a/molecule/cookiecutter/scenario/driver/lxd/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/lxd/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -3,7 +3,7 @@
 - name: Destroy
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
@@ -13,6 +13,6 @@
       lxd_container:
         name: "{{ item.name }}"
         state: absent
-        force_stop: "{{ item.force_stop | default(True) }}"
+        force_stop: "{{ item.force_stop | default(true) }}"
       with_items: "{{ molecule_yml.platforms }}"
 {%- endraw %}

--- a/molecule/cookiecutter/scenario/driver/lxd/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/prepare.yml
+++ b/molecule/cookiecutter/scenario/driver/lxd/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/prepare.yml
@@ -2,10 +2,10 @@
 {% raw -%}
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks:
     - name: Install python for Ansible
       raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)
-      become: True
-      changed_when: False
+      become: true
+      changed_when: false
 {%- endraw %}

--- a/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -3,7 +3,7 @@
 - name: Create
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"

--- a/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -3,7 +3,7 @@
 - name: Destroy
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"

--- a/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/prepare.yml
+++ b/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/prepare.yml
@@ -2,10 +2,10 @@
 {% raw -%}
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks:
     - name: Install python for Ansible
       raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal python-zipstream)
-      become: True
-      changed_when: False
+      become: true
+      changed_when: false
 {%- endraw %}

--- a/molecule/cookiecutter/scenario/driver/vagrant/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/vagrant/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -3,7 +3,7 @@
 - name: Create
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"

--- a/molecule/cookiecutter/scenario/driver/vagrant/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/vagrant/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -3,7 +3,7 @@
 - name: Destroy
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
@@ -15,7 +15,7 @@
         instance_name: "{{ item.name }}"
         platform_box: "{{ item.box }}"
         provider_name: "{{ molecule_yml.driver.provider.name }}"
-        force_stop: "{{ item.force_stop | default(True) }}"
+        force_stop: "{{ item.force_stop | default(true) }}"
 
         state: destroy
       register: server

--- a/molecule/cookiecutter/scenario/driver/vagrant/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/prepare.yml
+++ b/molecule/cookiecutter/scenario/driver/vagrant/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/prepare.yml
@@ -2,10 +2,10 @@
 {% raw -%}
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks:
     - name: Install python for Ansible
       raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)
-      become: True
-      changed_when: False
+      become: true
+      changed_when: false
 {%- endraw %}

--- a/molecule/cookiecutter/scenario/verifier/goss/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verifier.yml
+++ b/molecule/cookiecutter/scenario/verifier/goss/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verifier.yml
@@ -43,7 +43,7 @@
       command: "goss -g {{ item }} validate --format {{ goss_format }}"
       register: test_results
       with_items: "{{ test_files.stdout_lines }}"
-      ignore_errors: True
+      ignore_errors: true
 
     - name: Display details about the goss results
       debug:

--- a/molecule/cookiecutter/scenario/verifier/goss/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/{{cookiecutter.verifier_directory}}/test_default.yml
+++ b/molecule/cookiecutter/scenario/verifier/goss/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/{{cookiecutter.verifier_directory}}/test_default.yml
@@ -3,6 +3,6 @@
 ---
 file:
   /etc/hosts:
-    exists: True
+    exists: true
     owner: root
     group: root

--- a/test/resources/molecule_v1_vagrant.yml
+++ b/test/resources/molecule_v1_vagrant.yml
@@ -5,8 +5,8 @@ ansible:
   raw_env_vars:
     foo: bar
   extra_vars: foo=bar
-  verbose: True
-  become: True
+  verbose: true
+  become: true
   tags: foo,bar
 driver:
   name: vagrant

--- a/test/resources/playbooks/delegated/create.yml
+++ b/test/resources/playbooks/delegated/create.yml
@@ -2,7 +2,7 @@
 - name: Create
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   tasks:
     - include: create/docker.yml
     - include: create/ec2.yml

--- a/test/resources/playbooks/delegated/create/docker.yml
+++ b/test/resources/playbooks/delegated/create/docker.yml
@@ -4,6 +4,6 @@
     name: delegated-instance-docker
     hostname: delegated-instance-docker
     image: molecule_local/centos:latest
-    recreate: False
+    recreate: false
     log_driver: syslog
     command: sleep infinity

--- a/test/resources/playbooks/delegated/create/ec2.yml
+++ b/test/resources/playbooks/delegated/create/ec2.yml
@@ -31,8 +31,8 @@
     group: molecule
     instance_tags:
       name: "{{ ec2.name }}"
-    wait: True
-    assign_public_ip: True
+    wait: true
+    assign_public_ip: true
     exact_count: 1
     count_tag:
       name: "{{ ec2.name }}"

--- a/test/resources/playbooks/delegated/destroy.yml
+++ b/test/resources/playbooks/delegated/destroy.yml
@@ -2,7 +2,7 @@
 - name: Destroy
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   tasks:
     - include: destroy/docker.yml
     - include: destroy/ec2.yml

--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -2,7 +2,7 @@
 - name: Create
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
@@ -27,7 +27,7 @@
         path: "{{ molecule_ephemeral_directory }}"
         name: "molecule_local/{{ item.item.image }}"
         dockerfile: "{{ item.item.dockerfile | default(item.invocation.module_args.dest) }}"
-        force: "{{ item.item.force | default(True) }}"
+        force: "{{ item.item.force | default(true) }}"
       with_items: "{{ platforms.results }}"
       when: platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
 
@@ -37,7 +37,7 @@
         hostname: "{{ item.name }}"
         image: "molecule_local/{{ item.image }}"
         state: started
-        recreate: False
+        recreate: false
         log_driver: syslog
         command: "{{ item.command | default('sleep infinity') }}"
         privileged: "{{ item.privileged | default(omit) }}"

--- a/test/resources/playbooks/docker/destroy.yml
+++ b/test/resources/playbooks/docker/destroy.yml
@@ -2,7 +2,7 @@
 - name: Destroy
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
@@ -12,5 +12,5 @@
       docker_container:
         name: "{{ item.name }}"
         state: absent
-        force_kill: "{{ item.force_kill | default(True) }}"
+        force_kill: "{{ item.force_kill | default(true) }}"
       with_items: "{{ molecule_yml.platforms }}"

--- a/test/resources/playbooks/ec2/create.yml
+++ b/test/resources/playbooks/ec2/create.yml
@@ -2,7 +2,7 @@
 - name: Create
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
@@ -35,8 +35,8 @@
         group: "{{ security_group_name }}"
         instance_tags:
           instance: "{{ item.name }}"
-        wait: True
-        assign_public_ip: True
+        wait: true
+        assign_public_ip: true
         exact_count: 1
         count_tag:
           instance: "{{ item.name }}"

--- a/test/resources/playbooks/ec2/destroy.yml
+++ b/test/resources/playbooks/ec2/destroy.yml
@@ -2,7 +2,7 @@
 - name: Destroy
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
@@ -13,12 +13,12 @@
         - name: Populate instance config
           set_fact:
             instance_conf: "{{ lookup('file', molecule_instance_config) | molecule_from_yaml }}"
-            skip_instances: False
+            skip_instances: false
       rescue:
         - name: Populate instance config when file missing
           set_fact:
             instance_conf: {}
-            skip_instances: True
+            skip_instances: true
 
     - name: Destroy molecule instance(s)
       ec2:

--- a/test/resources/playbooks/gce/create.yml
+++ b/test/resources/playbooks/gce/create.yml
@@ -2,7 +2,7 @@
 - name: Create
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"

--- a/test/resources/playbooks/gce/destroy.yml
+++ b/test/resources/playbooks/gce/destroy.yml
@@ -2,7 +2,7 @@
 - name: Destroy
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"

--- a/test/resources/playbooks/lxc/create.yml
+++ b/test/resources/playbooks/lxc/create.yml
@@ -2,7 +2,7 @@
 - name: Create
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
@@ -11,7 +11,7 @@
     - name: Create molecule instance(s)
       lxc_container:
         name: "{{ item.name }}"
-        container_log: True
+        container_log: true
         template: ubuntu
         state: started
         template_options: --release xenial

--- a/test/resources/playbooks/lxc/destroy.yml
+++ b/test/resources/playbooks/lxc/destroy.yml
@@ -2,7 +2,7 @@
 - name: Destroy
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"

--- a/test/resources/playbooks/lxd/create.yml
+++ b/test/resources/playbooks/lxd/create.yml
@@ -2,7 +2,7 @@
 - name: Create
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
@@ -19,6 +19,6 @@
           protocol: lxd
           alias: ubuntu/xenial/amd64
         profiles: ["default"]
-        wait_for_ipv4_addresses: True
+        wait_for_ipv4_addresses: true
         timeout: 600
       with_items: "{{ molecule_yml.platforms }}"

--- a/test/resources/playbooks/lxd/destroy.yml
+++ b/test/resources/playbooks/lxd/destroy.yml
@@ -2,7 +2,7 @@
 - name: Destroy
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
@@ -12,5 +12,5 @@
       lxd_container:
         name: "{{ item.name }}"
         state: absent
-        force_stop: "{{ item.force_stop | default(True) }}"
+        force_stop: "{{ item.force_stop | default(true) }}"
       with_items: "{{ molecule_yml.platforms }}"

--- a/test/resources/playbooks/openstack/create.yml
+++ b/test/resources/playbooks/openstack/create.yml
@@ -2,7 +2,7 @@
 - name: Create
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
@@ -22,14 +22,14 @@
     neutron:
       networks:
         - name: molecule
-          external: False
-          shared: False
+          external: false
+          shared: false
       subnets:
         - name: molecule
           network_name: molecule
           ip_version: 4
           cidr: 192.168.1.0/24
-          enable_dhcp: True
+          enable_dhcp: true
           dns_nameservers:
             - 8.8.8.8
             - 8.8.4.4

--- a/test/resources/playbooks/openstack/destroy.yml
+++ b/test/resources/playbooks/openstack/destroy.yml
@@ -2,7 +2,7 @@
 - name: Destroy
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"

--- a/test/resources/playbooks/openstack/neutron.yml
+++ b/test/resources/playbooks/openstack/neutron.yml
@@ -9,7 +9,7 @@
     provider_physical_network: "{{ item.provider_physical_network | default(omit) }}"
     validate_certs: "{{ validate_certs | default(omit) }}"
   with_items: "{{ neutron.networks }}"
-  run_once: True
+  run_once: true
 
 - name: Gather facts about network for use with instance creation
   os_networks_facts:
@@ -30,7 +30,7 @@
     allocation_pool_end: "{{ item.pool_end | default(omit) }}"
     validate_certs: "{{ validate_certs | default(omit) }}"
   with_items: "{{ neutron.subnets }}"
-  run_once: True
+  run_once: true
 
 - name: Create routers
   os_router:
@@ -39,4 +39,4 @@
     interfaces: "{{ item.interfaces }}"
     external_fixed_ips: "{{ item.external_fixed_ips | default(omit) }}"
   with_items: "{{ neutron.routers }}"
-  run_once: True
+  run_once: true

--- a/test/resources/playbooks/vagrant/create.yml
+++ b/test/resources/playbooks/vagrant/create.yml
@@ -2,7 +2,7 @@
 - name: Create
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"

--- a/test/resources/playbooks/vagrant/destroy.yml
+++ b/test/resources/playbooks/vagrant/destroy.yml
@@ -2,7 +2,7 @@
 - name: Destroy
   hosts: localhost
   connection: local
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
@@ -14,7 +14,7 @@
         instance_name: "{{ item.name }}"
         platform_box: "{{ item.box }}"
         provider_name: "{{ molecule_yml.driver.provider.name }}"
-        force_stop: "{{ item.force_stop | default(True) }}"
+        force_stop: "{{ item.force_stop | default(true) }}"
 
         state: destroy
       register: server

--- a/test/scenarios/dependency/molecule/ansible-galaxy/prepare.yml
+++ b/test/scenarios/dependency/molecule/ansible-galaxy/prepare.yml
@@ -1,5 +1,5 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks: []

--- a/test/scenarios/dependency/molecule/gilt/prepare.yml
+++ b/test/scenarios/dependency/molecule/gilt/prepare.yml
@@ -1,5 +1,5 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks: []

--- a/test/scenarios/driver/delegated/molecule/docker/molecule.yml
+++ b/test/scenarios/driver/delegated/molecule/docker/molecule.yml
@@ -4,7 +4,7 @@ dependency:
 driver:
   name: delegated
   options:
-    managed: False
+    managed: false
     login_cmd_template: 'docker exec -ti {instance} bash'
     ansible_connection_options:
       ansible_connection: docker

--- a/test/scenarios/driver/delegated/molecule/docker/prepare.yml
+++ b/test/scenarios/driver/delegated/molecule/docker/prepare.yml
@@ -1,5 +1,5 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks: []

--- a/test/scenarios/driver/delegated/molecule/ec2/molecule.yml
+++ b/test/scenarios/driver/delegated/molecule/ec2/molecule.yml
@@ -4,7 +4,7 @@ dependency:
 driver:
   name: delegated
   options:
-    managed: False
+    managed: false
     login_cmd_template: 'ssh {instance} -F /tmp/ssh-config-ec2'
     ansible_connection_options:
       connection: ssh

--- a/test/scenarios/driver/delegated/molecule/ec2/playbook.yml
+++ b/test/scenarios/driver/delegated/molecule/ec2/playbook.yml
@@ -1,6 +1,6 @@
 ---
 - name: Converge
   hosts: all
-  become: True
+  become: true
   roles:
     - molecule

--- a/test/scenarios/driver/delegated/molecule/ec2/prepare.yml
+++ b/test/scenarios/driver/delegated/molecule/ec2/prepare.yml
@@ -1,9 +1,9 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks:
     - name: Install python for Ansible
       raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal python-zipstream)
-      become: True
-      changed_when: False
+      become: true
+      changed_when: false

--- a/test/scenarios/driver/delegated/molecule/gce/molecule.yml
+++ b/test/scenarios/driver/delegated/molecule/gce/molecule.yml
@@ -4,7 +4,7 @@ dependency:
 driver:
   name: delegated
   options:
-    managed: False
+    managed: false
     login_cmd_template: 'ssh {instance} -F /tmp/ssh-config-gce'
     ansible_connection_options:
       connection: ssh

--- a/test/scenarios/driver/delegated/molecule/gce/playbook.yml
+++ b/test/scenarios/driver/delegated/molecule/gce/playbook.yml
@@ -1,6 +1,6 @@
 ---
 - name: Converge
   hosts: all
-  become: True
+  become: true
   roles:
     - molecule

--- a/test/scenarios/driver/delegated/molecule/gce/prepare.yml
+++ b/test/scenarios/driver/delegated/molecule/gce/prepare.yml
@@ -1,5 +1,5 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks: []

--- a/test/scenarios/driver/delegated/molecule/openstack/molecule.yml
+++ b/test/scenarios/driver/delegated/molecule/openstack/molecule.yml
@@ -4,7 +4,7 @@ dependency:
 driver:
   name: delegated
   options:
-    managed: False
+    managed: false
     login_cmd_template: 'ssh {instance} -F /tmp/ssh-config-openstack'
     ansible_connection_options:
       connection: ssh

--- a/test/scenarios/driver/delegated/molecule/openstack/playbook.yml
+++ b/test/scenarios/driver/delegated/molecule/openstack/playbook.yml
@@ -1,6 +1,6 @@
 ---
 - name: Converge
   hosts: all
-  become: True
+  become: true
   roles:
     - molecule

--- a/test/scenarios/driver/delegated/molecule/openstack/prepare.yml
+++ b/test/scenarios/driver/delegated/molecule/openstack/prepare.yml
@@ -1,9 +1,9 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks:
     - name: Install python for Ansible
       raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal python-zipstream)
-      become: True
-      changed_when: False
+      become: true
+      changed_when: false

--- a/test/scenarios/driver/delegated/molecule/vagrant/molecule.yml
+++ b/test/scenarios/driver/delegated/molecule/vagrant/molecule.yml
@@ -4,7 +4,7 @@ dependency:
 driver:
   name: delegated
   options:
-    managed: False
+    managed: false
     login_cmd_template: 'ssh {instance} -F /tmp/ssh-config-vagrant'
     ansible_connection_options:
       connection: ssh

--- a/test/scenarios/driver/delegated/molecule/vagrant/playbook.yml
+++ b/test/scenarios/driver/delegated/molecule/vagrant/playbook.yml
@@ -1,6 +1,6 @@
 ---
 - name: Converge
   hosts: all
-  become: True
+  become: true
   roles:
     - molecule

--- a/test/scenarios/driver/delegated/molecule/vagrant/prepare.yml
+++ b/test/scenarios/driver/delegated/molecule/vagrant/prepare.yml
@@ -1,5 +1,5 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks: []

--- a/test/scenarios/driver/docker/molecule/default/playbook.yml
+++ b/test/scenarios/driver/docker/molecule/default/playbook.yml
@@ -1,6 +1,6 @@
 ---
 - name: Converge
   hosts: all
-  become: True
+  become: true
   roles:
     - molecule

--- a/test/scenarios/driver/docker/molecule/default/prepare.yml
+++ b/test/scenarios/driver/docker/molecule/default/prepare.yml
@@ -1,5 +1,5 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks: []

--- a/test/scenarios/driver/docker/molecule/multi-node/playbook.yml
+++ b/test/scenarios/driver/docker/molecule/multi-node/playbook.yml
@@ -1,24 +1,24 @@
 ---
 - name: Converge
   hosts: all
-  become: True
+  become: true
   roles:
     - molecule
 
 - name: Converge
   hosts: bar
-  become: True
+  become: true
   roles:
     - molecule
 
 - name: Converge
   hosts: foo
-  become: True
+  become: true
   roles:
     - molecule
 
 - name: Converge
   hosts: baz
-  become: True
+  become: true
   roles:
     - molecule

--- a/test/scenarios/driver/docker/molecule/multi-node/prepare.yml
+++ b/test/scenarios/driver/docker/molecule/multi-node/prepare.yml
@@ -1,5 +1,5 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks: []

--- a/test/scenarios/driver/ec2/molecule/default/playbook.yml
+++ b/test/scenarios/driver/ec2/molecule/default/playbook.yml
@@ -1,6 +1,6 @@
 ---
 - name: Converge
   hosts: all
-  become: True
+  become: true
   roles:
     - molecule

--- a/test/scenarios/driver/ec2/molecule/default/prepare.yml
+++ b/test/scenarios/driver/ec2/molecule/default/prepare.yml
@@ -1,9 +1,9 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks:
     - name: Install python for Ansible
       raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal python-zipstream)
-      become: True
-      changed_when: False
+      become: true
+      changed_when: false

--- a/test/scenarios/driver/ec2/molecule/multi-node/playbook.yml
+++ b/test/scenarios/driver/ec2/molecule/multi-node/playbook.yml
@@ -1,24 +1,24 @@
 ---
 - name: Converge
   hosts: all
-  become: True
+  become: true
   roles:
     - molecule
 
 - name: Converge
   hosts: bar
-  become: True
+  become: true
   roles:
     - molecule
 
 - name: Converge
   hosts: foo
-  become: True
+  become: true
   roles:
     - molecule
 
 - name: Converge
   hosts: baz
-  become: True
+  become: true
   roles:
     - molecule

--- a/test/scenarios/driver/ec2/molecule/multi-node/prepare.yml
+++ b/test/scenarios/driver/ec2/molecule/multi-node/prepare.yml
@@ -1,9 +1,9 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks:
     - name: Install python for Ansible
       raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal python-zipstream)
-      become: True
-      changed_when: False
+      become: true
+      changed_when: false

--- a/test/scenarios/driver/gce/molecule/default/playbook.yml
+++ b/test/scenarios/driver/gce/molecule/default/playbook.yml
@@ -1,6 +1,6 @@
 ---
 - name: Converge
   hosts: all
-  become: True
+  become: true
   roles:
     - molecule

--- a/test/scenarios/driver/gce/molecule/default/prepare.yml
+++ b/test/scenarios/driver/gce/molecule/default/prepare.yml
@@ -1,9 +1,9 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks:
     - name: Install python for Ansible
       raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal python-zipstream)
-      become: True
-      changed_when: False
+      become: true
+      changed_when: false

--- a/test/scenarios/driver/gce/molecule/multi-node/playbook.yml
+++ b/test/scenarios/driver/gce/molecule/multi-node/playbook.yml
@@ -1,24 +1,24 @@
 ---
 - name: Converge
   hosts: all
-  become: True
+  become: true
   roles:
     - molecule
 
 - name: Converge
   hosts: bar
-  become: True
+  become: true
   roles:
     - molecule
 
 - name: Converge
   hosts: foo
-  become: True
+  become: true
   roles:
     - molecule
 
 - name: Converge
   hosts: baz
-  become: True
+  become: true
   roles:
     - molecule

--- a/test/scenarios/driver/gce/molecule/multi-node/prepare.yml
+++ b/test/scenarios/driver/gce/molecule/multi-node/prepare.yml
@@ -1,9 +1,9 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks:
     - name: Install python for Ansible
       raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal python-zipstream)
-      become: True
-      changed_when: False
+      become: true
+      changed_when: false

--- a/test/scenarios/driver/lxc/molecule/default/prepare.yml
+++ b/test/scenarios/driver/lxc/molecule/default/prepare.yml
@@ -1,5 +1,5 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks: []

--- a/test/scenarios/driver/lxc/molecule/multi-node/prepare.yml
+++ b/test/scenarios/driver/lxc/molecule/multi-node/prepare.yml
@@ -1,5 +1,5 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks: []

--- a/test/scenarios/driver/lxd/molecule/default/prepare.yml
+++ b/test/scenarios/driver/lxd/molecule/default/prepare.yml
@@ -1,9 +1,9 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks:
     - name: Install python for Ansible
       raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)
-      become: True
-      changed_when: False
+      become: true
+      changed_when: false

--- a/test/scenarios/driver/lxd/molecule/multi-node/prepare.yml
+++ b/test/scenarios/driver/lxd/molecule/multi-node/prepare.yml
@@ -1,9 +1,9 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks:
     - name: Install python for Ansible
       raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)
-      become: True
-      changed_when: False
+      become: true
+      changed_when: false

--- a/test/scenarios/driver/openstack/molecule/default/playbook.yml
+++ b/test/scenarios/driver/openstack/molecule/default/playbook.yml
@@ -1,6 +1,6 @@
 ---
 - name: Converge
   hosts: all
-  become: True
+  become: true
   roles:
     - molecule

--- a/test/scenarios/driver/openstack/molecule/default/prepare.yml
+++ b/test/scenarios/driver/openstack/molecule/default/prepare.yml
@@ -1,9 +1,9 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks:
     - name: Install python for Ansible
       raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal python-zipstream)
-      become: True
-      changed_when: False
+      become: true
+      changed_when: false

--- a/test/scenarios/driver/openstack/molecule/multi-node/playbook.yml
+++ b/test/scenarios/driver/openstack/molecule/multi-node/playbook.yml
@@ -1,24 +1,24 @@
 ---
 - name: Converge
   hosts: all
-  become: True
+  become: true
   roles:
     - molecule
 
 - name: Converge
   hosts: bar
-  become: True
+  become: true
   roles:
     - molecule
 
 - name: Converge
   hosts: foo
-  become: True
+  become: true
   roles:
     - molecule
 
 - name: Converge
   hosts: baz
-  become: True
+  become: true
   roles:
     - molecule

--- a/test/scenarios/driver/openstack/molecule/multi-node/prepare.yml
+++ b/test/scenarios/driver/openstack/molecule/multi-node/prepare.yml
@@ -1,9 +1,9 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks:
     - name: Install python for Ansible
       raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal python-zipstream)
-      become: True
-      changed_when: False
+      become: true
+      changed_when: false

--- a/test/scenarios/driver/vagrant/molecule/default/molecule.yml
+++ b/test/scenarios/driver/vagrant/molecule/default/molecule.yml
@@ -13,7 +13,7 @@ platforms:
   - name: instance
     box: debian/jessie64
     interfaces:
-      - auto_config: True
+      - auto_config: true
         network_name: private_network
         type: dhcp
 provisioner:

--- a/test/scenarios/driver/vagrant/molecule/default/playbook.yml
+++ b/test/scenarios/driver/vagrant/molecule/default/playbook.yml
@@ -1,6 +1,6 @@
 ---
 - name: Converge
   hosts: all
-  become: True
+  become: true
   roles:
     - molecule

--- a/test/scenarios/driver/vagrant/molecule/default/prepare.yml
+++ b/test/scenarios/driver/vagrant/molecule/default/prepare.yml
@@ -1,5 +1,5 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks: []

--- a/test/scenarios/driver/vagrant/molecule/multi-node/molecule.yml
+++ b/test/scenarios/driver/vagrant/molecule/multi-node/molecule.yml
@@ -13,7 +13,7 @@ platforms:
   - name: instance-1
     box: debian/jessie64
     interfaces:
-      - auto_config: True
+      - auto_config: true
         network_name: private_network
         type: dhcp
     groups:
@@ -22,7 +22,7 @@ platforms:
   - name: instance-2
     box: debian/jessie64
     interfaces:
-      - auto_config: True
+      - auto_config: true
         network_name: private_network
         type: dhcp
     groups:

--- a/test/scenarios/driver/vagrant/molecule/multi-node/playbook.yml
+++ b/test/scenarios/driver/vagrant/molecule/multi-node/playbook.yml
@@ -1,24 +1,24 @@
 ---
 - name: Converge
   hosts: all
-  become: True
+  become: true
   roles:
     - molecule
 
 - name: Converge
   hosts: bar
-  become: True
+  become: true
   roles:
     - molecule
 
 - name: Converge
   hosts: foo
-  become: True
+  become: true
   roles:
     - molecule
 
 - name: Converge
   hosts: baz
-  become: True
+  become: true
   roles:
     - molecule

--- a/test/scenarios/driver/vagrant/molecule/multi-node/prepare.yml
+++ b/test/scenarios/driver/vagrant/molecule/multi-node/prepare.yml
@@ -1,5 +1,5 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks: []

--- a/test/scenarios/host_group_vars/molecule/default/group_vars/example/all.yml
+++ b/test/scenarios/host_group_vars/molecule/default/group_vars/example/all.yml
@@ -1,2 +1,2 @@
 ---
-host_group_vars_group_vars_dir: True
+host_group_vars_group_vars_dir: true

--- a/test/scenarios/host_group_vars/molecule/default/host_vars/instance/all.yml
+++ b/test/scenarios/host_group_vars/molecule/default/host_vars/instance/all.yml
@@ -1,2 +1,2 @@
 ---
-host_group_vars_host_vars_dir: True
+host_group_vars_host_vars_dir: true

--- a/test/scenarios/host_group_vars/molecule/default/molecule.yml
+++ b/test/scenarios/host_group_vars/molecule/default/molecule.yml
@@ -22,13 +22,13 @@ provisioner:
   inventory:
     host_vars:
       instance:
-        host_group_vars_host_molecule_yml: True
+        host_group_vars_host_molecule_yml: true
     group_vars:
       example:
-        host_group_vars_example_group_one_molecule_yml: True
-        host_group_vars_example_group_two_molecule_yml: True
+        host_group_vars_example_group_one_molecule_yml: true
+        host_group_vars_example_group_two_molecule_yml: true
       example_1:
-        host_group_vars_example_1_child_group_molecule_yml: True
+        host_group_vars_example_1_child_group_molecule_yml: true
   lint:
     name: ansible-lint
 scenario:

--- a/test/scenarios/host_group_vars/molecule/default/playbook.yml
+++ b/test/scenarios/host_group_vars/molecule/default/playbook.yml
@@ -3,32 +3,32 @@
   tasks:
     - name: Host vars host_var for host host-group-vars from molecule.yml
       command: echo "{{ host_group_vars_host_molecule_yml }}"
-      changed_when: False
+      changed_when: false
 
     - name: Host vars from host_vars existing directory
       command: echo "{{ host_group_vars_host_vars_dir }}"
-      changed_when: False
+      changed_when: false
 
     - name: Group vars group_var for group example from molecule.yml
       command: echo "{{ host_group_vars_example_group_one_molecule_yml }} {{ host_group_vars_example_group_two_molecule_yml }}"
-      changed_when: False
+      changed_when: false
 
     - name: Group vars from group_vars existing directory
       command: echo "{{ host_group_vars_group_vars_dir }}"
-      changed_when: False
+      changed_when: false
 
     - name: Group vars group_var from child group example_1 from molecule.yml
       command: echo "{{ host_group_vars_example_1_child_group_molecule_yml }}"
-      changed_when: False
+      changed_when: false
 
 - hosts: example
   tasks:
     - name: Dummy converge of example group
       command: /bin/true
-      changed_when: False
+      changed_when: false
 
 - hosts: example_1
   tasks:
     - name: Dummy converge of child example_1 group
       command: /bin/true
-      changed_when: False
+      changed_when: false

--- a/test/scenarios/host_group_vars/molecule/default/prepare.yml
+++ b/test/scenarios/host_group_vars/molecule/default/prepare.yml
@@ -1,5 +1,5 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks: []

--- a/test/scenarios/idempotence/molecule/raises/playbook.yml
+++ b/test/scenarios/idempotence/molecule/raises/playbook.yml
@@ -1,6 +1,6 @@
 ---
 - name: Converge
   hosts: all
-  become: True
+  become: true
   roles:
     - idempotence

--- a/test/scenarios/idempotence/molecule/raises/prepare.yml
+++ b/test/scenarios/idempotence/molecule/raises/prepare.yml
@@ -1,5 +1,5 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks: []

--- a/test/scenarios/interpolation/molecule/default/playbook.yml
+++ b/test/scenarios/interpolation/molecule/default/playbook.yml
@@ -4,4 +4,4 @@
   tasks:
     - name: Dummy task
       command: /bin/true
-      changed_when: False
+      changed_when: false

--- a/test/scenarios/interpolation/molecule/default/prepare.yml
+++ b/test/scenarios/interpolation/molecule/default/prepare.yml
@@ -1,5 +1,5 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks: []

--- a/test/scenarios/overrride_driver/molecule/default/playbook.yml
+++ b/test/scenarios/overrride_driver/molecule/default/playbook.yml
@@ -4,4 +4,4 @@
   tasks:
     - name: Dummy task
       command: /bin/true
-      changed_when: False
+      changed_when: false

--- a/test/scenarios/overrride_driver/molecule/default/prepare.yml
+++ b/test/scenarios/overrride_driver/molecule/default/prepare.yml
@@ -1,5 +1,5 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks: []

--- a/test/scenarios/plugins/molecule/default/playbook.yml
+++ b/test/scenarios/plugins/molecule/default/playbook.yml
@@ -1,7 +1,7 @@
 ---
 - name: Converge
   hosts: all
-  become: True
+  become: true
   roles:
     # Role from project root
     - plugins

--- a/test/scenarios/plugins/molecule/default/prepare.yml
+++ b/test/scenarios/plugins/molecule/default/prepare.yml
@@ -1,5 +1,5 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks: []

--- a/test/scenarios/plugins/tasks/main.yml
+++ b/test/scenarios/plugins/tasks/main.yml
@@ -2,12 +2,12 @@
 - name: Ensure project filter env is set properly by Molecule
   debug:
     var: foo | project_filter
-  changed_when: False
+  changed_when: false
 
 - name: Ensure dependency filter env is set properly by Molecule
   debug:
     var: foo | dependency_filter
-  changed_when: False
+  changed_when: false
 
 - name: Ensure project library env is set properly by Molecule
   project_library:

--- a/test/scenarios/side_effect/molecule/default/molecule.yml
+++ b/test/scenarios/side_effect/molecule/default/molecule.yml
@@ -11,7 +11,7 @@ platforms:
   - name: instance
     image: centos:latest
     command: /sbin/init
-    privileged: True
+    privileged: true
 provisioner:
   name: ansible
   playbooks:

--- a/test/scenarios/side_effect/molecule/default/prepare.yml
+++ b/test/scenarios/side_effect/molecule/default/prepare.yml
@@ -1,5 +1,5 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks: []

--- a/test/scenarios/side_effect/molecule/default/side_effect.yml
+++ b/test/scenarios/side_effect/molecule/default/side_effect.yml
@@ -1,7 +1,7 @@
 ---
 - name: Side Effect
   hosts: all
-  gather_facts: False
+  gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   tasks:
     - name: Kill ntpd on target

--- a/test/scenarios/test_destroy_strategy/molecule/default/playbook.yml
+++ b/test/scenarios/test_destroy_strategy/molecule/default/playbook.yml
@@ -1,7 +1,7 @@
 ---
 - name: Converge
   hosts: all
-  become: True
+  become: true
   tasks:
     - name: Force a converge failure
       command: /bin/false

--- a/test/scenarios/test_destroy_strategy/molecule/default/prepare.yml
+++ b/test/scenarios/test_destroy_strategy/molecule/default/prepare.yml
@@ -1,5 +1,5 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks: []

--- a/test/scenarios/verifier/molecule/goss/prepare.yml
+++ b/test/scenarios/verifier/molecule/goss/prepare.yml
@@ -1,5 +1,5 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks: []

--- a/test/scenarios/verifier/molecule/goss/tests/test_default.yml
+++ b/test/scenarios/verifier/molecule/goss/tests/test_default.yml
@@ -3,13 +3,13 @@
 ---
 file:
   /etc/molecule:
-    exists: True
+    exists: true
     owner: root
     group: root
     mode: "0755"
     filetype: directory
   /etc/molecule/instance:
-    exists: True
+    exists: true
     owner: root
     group: root
     mode: "0644"

--- a/test/scenarios/verifier/molecule/goss/verifier.yml
+++ b/test/scenarios/verifier/molecule/goss/verifier.yml
@@ -31,7 +31,7 @@
       command: "goss -g {{ item }} validate --format {{ goss_format }}"
       register: test_results
       with_items: "{{ test_files.stdout_lines }}"
-      ignore_errors: True
+      ignore_errors: true
 
     - name: Display details about the goss results
       debug:

--- a/test/scenarios/verifier/molecule/testinfra/prepare.yml
+++ b/test/scenarios/verifier/molecule/testinfra/prepare.yml
@@ -1,5 +1,5 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  gather_facts: false
   tasks: []

--- a/tox.ini
+++ b/tox.ini
@@ -20,13 +20,11 @@ deps =
     ansible22: ansible==2.2.3.0
     ansible23: ansible==2.3.2.0
     ansible24: ansible==2.4.0.0
-whitelist_externals =
-    bash
 commands =
     unit: py.test -vv --cov-report=term-missing --cov={toxinidir}/molecule/ --no-cov-on-fail {posargs}
     functional: py.test -vv -x test/functional/ {posargs}
     lint: flake8
-    lint: bash -c "yamllint $(find test/ molecule/ -name '*.yml' -not -path '*.molecule/*' | xargs grep -rlL %)"
+    lint: yamllint test/ molecule/
 
 [testenv:format]
 commands =


### PR DESCRIPTION
* No longer ignoring truthy rule.
* Skipping cookiecutter jinja templates via .yamllint
  config file vs tox bash find.