### PR TITLE
A portable default command

### DIFF
--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -41,7 +41,7 @@
         state: started
         recreate: false
         log_driver: syslog
-        command: "{{ item.command | default('sleep infinity') }}"
+        command: "{{ item.command | default('bash -c \"while true; do sleep 10000; done\"') }}"
         privileged: "{{ item.privileged | default(omit) }}"
         volumes: "{{ item.volumes | default(omit) }}"
         capabilities: "{{ item.capabilities | default(omit) }}"

--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -39,7 +39,7 @@
         state: started
         recreate: false
         log_driver: syslog
-        command: "{{ item.command | default('sleep infinity') }}"
+        command: "{{ item.command | default('bash -c \"while true; do sleep 10000; done\"') }}"
         privileged: "{{ item.privileged | default(omit) }}"
         volumes: "{{ item.volumes | default(omit) }}"
         capabilities: "{{ item.capabilities | default(omit) }}"


### PR DESCRIPTION
Molecule attempts to boot the container with the `sleep infinity` command,
when command is absent.  However, this is not portable across supported
distros.  Updated command with a fairly generic while loop.

Fixes: #1043