### PR TITLE
Vagrant provider - Add basic support for libvirt

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -118,6 +118,7 @@ Supported Providers:
 * VirtualBox (default)
 * VMware (vmware_fusion, vmware_workstation and vmware_desktop)
 * Parallels
+* Libvirt (requires vagrant-libvirt plugin)
 
 Create instances.
 

--- a/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
+++ b/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
@@ -249,6 +249,32 @@ Vagrant.configure('2') do |config|
         end
       end
     end
+
+    ##
+    # Libvirt
+    ##
+    if provider['name'] == 'libvirt'
+      config.vm.provider provider['name'] do |libvirt|
+        libvirt.memory = provider['options']['memory']
+        libvirt.cpus = provider['options']['cpus']
+
+        # Custom
+        if provider['options']
+          provider['options'].each { |key, value|
+            if key != 'memory' and key != 'cpus'
+              eval("libvirt.#{key} = #{value}")
+            end
+          }
+        end
+
+        # Raw Configuration
+        if provider['raw_config_args']
+          provider['raw_config_args'].each { |raw_config_arg|
+            eval("libvirt.#{raw_config_arg}")
+          }
+        end
+      end
+    end
   end
 
   ##


### PR DESCRIPTION
This was pretty much a copy/paste from the parallels block above, I was considering appending to the
parallels section and adding an `if provider == parallels or provider == libvirt` but seems like the
original design wanted them intentionally separated for future provider specific functionality calls.

Let me know if you want me to back-pedal and do that instead.