### PR TITLE
EC2: support ansible 2.4

### DIFF
--- a/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
+++ b/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
@@ -19,6 +19,9 @@ platforms:
   - name: instance
     image: ami-a5b196c0
     instance_type: t2.micro
+    region: us-east-2
+    user: ubuntu
+    vpc_id: vpc-72e724c6
     vpc_subnet_id: subnet-6456fd1f
 {%- elif cookiecutter.driver_name == 'gce' %}
   - name: instance

--- a/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -10,7 +10,6 @@
     molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
     molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
 
-    ssh_user: ubuntu
     ssh_port: 22
 
     security_group_name: molecule
@@ -34,17 +33,28 @@
     keypair_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
   tasks:
     - include: security_group.yml
+      tags: skip_ansible_lint
+      vars:
+        region: "{{ item.region }}"
+        vpc_id: "{{ item.vpc_id }}"
+      with_items: "{{ molecule_yml.platforms }}"
     - include: keypair.yml
+      tags: skip_ansible_lint
+      vars:
+        region: "{{ item.region }}"
+      with_items: "{{ molecule_yml.platforms }}"
 
     - name: Create molecule instance(s)
       ec2:
         key_name: "{{ keypair_name }}"
+        region: "{{ item.region }}"
         image: "{{ item.image }}"
         instance_type: "{{ item.instance_type }}"
         vpc_subnet_id: "{{ item.vpc_subnet_id }}"
         group: "{{ security_group_name }}"
         instance_tags:
           instance: "{{ item.name }}"
+          user: "{{ item.user }}"
         wait: true
         assign_public_ip: true
         exact_count: 1
@@ -69,8 +79,9 @@
       set_fact:
         instance_conf_dict: {
           'instance': "{{ item.instances[0].tags.instance }}",
+          'region': "{{ item.instances[0].region }}",
           'address': "{{ item.instances[0].public_ip }}",
-          'user': "{{ ssh_user }}",
+          'user': "{{ item.instances[0].tags.user }}",
           'port': "{{ ssh_port }}",
           'identity_file': "{{ keypair_path }}",
           'instance_ids': "{{ item.instance_ids }}", }

--- a/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -25,6 +25,7 @@
       ec2:
         state: absent
         instance_ids: "{{ item.instance_ids }}"
+        region: "{{ item.region }}"
       register: server
       with_items: "{{ instance_conf }}"
       when: not skip_instances

--- a/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/keypair.yml
+++ b/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/keypair.yml
@@ -8,12 +8,14 @@
 - name: Delete remote keypair
   ec2_key:
     name: "{{ keypair_name }}"
+    region: "{{ region }}"
     state: absent
   when: not keypair_local.stat.exists
 
 - name: Create keypair
   ec2_key:
     name: "{{ keypair_name }}"
+    region: "{{ region }}"
   register: keypair
 
 - name: Persist the keypair

--- a/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/security_group.yml
+++ b/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/security_group.yml
@@ -3,7 +3,9 @@
 - name: Create security group
   ec2_group:
     name: "{{ security_group_name }}"
-    description: "{{ security_group_name }}"
+    description: "{{ security_group_description }}"
+    region: "{{ region }}"
+    vpc_id: "{{ vpc_id }}"
     rules: "{{ security_group_rules }}"
     rules_egress: "{{ security_group_rules_egress }}"
 {%- endraw %}

--- a/test/scenarios/driver/ec2/molecule/default/molecule.yml
+++ b/test/scenarios/driver/ec2/molecule/default/molecule.yml
@@ -11,6 +11,9 @@ platforms:
   - name: instance
     image: ami-a5b196c0
     instance_type: t2.micro
+    region: us-east-2
+    user: ubuntu
+    vpc_id: vpc-72e724c6
     vpc_subnet_id: subnet-6456fd1f
 provisioner:
   name: ansible


### PR DESCRIPTION
This PR fixes some issues in ec2 driver when using ansible 2.4, `region` or `ec2_url` should be provided for some modules.
Since `include` is now deprecated in 2.4, we skip those in molecule generated playbooks.
Also `user` and `vpc_id` are added to platforms, since they are needed for some AMIs and subnets.