### PR TITLE
Update verifier.yml

### DIFF
--- a/molecule/cookiecutter/scenario/verifier/goss/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verifier.yml
+++ b/molecule/cookiecutter/scenario/verifier/goss/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verifier.yml
@@ -40,7 +40,7 @@
       register: test_files
 
     - name: Execute Goss tests
-      command: "goss -g {{ item }} validate --format {{ goss_format }}"
+      command: "{{ goss_dst }} -g {{ item }} validate --format {{ goss_format }}"
       register: test_results
       with_items: "{{ test_files.stdout_lines }}"
       ignore_errors: true


### PR DESCRIPTION
instead of "goss", us the (variable) "{{ goss_dst }}" which can always be found. Solves #1065.