### PR TITLE
Correct starting container on Docker edge

### DIFF
--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -40,7 +40,7 @@
         image: "molecule_local/{{ item.image }}"
         state: started
         recreate: false
-        log_driver: syslog
+        log_driver: none
         command: "{{ item.command | default('bash -c \"while true; do sleep 10000; done\"') }}"
         privileged: "{{ item.privileged | default(omit) }}"
         volumes: "{{ item.volumes | default(omit) }}"

--- a/test/resources/playbooks/delegated/create/docker.yml
+++ b/test/resources/playbooks/delegated/create/docker.yml
@@ -5,5 +5,5 @@
     hostname: delegated-instance-docker
     image: molecule_local/centos:latest
     recreate: false
-    log_driver: syslog
+    log_driver: none
     command: sleep infinity

--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -38,7 +38,7 @@
         image: "molecule_local/{{ item.image }}"
         state: started
         recreate: false
-        log_driver: syslog
+        log_driver: none
         command: "{{ item.command | default('bash -c \"while true; do sleep 10000; done\"') }}"
         privileged: "{{ item.privileged | default(omit) }}"
         volumes: "{{ item.volumes | default(omit) }}"


### PR DESCRIPTION
Docker edge would fail to start container due to syslog.
Since we don't need to log to syslog, setting to none.

Fixes: #1077