### PR TITLE
Converge the dependency scenario

### DIFF
--- a/test/scenarios/dependency/molecule/ansible-galaxy/playbook.yml
+++ b/test/scenarios/dependency/molecule/ansible-galaxy/playbook.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - yatesr.timezone

--- a/test/scenarios/dependency/molecule/gilt/playbook.yml
+++ b/test/scenarios/dependency/molecule/gilt/playbook.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - timezone


### PR DESCRIPTION
The dependency functional test downloads the dependent role, but should
converge to ensure Molecule picks it up.