### PR TITLE
regex support in additional_files_or_dirs

### DIFF
--- a/molecule/verifier/testinfra.py
+++ b/molecule/verifier/testinfra.py
@@ -19,7 +19,7 @@
 #  DEALINGS IN THE SOFTWARE.
 
 import os
-
+import glob
 import sh
 
 from molecule import logger
@@ -126,9 +126,18 @@ class Testinfra(base.Base):
 
         :return: None
         """
+        list_of_files_or_dirs = []
         options = self.options
         verbose_flag = util.verbose_flag(options)
-        args = verbose_flag + self.additional_files_or_dirs
+        additional_files_or_dirs = self.additional_files_or_dirs
+        for additional_path in additional_files_or_dirs:
+            glob_add_path_dir = glob.glob(self._config.scenario.directory + '/' + additional_path)
+            # If file/directory not exists, length will be 0 and continue with next path.
+            if len(glob_add_path_dir) == 0:
+                continue
+            list_of_files_or_dirs.append(glob_add_path_dir)
+
+        args = verbose_flag + list_of_files_or_dirs
 
         self._testinfra_command = sh.Command('py.test').bake(
             options,

--- a/molecule/verifier/testinfra.py
+++ b/molecule/verifier/testinfra.py
@@ -131,11 +131,11 @@ class Testinfra(base.Base):
         verbose_flag = util.verbose_flag(options)
         additional_files_or_dirs = self.additional_files_or_dirs
         for additional_path in additional_files_or_dirs:
-            glob_add_path_dir = glob.glob(self._config.scenario.directory + '/' + additional_path)
-            # If file/directory not exists, length will be 0 and continue with next path.
-            if len(glob_add_path_dir) == 0:
+            glob_add_path_dir = os.path.join(self._config.scenario.directory, additional_path)
+            add_path_exists = glob.glob(glob_add_path_dir)
+            if not add_path_exists:
                 continue
-            list_of_files_or_dirs.append(glob_add_path_dir)
+            list_of_files_or_dirs.append(add_path_exists)
 
         args = verbose_flag + list_of_files_or_dirs
 


### PR DESCRIPTION
Currently a WIP for issue #1060 , need to figure out how to properly test this. I created the PR already, so you can already comment on changes. 😄 

When a `molecule.yml` is configured like this:
```
verifier:
  name: testinfra
  additional_files_or_dirs:
    - ../../tests/test_*.py
    - ../../tests/*/tests/
  lint:
    name: flake8
```
The `molecule verify` will be using the additional file and directories:
```
    ============================= test session starts ==============================
    platform darwin -- Python 2.7.10, pytest-3.3.2, py-1.5.2, pluggy-0.6.0
    rootdir: /Users/wdijkerman/git/ansible/access, inifile:
    plugins: testinfra-1.7.1
collected 4 items                                                              
    
    tests/test_default.py .                                                  [ 25%]
    ../../tests/test_first.py .                                              [ 50%]
    ../../tests/dir2/tests/test_dir2.py .                                    [ 75%]
    ../../tests/dir1/tests/test_dir1.py .                                    [100%]
    
    =============================== warnings summary ===============================
```

I'm not sure if is needed so I will just mention it here, but a check is added to see if the additional file or directory exists. If this doesn't exist, the entry will be skipped and the `verify` step will not fail on this.