### PR TITLE
Moved prune to run after destroy

### DIFF
--- a/molecule/command/destroy.py
+++ b/molecule/command/destroy.py
@@ -59,7 +59,6 @@ class Destroy(base.Base):
         :return: None
         """
         self.print_info()
-        self.prune()
 
         if self._config.command_args.get('destroy') == 'never':
             msg = "Skipping, '--destroy=never' requested."
@@ -73,6 +72,7 @@ class Destroy(base.Base):
 
         self._config.provisioner.destroy()
         self._config.state.reset()
+        self.prune()
 
 
 @click.command()

--- a/test/unit/command/test_destroy.py
+++ b/test/unit/command/test_destroy.py
@@ -32,11 +32,11 @@ def test_execute(mocker, patched_destroy_prune, patched_logger_info,
     ]
     assert x == patched_logger_info.mock_calls
 
-    patched_destroy_prune.assert_called_once_with()
     patched_ansible_destroy.assert_called_once_with()
 
     assert not config_instance.state.converged
     assert not config_instance.state.created
+    patched_destroy_prune.assert_called_once_with()
 
 
 def test_execute_skips_when_destroy_strategy_is_never(


### PR DESCRIPTION
Prune should not run before destroy, should run after destroy
was successful.

Fixes: #1124