### PR TITLE
Add custom nameserver to Docker container 

### DIFF
--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -47,6 +47,7 @@
         capabilities: "{{ item.capabilities | default(omit) }}"
         ports: "{{ item.exposed_ports | default(omit) }}"
         ulimits: "{{ item.ulimits | default(omit) }}"
+        dns_servers: "{{ item.dns_servers | default(omit) }}"
       register: server
       with_items: "{{ molecule_yml.platforms }}"
       async: 7200

--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -51,6 +51,7 @@ class Docker(base.Base):
             volumes: "{{ item.volumes | default(omit) }}"
             capabilities: "{{ item.capabilities | default(omit) }}"
             ulimits: "{{ item.ulimits | default(omit) }}"
+            dns_servers: "{{ item.dns_servers | default(omit) }}"
 
     .. code-block:: bash
 

--- a/molecule/model/schema.py
+++ b/molecule/model/schema.py
@@ -81,6 +81,7 @@ class PlatformsDockerSchema(marshmallow.Schema):
     volumes = marshmallow.fields.List(marshmallow.fields.Str())
     capabilities = marshmallow.fields.List(marshmallow.fields.Str())
     ulimits = marshmallow.fields.List(marshmallow.fields.Str())
+    dns_servers = marshmallow.fields.List(marshmallow.fields.Str())
 
 
 class PlatformsVagrantSchema(PlatformsBaseSchema):

--- a/test/resources/playbooks/delegated/create/docker.yml
+++ b/test/resources/playbooks/delegated/create/docker.yml
@@ -8,3 +8,4 @@
     log_driver: json-file
     command: sleep infinity
     ulimits: "{{ item.ulimits | default(omit) }}"
+    dns_servers: "{{ item.dns_servers | default(omit) }}"

--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -45,6 +45,7 @@
         capabilities: "{{ item.capabilities | default(omit) }}"
         ports: "{{ item.exposed_ports | default(omit) }}"
         ulimits: "{{ item.ulimits | default(omit) }}"
+        dns_servers: "{{ item.dns_servers | default(omit) }}"
       register: server
       with_items: "{{ molecule_yml.platforms }}"
       async: 7200


### PR DESCRIPTION
Add dns_servers option for create Docker containers with custom dns