### PR TITLE
Ignore psutil on cygwin platform

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ Jinja2==2.9.6
 marshmallow==2.13.5
 pbr==3.0.1
 pexpect==4.2.1
-psutil==5.2.2; sys_platform!="win32"
+psutil==5.2.2; sys_platform!="win32" and sys_platform!="cygwin"
 PyYAML==3.12
 sh==1.12.14
 tabulate==0.7.7


### PR DESCRIPTION
Omit installation of psutil on cygwin, where it does not exist

Fixes Issue #1069



