### PR TITLE
Ability to set multiple x options

### DIFF
--- a/molecule/provisioner/lint/ansible_lint.py
+++ b/molecule/provisioner/lint/ansible_lint.py
@@ -49,6 +49,9 @@ class AnsibleLint(base.Base):
               exclude:
                 - path/exclude1
                 - path/exclude2
+              x:
+                - ANSIBLE0011
+                - ANSIBLE0012
               force-color: True
 
     The role linting can be disabled by setting `enabled` to False.
@@ -90,6 +93,7 @@ class AnsibleLint(base.Base):
         d = {
             'default_exclude': [self._config.scenario.ephemeral_directory],
             'exclude': [],
+            'x': [],
         }
         if self._config.debug:
             d['v'] = True
@@ -114,10 +118,14 @@ class AnsibleLint(base.Base):
         default_exclude_list = options.pop('default_exclude')
         options_exclude_list = options.pop('exclude')
         excludes = default_exclude_list + options_exclude_list
+        x_list = options.pop('x')
+
         exclude_args = ['--exclude={}'.format(exclude) for exclude in excludes]
+        x_args = ['-x={}'.format(x) for x in x_list]
         self._ansible_lint_command = sh.ansible_lint.bake(
             options,
             exclude_args,
+            x_args,
             self._config.provisioner.playbooks.converge,
             _env=self.env,
             _out=LOG.out,

--- a/test/unit/provisioner/lint/test_ansible_lint.py
+++ b/test/unit/provisioner/lint/test_ansible_lint.py
@@ -39,6 +39,10 @@ def molecule_provisioner_lint_section_data():
                         'foo',
                         'bar',
                     ],
+                    'x': [
+                        'foo',
+                        'bar',
+                    ],
                 },
                 'env': {
                     'foo': 'bar',
@@ -66,6 +70,7 @@ def test_default_options_property(ansible_lint_instance):
         'default_exclude':
         [ansible_lint_instance._config.scenario.ephemeral_directory],
         'exclude': [],
+        'x': [],
     }
 
     assert x == ansible_lint_instance.default_options
@@ -87,6 +92,10 @@ def test_options_property(ansible_lint_instance):
             'foo',
             'bar',
         ],
+        'x': [
+            'foo',
+            'bar',
+        ],
         'foo':
         'bar',
         'v':
@@ -102,6 +111,10 @@ def test_options_property_handles_cli_args(ansible_lint_instance):
         'default_exclude':
         [ansible_lint_instance._config.scenario.ephemeral_directory],
         'exclude': [
+            'foo',
+            'bar',
+        ],
+        'x': [
             'foo',
             'bar',
         ],
@@ -132,10 +145,16 @@ def test_env_property(ansible_lint_instance):
 def test_bake(ansible_lint_instance):
     ansible_lint_instance.bake()
     x = [
-        str(sh.ansible_lint), '--foo=bar', '-v', '--exclude={}'.format(
+        str(sh.ansible_lint),
+        '--foo=bar',
+        '-v',
+        '--exclude={}'.format(
             ansible_lint_instance._config.scenario.ephemeral_directory),
-        '--exclude=foo', '--exclude=bar',
-        ansible_lint_instance._config.provisioner.playbooks.converge
+        '--exclude=foo',
+        '--exclude=bar',
+        ansible_lint_instance._config.provisioner.playbooks.converge,
+        '-x=foo',
+        '-x=bar',
     ]
     result = str(ansible_lint_instance._ansible_lint_command).split()
 


### PR DESCRIPTION
Ansible-lint can take additional `-x` flags.  Molecule would not
allow multiple to be set.

Fixes: #933