### PR TITLE
Correctly converge the dependency scenario

### DIFF
--- a/test/functional/test_command.py
+++ b/test/functional/test_command.py
@@ -154,6 +154,10 @@ def test_command_dependency_ansible_galaxy(scenario_to_test, with_scenario,
                                    'roles', 'timezone')
     assert os.path.isdir(dependency_role)
 
+    options = {'scenario_name': scenario_name}
+    cmd = sh.molecule.bake('converge', **options)
+    pytest.helpers.run_command(cmd)
+
 
 @pytest.mark.parametrize(
     'scenario_to_test, driver_name, scenario_name', [
@@ -180,6 +184,10 @@ def test_command_dependency_gilt(scenario_to_test, with_scenario,
     dependency_role = os.path.join('molecule', 'gilt', '.molecule', 'roles',
                                    'timezone')
     assert os.path.isdir(dependency_role)
+
+    options = {'scenario_name': scenario_name}
+    cmd = sh.molecule.bake('converge', **options)
+    pytest.helpers.run_command(cmd)
 
 
 @pytest.mark.parametrize(

--- a/test/scenarios/dependency/molecule/ansible-galaxy/playbook.yml
+++ b/test/scenarios/dependency/molecule/ansible-galaxy/playbook.yml
@@ -3,4 +3,4 @@
   hosts: all
   become: true
   roles:
-    - yatesr.timezone
+    - timezone


### PR DESCRIPTION
Follow-up PR to #1112.  The dependency functional tests don't converge,
which would never catch the issue.