### PR TITLE
Add docker network

### DIFF
--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -33,6 +33,12 @@
       with_items: "{{ platforms.results }}"
       when: platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
 
+    - name: Create docker network(s)
+      docker_network:
+        name: "{{ item }}"
+        state: present
+      with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks }}"
+
     - name: Create molecule instance(s)
       docker_container:
         name: "{{ item.name }}"
@@ -47,6 +53,7 @@
         capabilities: "{{ item.capabilities | default(omit) }}"
         ports: "{{ item.exposed_ports | default(omit) }}"
         ulimits: "{{ item.ulimits | default(omit) }}"
+        networks: "{{ item.networks | default(omit) }}"
       register: server
       with_items: "{{ molecule_yml.platforms }}"
       async: 7200

--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -26,4 +26,10 @@
       until: docker_jobs.finished
       retries: 300
       with_items: "{{ server.results }}"
+
+    - name: Delete docker network(s)
+      docker_network:
+        name: "{{ item }}"
+        state: absent
+      with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks }}"
 {%- endraw %}

--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -52,6 +52,7 @@ class Docker(base.Base):
             capabilities: "{{ item.capabilities | default(omit) }}"
             ulimits: "{{ item.ulimits | default(omit) }}"
             dns_servers: "{{ item.dns_servers | default(omit) }}"
+            networks: "{{ item.networks | default(omit) }}"
 
     .. code-block:: bash
 

--- a/molecule/model/schema.py
+++ b/molecule/model/schema.py
@@ -81,6 +81,7 @@ class PlatformsDockerSchema(marshmallow.Schema):
     volumes = marshmallow.fields.List(marshmallow.fields.Str())
     capabilities = marshmallow.fields.List(marshmallow.fields.Str())
     ulimits = marshmallow.fields.List(marshmallow.fields.Str())
+    networks = marshmallow.fields.List(marshmallow.fields.Str())
 
 
 class PlatformsVagrantSchema(PlatformsBaseSchema):

--- a/molecule/provisioner/ansible/plugins/filters/molecule_core.py
+++ b/molecule/provisioner/ansible/plugins/filters/molecule_core.py
@@ -49,6 +49,19 @@ def header(content):
     return util.molecule_prepender(content)
 
 
+def get_docker_networks(data):
+    network_list = []
+    for platform in data:
+        if "networks" in platform:
+            for network in platform['networks']:
+                if "name" in network:
+                    name = network['name']
+                    network_list.append(name)
+                else:
+                    network_list.append("something")
+    return network_list
+
+
 class FilterModule(object):
     """ Core Molecule filter plugins. """
 
@@ -57,4 +70,5 @@ class FilterModule(object):
             'molecule_from_yaml': from_yaml,
             'molecule_to_yaml': to_yaml,
             'molecule_header': header,
+            'molecule_get_docker_networks': get_docker_networks,
         }

--- a/molecule/provisioner/ansible/plugins/filters/molecule_core.py
+++ b/molecule/provisioner/ansible/plugins/filters/molecule_core.py
@@ -57,8 +57,6 @@ def get_docker_networks(data):
                 if "name" in network:
                     name = network['name']
                     network_list.append(name)
-                else:
-                    network_list.append("something")
     return network_list
 
 

--- a/test/resources/playbooks/delegated/create/docker.yml
+++ b/test/resources/playbooks/delegated/create/docker.yml
@@ -8,3 +8,4 @@
     log_driver: json-file
     command: sleep infinity
     ulimits: "{{ item.ulimits | default(omit) }}"
+    networks: "{{ item.networks | default(omit) }}"

--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -31,6 +31,12 @@
       with_items: "{{ platforms.results }}"
       when: platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
 
+    - name: Create docker network(s)
+      docker_network:
+        name: "{{ item }}"
+        state: present
+      with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks }}"
+
     - name: Create molecule instance(s)
       docker_container:
         name: "{{ item.name }}"
@@ -45,6 +51,7 @@
         capabilities: "{{ item.capabilities | default(omit) }}"
         ports: "{{ item.exposed_ports | default(omit) }}"
         ulimits: "{{ item.ulimits | default(omit) }}"
+        networks: "{{ item.networks | default(omit) }}"
       register: server
       with_items: "{{ molecule_yml.platforms }}"
       async: 7200

--- a/test/resources/playbooks/docker/destroy.yml
+++ b/test/resources/playbooks/docker/destroy.yml
@@ -25,3 +25,9 @@
       until: docker_jobs.finished
       retries: 300
       with_items: "{{ server.results }}"
+
+    - name: Delete docker network(s)
+      docker_network:
+        name: "{{ item }}"
+        state: absent
+      with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks }}"


### PR DESCRIPTION
This PR contains the following change:

* Creation/Deletion of Docker networks via the `create.yml` and `delete.yml` playbooks;

A filter `molecule_get_docker_networks` will be used that checks if a `networks` key is configured in the platforms. If so, it then checks if it has a `name` key and if that exists to, this name will be used with creating or deleting the docker network. If no `networks` key is configured in the platform (Or if so, but has no `name` key), then an empty list is returned and task is skipped.

Example usage for `molecule.yml`:

```
platforms:
  - name: ansible-docker
    image: milcom/centos7-systemd
    groups:
      - group1
    privileged: True
    networks:
      - name: my_fancy_network
```

If a better approach is needed, please let me know and I'll try again.
(I hope I have updated all correct test files :-) )