### PR TITLE
Disallow privilege_escalation via schema

### DIFF
--- a/molecule/model/base.py
+++ b/molecule/model/base.py
@@ -42,3 +42,9 @@ class BaseDisallowed(marshmallow.Schema):
             if any(disallowed in defaults for disallowed in disallowed_list):
                 raise marshmallow.ValidationError(
                     'Disallowed user provided config option', defaults)
+
+        privilege_escalation = data.get('privilege_escalation')
+        if privilege_escalation:
+            raise marshmallow.ValidationError(
+                'Disallowed user provided config option',
+                'privilege_escalation')

--- a/molecule/model/schema.py
+++ b/molecule/model/schema.py
@@ -134,6 +134,7 @@ class ProvisionerPlaybooksSchema(PlaybooksSchema):
 
 class ProvisionerConfigOptionsSchema(base.BaseDisallowed):
     defaults = marshmallow.fields.Dict()
+    privilege_escalation = marshmallow.fields.Dict()
 
 
 class ProvisionerSchema(base.BaseUnknown):

--- a/test/unit/model/test_schema.py
+++ b/test/unit/model/test_schema.py
@@ -56,17 +56,20 @@ def test_validate_raises_on_invalid_field(config):
 def test_validate_raises_on_disallowed_field(config):
     disallowed_options = [
         {
-            'roles_path': '/path/to/roles'
+            'defaults': { 'roles_path': '/path/to/roles' }
         },
         {
-            'library': '/path/to/library'
+            'defaults': { 'library': '/path/to/library' }
         },
         {
-            'filter_plugins': '/path/to/filter_plugins'
+            'defaults': { 'filter_plugins': '/path/to/filter_plugins' }
+        },
+        {
+            'privilege_escalation': { 'foo': 'bar' }
         },
     ]
-    for option in disallowed_options:
-        config['provisioner']['config_options']['defaults'] = option
+    for options in disallowed_options:
+        config['provisioner']['config_options'] = options
 
         with pytest.raises(marshmallow.ValidationError) as e:
             schema.validate(config)

--- a/test/unit/provisioner/test_ansible.py
+++ b/test/unit/provisioner/test_ansible.py
@@ -874,27 +874,6 @@ def test_sanitize_env(mocker, ansible_instance, patched_logger_warn):
     assert x == patched_logger_warn.mock_calls
 
 
-def test_sanitize_config_options(mocker, ansible_instance,
-                                 patched_logger_warn):
-    options = {
-        'privilege_escalation': {
-            'become_user': 'root',
-            'become': True,
-            'become_method': 'sudo'
-        },
-        'foo': 'bar',
-    }
-
-    x = {
-        'foo': 'bar',
-    }
-    assert x == ansible_instance._sanitize_config_options(options)
-
-    msg = "Disallowed user provided config option '{}'.  Removing.".format(
-        'privilege_escalation')
-    patched_logger_warn.assert_called_once_with(msg)
-
-
 def test_absolute_path_for(ansible_instance):
     env = {'foo': 'foo:bar'}
     x = ':'.join([


### PR DESCRIPTION
Perform the validation through the schema instead of the provisioner.