### PR TITLE
Corrected testinfra SystemInfo tests

### DIFF
--- a/test/scenarios/driver/delegated/molecule/docker/tests/test_default.py
+++ b/test/scenarios/driver/delegated/molecule/docker/tests/test_default.py
@@ -7,7 +7,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_hostname(host):
-    assert 'delegated-instance-docker' == host.system_info.hostname
+    assert 'delegated-instance-docker' == host.check_output('hostname -s')
 
 
 def test_etc_molecule_directory(host):

--- a/test/scenarios/driver/delegated/molecule/ec2/tests/test_default.py
+++ b/test/scenarios/driver/delegated/molecule/ec2/tests/test_default.py
@@ -21,7 +21,7 @@ def test_etc_molecule_directory(host):
 
 
 def test_etc_molecule_ansible_hostname_file(host):
-    filename = '/etc/molecule/{}'.format(host.system_info.hostname)
+    filename = '/etc/molecule/{}'.format(host.check_output('hostname -s'))
     f = host.file(filename)
 
     assert f.is_file

--- a/test/scenarios/driver/delegated/molecule/gce/tests/test_default.py
+++ b/test/scenarios/driver/delegated/molecule/gce/tests/test_default.py
@@ -21,7 +21,7 @@ def test_etc_molecule_directory(host):
 
 
 def test_etc_molecule_ansible_hostname_file(host):
-    filename = '/etc/molecule/{}'.format(host.system_info.hostname)
+    filename = '/etc/molecule/{}'.format(host.check_output('hostname -s'))
     f = host.file(filename)
 
     assert f.is_file

--- a/test/scenarios/driver/delegated/molecule/openstack/tests/test_default.py
+++ b/test/scenarios/driver/delegated/molecule/openstack/tests/test_default.py
@@ -7,7 +7,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_hostname(host):
-    assert 'delegated-instance-openstack' == host.system_info.hostname
+    assert 'delegated-instance-openstack' == host.check_output('hostname -s')
 
 
 def test_etc_molecule_directory(host):

--- a/test/scenarios/driver/delegated/molecule/vagrant/tests/test_default.py
+++ b/test/scenarios/driver/delegated/molecule/vagrant/tests/test_default.py
@@ -7,7 +7,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_hostname(host):
-    assert 'delegated-instance-vagrant' == host.system_info.hostname
+    assert 'delegated-instance-vagrant' == host.check_output('hostname -s')
 
 
 def test_etc_molecule_directory(host):

--- a/test/scenarios/driver/docker/molecule/default/tests/test_default.py
+++ b/test/scenarios/driver/docker/molecule/default/tests/test_default.py
@@ -7,7 +7,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_hostname(host):
-    assert 'instance' == host.system_info.hostname
+    assert 'instance' == host.check_output('hostname -s')
 
 
 def test_etc_molecule_directory(host):

--- a/test/scenarios/driver/docker/molecule/multi-node/tests/test_bar.py
+++ b/test/scenarios/driver/docker/molecule/multi-node/tests/test_bar.py
@@ -7,7 +7,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_hostname(host):
-    assert 'instance-1' == host.system_info.hostname
+    assert 'instance-1' == host.check_output('hostname -s')
 
 
 def test_etc_molecule_directory(host):

--- a/test/scenarios/driver/docker/molecule/multi-node/tests/test_baz.py
+++ b/test/scenarios/driver/docker/molecule/multi-node/tests/test_baz.py
@@ -7,7 +7,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_hostname(host):
-    assert 'instance-2' == host.system_info.hostname
+    assert 'instance-2' == host.check_output('hostname -s')
 
 
 def test_etc_molecule_directory(host):

--- a/test/scenarios/driver/docker/molecule/multi-node/tests/test_default.py
+++ b/test/scenarios/driver/docker/molecule/multi-node/tests/test_default.py
@@ -8,7 +8,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_hostname(host):
-    assert re.search(r'instance-[12]', host.system_info.hostname)
+    assert re.search(r'instance-[12]', host.check_output('hostname -s'))
 
 
 def test_etc_molecule_directory(host):
@@ -21,7 +21,7 @@ def test_etc_molecule_directory(host):
 
 
 def test_etc_molecule_ansible_hostname_file(host):
-    filename = '/etc/molecule/{}'.format(host.system_info.hostname)
+    filename = '/etc/molecule/{}'.format(host.check_output('hostname -s'))
     f = host.file(filename)
 
     assert f.is_file

--- a/test/scenarios/driver/docker/molecule/multi-node/tests/test_foo.py
+++ b/test/scenarios/driver/docker/molecule/multi-node/tests/test_foo.py
@@ -8,7 +8,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_hostname(host):
-    assert re.search(r'instance-[12]', host.system_info.hostname)
+    assert re.search(r'instance-[12]', host.check_output('hostname -s'))
 
 
 def test_etc_molecule_directory(host):
@@ -21,7 +21,7 @@ def test_etc_molecule_directory(host):
 
 
 def test_etc_molecule_ansible_hostname_file(host):
-    filename = '/etc/molecule/{}'.format(host.system_info.hostname)
+    filename = '/etc/molecule/{}'.format(host.check_output('hostname -s'))
     f = host.file(filename)
 
     assert f.is_file

--- a/test/scenarios/driver/ec2/molecule/default/tests/test_default.py
+++ b/test/scenarios/driver/ec2/molecule/default/tests/test_default.py
@@ -21,7 +21,7 @@ def test_etc_molecule_directory(host):
 
 
 def test_etc_molecule_ansible_hostname_file(host):
-    filename = '/etc/molecule/{}'.format(host.system_info.hostname)
+    filename = '/etc/molecule/{}'.format(host.check_output('hostname -s'))
     f = host.file(filename)
 
     assert f.is_file

--- a/test/scenarios/driver/ec2/molecule/multi-node/tests/test_default.py
+++ b/test/scenarios/driver/ec2/molecule/multi-node/tests/test_default.py
@@ -21,7 +21,7 @@ def test_etc_molecule_directory(host):
 
 
 def test_etc_molecule_ansible_hostname_file(host):
-    filename = '/etc/molecule/{}'.format(host.system_info.hostname)
+    filename = '/etc/molecule/{}'.format(host.check_output('hostname -s'))
     f = host.file(filename)
 
     assert f.is_file

--- a/test/scenarios/driver/gce/molecule/default/tests/test_default.py
+++ b/test/scenarios/driver/gce/molecule/default/tests/test_default.py
@@ -21,7 +21,7 @@ def test_etc_molecule_directory(host):
 
 
 def test_etc_molecule_ansible_hostname_file(host):
-    filename = '/etc/molecule/{}'.format(host.system_info.hostname)
+    filename = '/etc/molecule/{}'.format(host.check_output('hostname -s'))
     f = host.file(filename)
 
     assert f.is_file

--- a/test/scenarios/driver/gce/molecule/multi-node/tests/test_default.py
+++ b/test/scenarios/driver/gce/molecule/multi-node/tests/test_default.py
@@ -21,7 +21,7 @@ def test_etc_molecule_directory(host):
 
 
 def test_etc_molecule_ansible_hostname_file(host):
-    filename = '/etc/molecule/{}'.format(host.system_info.hostname)
+    filename = '/etc/molecule/{}'.format(host.check_output('hostname -s'))
     f = host.file(filename)
 
     assert f.is_file

--- a/test/scenarios/driver/lxc/molecule/default/tests/test_default.py
+++ b/test/scenarios/driver/lxc/molecule/default/tests/test_default.py
@@ -7,7 +7,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_hostname(host):
-    assert 'instance' == host.system_info.hostname
+    assert 'instance' == host.check_output('hostname -s')
 
 
 def test_etc_molecule_directory(host):

--- a/test/scenarios/driver/lxc/molecule/multi-node/tests/test_default.py
+++ b/test/scenarios/driver/lxc/molecule/multi-node/tests/test_default.py
@@ -8,7 +8,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_hostname(host):
-    assert re.search(r'instance-[12]', host.system_info.hostname)
+    assert re.search(r'instance-[12]', host.check_output('hostname -s'))
 
 
 def test_etc_molecule_directory(host):
@@ -21,7 +21,7 @@ def test_etc_molecule_directory(host):
 
 
 def test_etc_molecule_ansible_hostname_file(host):
-    filename = '/etc/molecule/{}'.format(host.system_info.hostname)
+    filename = '/etc/molecule/{}'.format(host.check_output('hostname -s'))
     f = host.file(filename)
 
     assert f.is_file

--- a/test/scenarios/driver/lxd/molecule/default/tests/test_default.py
+++ b/test/scenarios/driver/lxd/molecule/default/tests/test_default.py
@@ -6,4 +6,4 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_hostname(host):
-    assert 'instance' == host.system_info.hostname
+    assert 'instance' == host.check_output('hostname -s')

--- a/test/scenarios/driver/lxd/molecule/multi-node/tests/test_default.py
+++ b/test/scenarios/driver/lxd/molecule/multi-node/tests/test_default.py
@@ -8,7 +8,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_hostname(host):
-    assert re.search(r'instance-[12]', host.system_info.hostname)
+    assert re.search(r'instance-[12]', host.check_output('hostname -s'))
 
 
 def test_etc_molecule_directory(host):
@@ -21,7 +21,7 @@ def test_etc_molecule_directory(host):
 
 
 def test_etc_molecule_ansible_hostname_file(host):
-    filename = '/etc/molecule/{}'.format(host.system_info.hostname)
+    filename = '/etc/molecule/{}'.format(host.check_output('hostname -s'))
     f = host.file(filename)
 
     assert f.is_file

--- a/test/scenarios/driver/openstack/molecule/default/tests/test_default.py
+++ b/test/scenarios/driver/openstack/molecule/default/tests/test_default.py
@@ -7,7 +7,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_hostname(host):
-    assert 'instance' == host.system_info.hostname
+    assert 'instance' == host.check_output('hostname -s')
 
 
 def test_etc_molecule_directory(host):

--- a/test/scenarios/driver/openstack/molecule/multi-node/tests/test_default.py
+++ b/test/scenarios/driver/openstack/molecule/multi-node/tests/test_default.py
@@ -8,7 +8,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_hostname(host):
-    assert re.search(r'instance-[12]', host.system_info.hostname)
+    assert re.search(r'instance-[12]', host.check_output('hostname -s'))
 
 
 def test_etc_molecule_directory(host):
@@ -21,7 +21,7 @@ def test_etc_molecule_directory(host):
 
 
 def test_etc_molecule_ansible_hostname_file(host):
-    filename = '/etc/molecule/{}'.format(host.system_info.hostname)
+    filename = '/etc/molecule/{}'.format(host.check_output('hostname -s'))
     f = host.file(filename)
 
     assert f.is_file

--- a/test/scenarios/driver/vagrant/molecule/default/tests/test_default.py
+++ b/test/scenarios/driver/vagrant/molecule/default/tests/test_default.py
@@ -7,7 +7,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_hostname(host):
-    assert 'instance' == host.system_info.hostname
+    assert 'instance' == host.check_output('hostname -s')
 
 
 def test_etc_molecule_directory(host):

--- a/test/scenarios/driver/vagrant/molecule/multi-node/tests/test_default.py
+++ b/test/scenarios/driver/vagrant/molecule/multi-node/tests/test_default.py
@@ -8,7 +8,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_hostname(host):
-    assert re.search(r'instance-[12]', host.system_info.hostname)
+    assert re.search(r'instance-[12]', host.check_output('hostname -s'))
 
 
 def test_etc_molecule_directory(host):
@@ -21,7 +21,7 @@ def test_etc_molecule_directory(host):
 
 
 def test_etc_molecule_ansible_hostname_file(host):
-    filename = '/etc/molecule/{}'.format(host.system_info.hostname)
+    filename = '/etc/molecule/{}'.format(host.check_output('hostname -s'))
     f = host.file(filename)
 
     assert f.is_file

--- a/test/scenarios/test_destroy_strategy/molecule/default/tests/test_default.py
+++ b/test/scenarios/test_destroy_strategy/molecule/default/tests/test_default.py
@@ -7,7 +7,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_hostname(host):
-    assert 'instance' == host.system_info.hostname
+    assert 'instance' == host.check_output('hostname -s')
 
 
 def test_etc_molecule_directory(host):


### PR DESCRIPTION
Testinfra exposed methods on the SystemInfo class, which should not have
been exposed.  Updated tests to no longer rely on this API.

https://github.com/philpep/testinfra/issues/260