### PR TITLE
Bump tree-format to 0.1.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,5 @@ PyYAML==3.12
 sh==1.12.14
 tabulate==0.7.7
 testinfra==1.7.1
-tree-format==0.1.1
+tree-format==0.1.2
 yamllint==1.8.1


### PR DESCRIPTION
Version 0.1.1 fails to build in some environments with an encoding error,
this is fixed in 0.1.2.

Before:

```
Collecting tree-format==0.1.1 (from molecule==2.6.0)
  Downloading tree-format-0.1.1.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-anvkxj1i/tree-format/setup.py", line 23, in <module>
        long_description = readme.read()
      File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 129: ordinal not in range(128)
    
    ----------------------------------------
```

After, no errors:

```
[ ... ]
Collecting testinfra==1.7.1 (from molecule===2.6.1.dev3)
  Downloading testinfra-1.7.1-py2.py3-none-any.whl (53kB)
Collecting tree-format==0.1.2 (from molecule===2.6.1.dev3)
  Downloading tree-format-0.1.2.tar.gz
Collecting yamllint==1.8.1 (from molecule===2.6.1.dev3)
  Downloading yamllint-1.8.1-py2.py3-none-any.whl
[ ... ]
```