### PR TITLE
Switching bash->sh, busybox/alpine don't have bash.

### DIFF
--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -41,7 +41,7 @@
         state: started
         recreate: false
         log_driver: syslog
-        command: "{{ item.command | default('bash -c \"while true; do sleep 10000; done\"') }}"
+        command: "{{ item.command | default('sh -c \"while true; do sleep 10000; done\"') }}"
         privileged: "{{ item.privileged | default(omit) }}"
         volumes: "{{ item.volumes | default(omit) }}"
         capabilities: "{{ item.capabilities | default(omit) }}"

--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -39,7 +39,7 @@
         state: started
         recreate: false
         log_driver: syslog
-        command: "{{ item.command | default('bash -c \"while true; do sleep 10000; done\"') }}"
+        command: "{{ item.command | default('sh -c \"while true; do sleep 10000; done\"') }}"
         privileged: "{{ item.privileged | default(omit) }}"
         volumes: "{{ item.volumes | default(omit) }}"
         capabilities: "{{ item.capabilities | default(omit) }}"


### PR DESCRIPTION
For issue 1043/1044, the suggested fix does not work:
```
        "msg": "Error starting container ffb78290c3d010d1e2d3a60fed29151e2e0df47e3369af21be2aa11f63d2b423: 400 Client Error: Bad Request (\"oci runtime error: container_linux.go:265: starting container process caused \"exec: \\\"bash\\\": executable file not found in $PATH\"\n\")"
```

busybox and alpine don't have bash installed by default, sh is available though.

I've [tested](https://travis-ci.org/robertdebock/ansible-role-bootstrap/builds/305131687) this on:
- alpine (3.5 & 3.6)
- busybox (1.27)
- centos (6 & 7)
- debian (jessie & buster)
- fedora (26 & 27)
- ubuntu (artful & zesty)

(busybox has some other issue; it does not have python installed...)
