### PR TITLE
Corrected ability to set multiple x options

### DIFF
--- a/molecule/provisioner/lint/ansible_lint.py
+++ b/molecule/provisioner/lint/ansible_lint.py
@@ -121,11 +121,11 @@ class AnsibleLint(base.Base):
         x_list = options.pop('x')
 
         exclude_args = ['--exclude={}'.format(exclude) for exclude in excludes]
-        x_args = ['-x={}'.format(x) for x in x_list]
+        x_args = tuple(('-x', x) for x in x_list)
         self._ansible_lint_command = sh.ansible_lint.bake(
             options,
             exclude_args,
-            x_args,
+            sum(x_args, ()),
             self._config.provisioner.playbooks.converge,
             _env=self.env,
             _out=LOG.out,

--- a/test/unit/model/test_schema.py
+++ b/test/unit/model/test_schema.py
@@ -56,16 +56,24 @@ def test_validate_raises_on_invalid_field(config):
 def test_validate_raises_on_disallowed_field(config):
     disallowed_options = [
         {
-            'defaults': { 'roles_path': '/path/to/roles' }
+            'defaults': {
+                'roles_path': '/path/to/roles'
+            }
         },
         {
-            'defaults': { 'library': '/path/to/library' }
+            'defaults': {
+                'library': '/path/to/library'
+            }
         },
         {
-            'defaults': { 'filter_plugins': '/path/to/filter_plugins' }
+            'defaults': {
+                'filter_plugins': '/path/to/filter_plugins'
+            }
         },
         {
-            'privilege_escalation': { 'foo': 'bar' }
+            'privilege_escalation': {
+                'foo': 'bar'
+            }
         },
     ]
     for options in disallowed_options:

--- a/test/unit/provisioner/lint/test_ansible_lint.py
+++ b/test/unit/provisioner/lint/test_ansible_lint.py
@@ -148,13 +148,15 @@ def test_bake(ansible_lint_instance):
         str(sh.ansible_lint),
         '--foo=bar',
         '-v',
+        '-x',
+        '-x',
         '--exclude={}'.format(
             ansible_lint_instance._config.scenario.ephemeral_directory),
         '--exclude=foo',
         '--exclude=bar',
         ansible_lint_instance._config.provisioner.playbooks.converge,
-        '-x=foo',
-        '-x=bar',
+        'bar',
+        'foo',
     ]
     result = str(ansible_lint_instance._ansible_lint_command).split()
 


### PR DESCRIPTION
The sh module required short commands to be passed
as a tuple not a list.

Fixes: #933