### PR TITLE
Docs: usage of dependency role-file instead of requirements_file

### DIFF
--- a/molecule/dependency/ansible_galaxy.py
+++ b/molecule/dependency/ansible_galaxy.py
@@ -43,6 +43,7 @@ class AnsibleGalaxy(base.Base):
           options:
             ignore-certs: True
             ignore-errors: True
+            role-file: requirements.yml
 
 
     The dependency manager can be disabled by setting `enabled` to False.


### PR DESCRIPTION
For avoid exploring molecule sources.