### PR TITLE
Corrected ansible args

### DIFF
--- a/molecule/provisioner/ansible_playbook.py
+++ b/molecule/provisioner/ansible_playbook.py
@@ -73,8 +73,9 @@ class AnsiblePlaybook(object):
             _err=self._err)
 
         if self._config.ansible_args:
-            self._ansible_command = self._ansible_command.bake(
-                self._config.ansible_args)
+            if self._config.action not in ['create', 'destroy']:
+                self._ansible_command = self._ansible_command.bake(
+                    self._config.ansible_args)
 
     def execute(self):
         """

--- a/test/unit/provisioner/test_ansible_playbook.py
+++ b/test/unit/provisioner/test_ansible_playbook.py
@@ -66,10 +66,34 @@ def test_bake(inventory_file, ansible_playbook_instance):
 def test_bake_removes_non_interactive_options_from_non_converge_playbooks(
         inventory_file, ansible_playbook_instance):
     ansible_playbook_instance.bake()
+
     x = '{} --inventory={} playbook'.format(
         str(sh.ansible_playbook), inventory_file)
 
     assert x == ansible_playbook_instance._ansible_command
+
+
+def test_bake_has_ansible_args(inventory_file, ansible_playbook_instance):
+    ansible_playbook_instance._config.ansible_args = ('foo', 'bar')
+    ansible_playbook_instance.bake()
+
+    x = '{} --inventory={} playbook foo bar'.format(
+        str(sh.ansible_playbook), inventory_file)
+
+    assert x == ansible_playbook_instance._ansible_command
+
+
+def test_bake_does_not_have_ansible_args(inventory_file,
+                                         ansible_playbook_instance):
+    for action in ['create', 'destroy']:
+        ansible_playbook_instance._config.ansible_args = ('foo', 'bar')
+        ansible_playbook_instance._config.action = action
+        ansible_playbook_instance.bake()
+
+        x = '{} --inventory={} playbook'.format(
+            str(sh.ansible_playbook), inventory_file)
+
+        assert x == ansible_playbook_instance._ansible_command
 
 
 def test_execute(patched_run_command, ansible_playbook_instance):


### PR DESCRIPTION
Molecule supports the arbitrary passing of ansible args to Molecule's
converge subcommand.  However, these args were not stripped from
Molecule's instance management playbooks.  This can prevent Molecule
from properly setting up the Molecule env.