### PR TITLE
Added dependency to check and converge scenario

### DIFF
--- a/molecule/command/check.py
+++ b/molecule/command/check.py
@@ -62,7 +62,8 @@ class Check(base.Base):
     help='Name of the scenario to target. (default)')
 def check(ctx, scenario_name):  # pragma: no cover
     """
-    Use the provisioner to perform a Dry-Run (create, converge, create).
+    Use the provisioner to perform a Dry-Run (destroy, dependency, create,
+    prepare, converge).
     """
     args = ctx.obj.get('args')
     subcommand = base._get_subcommand(__name__)

--- a/molecule/command/converge.py
+++ b/molecule/command/converge.py
@@ -70,7 +70,11 @@ class Converge(base.Base):
     help='Name of the scenario to target. (default)')
 @click.argument('ansible_args', nargs=-1, type=click.UNPROCESSED)
 def converge(ctx, scenario_name, ansible_args):  # pragma: no cover
-    """ Use the provisioner to configure instances (create, converge). """
+    """
+    Use the provisioner to configure instances (dependency, create, prepare
+    converge).
+    """
+
     args = ctx.obj.get('args')
     subcommand = base._get_subcommand(__name__)
     command_args = {

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -315,6 +315,7 @@ class Config(object):
                 'default',
                 'check_sequence': [
                     'destroy',
+                    'dependency',
                     'create',
                     'prepare',
                     'converge',
@@ -322,6 +323,7 @@ class Config(object):
                     'destroy',
                 ],
                 'converge_sequence': [
+                    'dependency',
                     'create',
                     'prepare',
                     'converge',

--- a/test/unit/test_scenario.py
+++ b/test/unit/test_scenario.py
@@ -59,6 +59,7 @@ def test_ephemeral_directory_property(molecule_scenario_directory_fixture,
 def test_check_sequence_property(scenario_instance):
     x = [
         'destroy',
+        'dependency',
         'create',
         'prepare',
         'converge',
@@ -71,6 +72,7 @@ def test_check_sequence_property(scenario_instance):
 
 def test_converge_sequence_property(scenario_instance):
     x = [
+        'dependency',
         'create',
         'prepare',
         'converge',

--- a/test/unit/test_scenarios.py
+++ b/test/unit/test_scenarios.py
@@ -148,12 +148,14 @@ def test_get_matrix(scenarios_instance):
             'idempotence': ['idempotence'],
             'syntax': ['syntax'],
             'converge': [
+                'dependency',
                 'create',
                 'prepare',
                 'converge',
             ],
             'check': [
                 'destroy',
+                'dependency',
                 'create',
                 'prepare',
                 'converge',
@@ -188,12 +190,14 @@ def test_get_matrix(scenarios_instance):
             'idempotence': ['idempotence'],
             'syntax': ['syntax'],
             'converge': [
+                'dependency',
                 'create',
                 'prepare',
                 'converge',
             ],
             'check': [
                 'destroy',
+                'dependency',
                 'create',
                 'prepare',
                 'converge',


### PR DESCRIPTION
When a developer is developing locally via the `converge` action
Molecule should bring in the dependencies automatically.  Also,
the same should be true when executing the `check` action.

Fixes: #1029