### PR TITLE
Adds an option to allow vagrant to run the provisioning step

### DIFF
--- a/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
+++ b/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
@@ -294,6 +294,7 @@ class VagrantClient(object):
         cd = self._created()
         if not cd:
             changed = True
+            no_provision = no_provision and self._module.params['no_provision']
             for line in self._vagrant.up(no_provision, stream_output=True):
                 # NOTE: Add prefix to ensure that output of 'vagrant up'
                 # doesn't start with one of the JSON start characters { or ].
@@ -401,6 +402,7 @@ def main():
             provider_options=dict(type='dict', default={}),
             provider_raw_config_args=dict(type='list', default=None),
             force_stop=dict(type='bool', default=False),
+            no_provision=dict(type='bool', default=True),
             state=dict(type='str', default='up', choices=['up', 'destroy'])),
         supports_check_mode=False)
 

--- a/test/resources/playbooks/vagrant/create.yml
+++ b/test/resources/playbooks/vagrant/create.yml
@@ -24,6 +24,8 @@
         provider_cpus: "{{ item.cpus | default(omit) }}"
         provider_raw_config_args: "{{ item.raw_config_args | default(omit) }}"
 
+        no_provision: "{{ item.no_provision | default(omit) }}"
+
         state: up
       register: server
       with_items: "{{ molecule_yml.platforms }}"

--- a/test/scenarios/driver/vagrant/molecule/default/molecule.yml
+++ b/test/scenarios/driver/vagrant/molecule/default/molecule.yml
@@ -16,6 +16,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: dhcp
+    no_provision: true
 provisioner:
   name: ansible
   playbooks:

--- a/test/scenarios/driver/vagrant/molecule/default/tests/test_default.py
+++ b/test/scenarios/driver/vagrant/molecule/default/tests/test_default.py
@@ -7,7 +7,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_hostname(host):
-    assert 'instance' == host.check_output('hostname -s')
+    assert host.check_output('hostname -s') == 'instance'
 
 
 def test_etc_molecule_directory(host):

--- a/test/scenarios/driver/vagrant/molecule/default/tests/test_default.py
+++ b/test/scenarios/driver/vagrant/molecule/default/tests/test_default.py
@@ -7,7 +7,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_hostname(host):
-    assert host.check_output('hostname -s') == 'instance'
+    assert 'instance' == host.check_output('hostname -s')
 
 
 def test_etc_molecule_directory(host):


### PR DESCRIPTION
There's a new module argument called "no_provision" which, if set
to False, causes Vagrant to run the provisioning step.

I ran into a problem where a Vagrant Box wouldn't work because it has a Vagrantfile included with some shell script, which is needed for the Box to work correctly.