### PR TITLE
Validate schema for invalid ansible config options

### DIFF
--- a/molecule/model/base.py
+++ b/molecule/model/base.py
@@ -25,9 +25,20 @@ from molecule import logger
 LOG = logger.get_logger(__name__)
 
 
-class Base(marshmallow.Schema):
+class BaseUnknown(marshmallow.Schema):
     @marshmallow.validates_schema(pass_original=True)
     def check_unknown_fields(self, data, original_data):
         unknown = set(original_data) - set(self.fields)
         if unknown:
             raise marshmallow.ValidationError('Unknown field', unknown)
+
+
+class BaseDisallowed(marshmallow.Schema):
+    @marshmallow.validates_schema()
+    def check_fields(self, data):
+        defaults = data.get('defaults')
+        if defaults:
+            disallowed_list = ['roles_path', 'library', 'filter_plugins']
+            if any(disallowed in defaults for disallowed in disallowed_list):
+                raise marshmallow.ValidationError(
+                    'Disallowed user provided config option', defaults)

--- a/molecule/model/schema.py
+++ b/molecule/model/schema.py
@@ -26,18 +26,18 @@ from molecule.model import base
 LOG = logger.get_logger(__name__)
 
 
-class DependencySchema(base.Base):
+class DependencySchema(base.BaseUnknown):
     name = marshmallow.fields.Str()
     enabled = marshmallow.fields.Bool()
     options = marshmallow.fields.Dict()
     env = marshmallow.fields.Dict()
 
 
-class DriverProviderSchema(base.Base):
+class DriverProviderSchema(base.BaseUnknown):
     name = marshmallow.fields.Str(allow_none=True)
 
 
-class DriverSchema(base.Base):
+class DriverSchema(base.BaseUnknown):
     name = marshmallow.fields.Str()
     provider = marshmallow.fields.Nested(DriverProviderSchema())
     options = marshmallow.fields.Dict()
@@ -45,14 +45,14 @@ class DriverSchema(base.Base):
     safe_files = marshmallow.fields.List(marshmallow.fields.Str())
 
 
-class LintSchema(base.Base):
+class LintSchema(base.BaseUnknown):
     name = marshmallow.fields.Str()
     enabled = marshmallow.fields.Bool()
     options = marshmallow.fields.Dict()
     env = marshmallow.fields.Dict()
 
 
-class InterfaceSchema(base.Base):
+class InterfaceSchema(base.BaseUnknown):
     network_name = marshmallow.fields.Str()
     type = marshmallow.fields.Str()
     auto_config = marshmallow.fields.Bool()
@@ -103,18 +103,18 @@ class PlatformsVagrantSchema(PlatformsBaseSchema):
     force_stop = marshmallow.fields.Bool()
 
 
-class ProvisionerInventoryLinksSchema(base.Base):
+class ProvisionerInventoryLinksSchema(base.BaseUnknown):
     host_vars = marshmallow.fields.Str()
     group_vars = marshmallow.fields.Str()
 
 
-class ProvisionerInventorySchema(base.Base):
+class ProvisionerInventorySchema(base.BaseUnknown):
     host_vars = marshmallow.fields.Dict()
     group_vars = marshmallow.fields.Dict()
     links = marshmallow.fields.Nested(ProvisionerInventoryLinksSchema())
 
 
-class PlaybooksSchema(base.Base):
+class PlaybooksSchema(base.BaseUnknown):
     create = marshmallow.fields.Str()
     converge = marshmallow.fields.Str()
     destroy = marshmallow.fields.Str()
@@ -132,9 +132,14 @@ class ProvisionerPlaybooksSchema(PlaybooksSchema):
     vagrant = marshmallow.fields.Nested(PlaybooksSchema())
 
 
-class ProvisionerSchema(base.Base):
+class ProvisionerConfigOptionsSchema(base.BaseDisallowed):
+    defaults = marshmallow.fields.Dict()
+
+
+class ProvisionerSchema(base.BaseUnknown):
     name = marshmallow.fields.Str()
-    config_options = marshmallow.fields.Dict()
+    config_options = marshmallow.fields.Nested(
+        ProvisionerConfigOptionsSchema())
     connection_options = marshmallow.fields.Dict()
     options = marshmallow.fields.Dict()
     env = marshmallow.fields.Dict()
@@ -144,7 +149,7 @@ class ProvisionerSchema(base.Base):
     lint = marshmallow.fields.Nested(LintSchema())
 
 
-class ScenarioSchema(base.Base):
+class ScenarioSchema(base.BaseUnknown):
     name = marshmallow.fields.Str()
     check_sequence = marshmallow.fields.List(marshmallow.fields.Str())
     converge_sequence = marshmallow.fields.List(marshmallow.fields.Str())
@@ -153,7 +158,7 @@ class ScenarioSchema(base.Base):
     test_sequence = marshmallow.fields.List(marshmallow.fields.Str())
 
 
-class VerifierSchema(base.Base):
+class VerifierSchema(base.BaseUnknown):
     name = marshmallow.fields.Str()
     enabled = marshmallow.fields.Bool()
     directory = marshmallow.fields.Str()
@@ -164,7 +169,7 @@ class VerifierSchema(base.Base):
     lint = marshmallow.fields.Nested(LintSchema())
 
 
-class MoleculeBaseSchema(base.Base):
+class MoleculeBaseSchema(base.BaseUnknown):
     dependency = marshmallow.fields.Nested(DependencySchema())
     driver = marshmallow.fields.Nested(DriverSchema())
     lint = marshmallow.fields.Nested(LintSchema())

--- a/molecule/model/schema_v1.py
+++ b/molecule/model/schema_v1.py
@@ -26,7 +26,7 @@ from molecule.model import base
 LOG = logger.get_logger(__name__)
 
 
-class AnsibleSchema(base.Base):
+class AnsibleSchema(base.BaseUnknown):
     config_file = marshmallow.fields.Str()
     playbook = marshmallow.fields.Str()
     raw_env_vars = marshmallow.fields.Dict()
@@ -36,40 +36,40 @@ class AnsibleSchema(base.Base):
     tags = marshmallow.fields.Str()
 
 
-class DriverSchema(base.Base):
+class DriverSchema(base.BaseUnknown):
     name = marshmallow.fields.Str()
 
 
-class PlatformSchema(base.Base):
+class PlatformSchema(base.BaseUnknown):
     name = marshmallow.fields.Str()
     box = marshmallow.fields.Str()
     box_version = marshmallow.fields.Str()
     box_url = marshmallow.fields.Str()
 
 
-class ProviderOptionsSchema(base.Base):
+class ProviderOptionsSchema(base.BaseUnknown):
     memory = marshmallow.fields.Int()
     cpus = marshmallow.fields.Int()
 
 
-class ProviderSchema(base.Base):
+class ProviderSchema(base.BaseUnknown):
     name = marshmallow.fields.Str()
     type = marshmallow.fields.Str()
     options = marshmallow.fields.Nested(ProviderOptionsSchema())
 
 
-class InterfaceSchema(base.Base):
+class InterfaceSchema(base.BaseUnknown):
     network_name = marshmallow.fields.Str()
     type = marshmallow.fields.Str()
     auto_config = marshmallow.fields.Bool()
     ip = marshmallow.fields.Str()
 
 
-class InstanceOptionsSchema(base.Base):
+class InstanceOptionsSchema(base.BaseUnknown):
     append_platform_to_hostname = marshmallow.fields.Bool()
 
 
-class InstanceSchema(base.Base):
+class InstanceSchema(base.BaseUnknown):
     name = marshmallow.fields.Str()
     ansible_groups = marshmallow.fields.List(marshmallow.fields.Str())
     interfaces = marshmallow.fields.List(
@@ -78,7 +78,7 @@ class InstanceSchema(base.Base):
     options = marshmallow.fields.Nested(InstanceOptionsSchema())
 
 
-class VagrantSchema(base.Base):
+class VagrantSchema(base.BaseUnknown):
     platforms = marshmallow.fields.List(
         marshmallow.fields.Nested(PlatformSchema()))
     providers = marshmallow.fields.List(
@@ -87,11 +87,11 @@ class VagrantSchema(base.Base):
         marshmallow.fields.Nested(InstanceSchema()))
 
 
-class VerifierOptionsSchema(base.Base):
+class VerifierOptionsSchema(base.BaseUnknown):
     sudo = marshmallow.fields.Bool()
 
 
-class VerifierSchema(base.Base):
+class VerifierSchema(base.BaseUnknown):
     name = marshmallow.fields.Str()
     options = marshmallow.fields.Nested(VerifierOptionsSchema())
 

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -108,6 +108,7 @@ def molecule_provisioner_section_data():
             'lint': {
                 'name': 'ansible-lint',
             },
+            'config_options': {},
         },
     }
 

--- a/test/unit/model/test_schema.py
+++ b/test/unit/model/test_schema.py
@@ -53,10 +53,22 @@ def test_validate_raises_on_invalid_field(config):
     assert 'Not a valid string.' in str(e)
 
 
-#  def validate(c):
-#      if c['driver']['name'] == 'vagrant':
-#          schema = MoleculeVagrantSchema(strict=True)
-#      else:
-#          schema = MoleculeSchema(strict=True)
+def test_validate_raises_on_disallowed_field(config):
+    disallowed_options = [
+        {
+            'roles_path': '/path/to/roles'
+        },
+        {
+            'library': '/path/to/library'
+        },
+        {
+            'filter_plugins': '/path/to/filter_plugins'
+        },
+    ]
+    for option in disallowed_options:
+        config['provisioner']['config_options']['defaults'] = option
 
-#      return schema.load(c)
+        with pytest.raises(marshmallow.ValidationError) as e:
+            schema.validate(config)
+
+        assert 'Disallowed user provided config option' in str(e)


### PR DESCRIPTION
Validate provisioner ansible config options which interfere
with other parts of Molecule.

Currently, disallowing the following options from being specified
in Molecule's ansible.cfg.

    roles_path
    library
    filter_plugins

Fixes: #1039