### PR TITLE
Options not used by create/destroy provisioner

### DIFF
--- a/molecule/provisioner/ansible.py
+++ b/molecule/provisioner/ansible.py
@@ -64,6 +64,10 @@ class Ansible(base.Base):
     Additional options can be passed to `ansible-playbook` through the options
     dict.  Any option set in this section will override the defaults.
 
+    .. important::
+
+        Options do not affect the create and destroy actions.
+
     .. code-block:: yaml
 
         provisioner:
@@ -135,7 +139,7 @@ class Ansible(base.Base):
 
     This can be used to bring instances into a particular state, prior to
     testing.
-    
+
     .. code-block:: yaml
 
         provisioner:
@@ -333,6 +337,8 @@ class Ansible(base.Base):
 
     @property
     def options(self):
+        if self._config.subcommand in ['create', 'destroy']:
+            return self.default_options
         return self._config.merge_dicts(
             self.default_options,
             self._config.config['provisioner']['options'])

--- a/test/unit/provisioner/test_ansible.py
+++ b/test/unit/provisioner/test_ansible.py
@@ -189,6 +189,13 @@ def test_options_property(ansible_instance):
     assert x == ansible_instance.options
 
 
+def test_options_property_does_not_merge(ansible_instance):
+    for subcommand in ['create', 'destroy']:
+        ansible_instance._config.command_args = {'subcommand': subcommand}
+
+        assert {} == ansible_instance.options
+
+
 def test_options_property_handles_cli_args(ansible_instance):
     ansible_instance._config.args = {'debug': True}
 


### PR DESCRIPTION
Create and Destroy should not be influenced by the changes in
`molecule.yml`.

Fixes: #1038