### PR TITLE
Corrected options not used by create/destroy

### DIFF
--- a/molecule/command/check.py
+++ b/molecule/command/check.py
@@ -75,5 +75,6 @@ def check(ctx, scenario_name):  # pragma: no cover
         base.get_configs(args, command_args), scenario_name)
     s.print_matrix()
     for scenario in s:
-        for term in scenario.sequence:
-            base.execute_subcommand(scenario.config, term)
+        for action in scenario.sequence:
+            scenario.config.action = action
+            base.execute_subcommand(scenario.config, action)

--- a/molecule/command/converge.py
+++ b/molecule/command/converge.py
@@ -85,5 +85,6 @@ def converge(ctx, scenario_name, ansible_args):  # pragma: no cover
         base.get_configs(args, command_args, ansible_args), scenario_name)
     s.print_matrix()
     for scenario in s:
-        for term in scenario.sequence:
-            base.execute_subcommand(scenario.config, term)
+        for action in scenario.sequence:
+            scenario.config.action = action
+            base.execute_subcommand(scenario.config, action)

--- a/molecule/command/create.py
+++ b/molecule/command/create.py
@@ -97,5 +97,6 @@ def create(ctx, scenario_name, driver_name):  # pragma: no cover
         base.get_configs(args, command_args), scenario_name)
     s.print_matrix()
     for scenario in s:
-        for term in scenario.sequence:
-            base.execute_subcommand(scenario.config, term)
+        for action in scenario.sequence:
+            scenario.config.action = action
+            base.execute_subcommand(scenario.config, action)

--- a/molecule/command/dependency.py
+++ b/molecule/command/dependency.py
@@ -72,5 +72,6 @@ def dependency(ctx, scenario_name):  # pragma: no cover
         base.get_configs(args, command_args), scenario_name)
     s.print_matrix()
     for scenario in s:
-        for term in scenario.sequence:
-            base.execute_subcommand(scenario.config, term)
+        for action in scenario.sequence:
+            scenario.config.action = action
+            base.execute_subcommand(scenario.config, action)

--- a/molecule/command/destroy.py
+++ b/molecule/command/destroy.py
@@ -108,5 +108,6 @@ def destroy(ctx, scenario_name, driver_name, __all):  # pragma: no cover
         base.get_configs(args, command_args), scenario_name)
     s.print_matrix()
     for scenario in s:
-        for term in scenario.sequence:
-            base.execute_subcommand(scenario.config, term)
+        for action in scenario.sequence:
+            scenario.config.action = action
+            base.execute_subcommand(scenario.config, action)

--- a/molecule/command/idempotence.py
+++ b/molecule/command/idempotence.py
@@ -138,5 +138,6 @@ def idempotence(ctx, scenario_name):  # pragma: no cover
         base.get_configs(args, command_args), scenario_name)
     s.print_matrix()
     for scenario in s:
-        for term in scenario.sequence:
-            base.execute_subcommand(scenario.config, term)
+        for action in scenario.sequence:
+            scenario.config.action = action
+            base.execute_subcommand(scenario.config, action)

--- a/molecule/command/lint.py
+++ b/molecule/command/lint.py
@@ -82,5 +82,6 @@ def lint(ctx, scenario_name):  # pragma: no cover
         base.get_configs(args, command_args), scenario_name)
     s.print_matrix()
     for scenario in s:
-        for term in scenario.sequence:
-            base.execute_subcommand(scenario.config, term)
+        for action in scenario.sequence:
+            scenario.config.action = action
+            base.execute_subcommand(scenario.config, action)

--- a/molecule/command/prepare.py
+++ b/molecule/command/prepare.py
@@ -115,5 +115,6 @@ def prepare(ctx, scenario_name, driver_name, force):  # pragma: no cover
         base.get_configs(args, command_args), scenario_name)
     s.print_matrix()
     for scenario in s:
-        for term in scenario.sequence:
-            base.execute_subcommand(scenario.config, term)
+        for action in scenario.sequence:
+            scenario.config.action = action
+            base.execute_subcommand(scenario.config, action)

--- a/molecule/command/side_effect.py
+++ b/molecule/command/side_effect.py
@@ -80,5 +80,6 @@ def side_effect(ctx, scenario_name):  # pragma: no cover
         base.get_configs(args, command_args), scenario_name)
     s.print_matrix()
     for scenario in s:
-        for term in scenario.sequence:
-            base.execute_subcommand(scenario.config, term)
+        for action in scenario.sequence:
+            scenario.config.action = action
+            base.execute_subcommand(scenario.config, action)

--- a/molecule/command/syntax.py
+++ b/molecule/command/syntax.py
@@ -72,5 +72,6 @@ def syntax(ctx, scenario_name):  # pragma: no cover
         base.get_configs(args, command_args), scenario_name)
     s.print_matrix()
     for scenario in s:
-        for term in scenario.sequence:
-            base.execute_subcommand(scenario.config, term)
+        for action in scenario.sequence:
+            scenario.config.action = action
+            base.execute_subcommand(scenario.config, action)

--- a/molecule/command/test.py
+++ b/molecule/command/test.py
@@ -110,8 +110,9 @@ def test(ctx, scenario_name, driver_name, __all, destroy):  # pragma: no cover
     s.print_matrix()
     for scenario in s:
         try:
-            for term in scenario.sequence:
-                base.execute_subcommand(scenario.config, term)
+            for action in scenario.sequence:
+                scenario.config.action = action
+                base.execute_subcommand(scenario.config, action)
         except SystemExit:
             if destroy == 'always':
                 msg = ('An error occured during the test sequence.  '

--- a/molecule/command/verify.py
+++ b/molecule/command/verify.py
@@ -72,5 +72,6 @@ def verify(ctx, scenario_name):  # pragma: no cover
         base.get_configs(args, command_args), scenario_name)
     s.print_matrix()
     for scenario in s:
-        for term in scenario.sequence:
-            base.execute_subcommand(scenario.config, term)
+        for action in scenario.sequence:
+            scenario.config.action = action
+            base.execute_subcommand(scenario.config, action)

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -89,6 +89,7 @@ class Config(object):
         self.command_args = command_args
         self.ansible_args = ansible_args
         self.config = self._combine()
+        self._action = None
 
     @property
     def debug(self):
@@ -97,6 +98,14 @@ class Config(object):
     @property
     def subcommand(self):
         return self.command_args['subcommand']
+
+    @property
+    def action(self):
+        return self._action
+
+    @action.setter
+    def action(self, value):
+        self._action = value
 
     @property
     def project_directory(self):

--- a/molecule/provisioner/ansible.py
+++ b/molecule/provisioner/ansible.py
@@ -337,7 +337,7 @@ class Ansible(base.Base):
 
     @property
     def options(self):
-        if self._config.subcommand in ['create', 'destroy']:
+        if self._config.action in ['create', 'destroy']:
             return self.default_options
         return self._config.merge_dicts(
             self.default_options,

--- a/molecule/scenarios.py
+++ b/molecule/scenarios.py
@@ -75,8 +75,8 @@ class Scenarios(object):
         msg = 'Test matrix'
         LOG.info(msg)
 
-        tree = tuple(('', [(scenario.name, [(term, [])
-                                            for term in scenario.sequence])
+        tree = tuple(('', [(scenario.name, [(action, [])
+                                            for action in scenario.sequence])
                            for scenario in self.all]))
 
         tf = tree_format.format_tree(
@@ -119,13 +119,13 @@ class Scenarios(object):
         {
             scenario_1: {
                 'subcommand': [
-                    'term-1',
-                    'term-2',
+                    'action-1',
+                    'action-2',
                 ],
             },
             scenario_2: {
                 'subcommand': [
-                    'term-1',
+                    'action-1',
                 ],
             },
         }

--- a/test/unit/provisioner/test_ansible.py
+++ b/test/unit/provisioner/test_ansible.py
@@ -190,8 +190,8 @@ def test_options_property(ansible_instance):
 
 
 def test_options_property_does_not_merge(ansible_instance):
-    for subcommand in ['create', 'destroy']:
-        ansible_instance._config.command_args = {'subcommand': subcommand}
+    for action in ['create', 'destroy']:
+        ansible_instance._config.action = action
 
         assert {} == ansible_instance.options
 

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -66,6 +66,16 @@ def test_subcommand_property(config_instance):
     assert 'test' == config_instance.subcommand
 
 
+def test_action_property(config_instance):
+    assert config_instance.action is None
+
+
+def test_action_setter(config_instance):
+    config_instance.action = 'foo'
+
+    assert 'foo' == config_instance.action
+
+
 def test_project_directory_property(config_instance):
     assert os.getcwd() == config_instance.project_directory
 


### PR DESCRIPTION
Corrected failed attempt to fix in #1047.  Now passing the action
executing into the config object to properly remove user options
from create/destroy options.

Fixes: #1038