### PR TITLE
Adding provision option for Vagrant provider

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -193,6 +193,7 @@ Create instances with additional provider options.
               - "customize ['modifyvm', :id, '--cpuexecutioncap', '50']"
             provider_options:
               gui: true
+            provision: true
             state: up
           with_items:
             - instance-1

--- a/molecule/cookiecutter/scenario/driver/vagrant/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/vagrant/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -25,6 +25,8 @@
         provider_cpus: "{{ item.cpus | default(omit) }}"
         provider_raw_config_args: "{{ item.raw_config_args | default(omit) }}"
 
+        provision: "{{ item.provision | default(omit) }}"
+
         state: up
       register: server
       with_items: "{{ molecule_yml.platforms }}"

--- a/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
+++ b/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
@@ -289,12 +289,13 @@ class VagrantClient(object):
         self._vagrant = self._get_vagrant()
         self._write_configs()
 
-    def up(self, no_provision=True):
+    def up(self):
         changed = False
         cd = self._created()
         if not cd:
             changed = True
-            for line in self._vagrant.up(no_provision, stream_output=True):
+            provision = self._module.params['provision']
+            for line in self._vagrant.up(provision=provision, stream_output=True):
                 # NOTE: Add prefix to ensure that output of 'vagrant up'
                 # doesn't start with one of the JSON start characters { or ].
                 print('<vagrant_output> {}'.format(line))
@@ -400,6 +401,7 @@ def main():
             provider_cpus=dict(type='int', default=2),
             provider_options=dict(type='dict', default={}),
             provider_raw_config_args=dict(type='list', default=None),
+            provision=dict(type='bool', default=False),
             force_stop=dict(type='bool', default=False),
             state=dict(type='str', default='up', choices=['up', 'destroy'])),
         supports_check_mode=False)

--- a/test/resources/playbooks/vagrant/create.yml
+++ b/test/resources/playbooks/vagrant/create.yml
@@ -24,6 +24,8 @@
         provider_cpus: "{{ item.cpus | default(omit) }}"
         provider_raw_config_args: "{{ item.raw_config_args | default(omit) }}"
 
+        provision: "{{ item.provision | default(omit) }}"
+
         state: up
       register: server
       with_items: "{{ molecule_yml.platforms }}"

--- a/test/scenarios/driver/vagrant/molecule/default/molecule.yml
+++ b/test/scenarios/driver/vagrant/molecule/default/molecule.yml
@@ -16,6 +16,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: dhcp
+    provision: false
 provisioner:
   name: ansible
   playbooks:


### PR DESCRIPTION
Continuing the work of @RuriRyan on [PR#1064](https://github.com/metacloud/molecule/pull/1064), this  PR adds an argument called **provision** to the Vagrant provisioner which controls if Vagrant provisioning is going to be executed or not.