### PR TITLE
Reduce create time with vagrant

### DIFF
--- a/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
+++ b/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
@@ -153,7 +153,7 @@ Vagrant.configure('2') do |config|
   if vagrant_config['provider']
     provider = vagrant_config['provider']
 
-    #Boot time optimization
+    # Boot time optimization
     if provider['options']
       if provider['options']['synced_folder']
         config.vm.synced_folder provider['options']['synced_folder']

--- a/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
+++ b/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
@@ -160,11 +160,13 @@ Vagrant.configure('2') do |config|
       else
         config.vm.synced_folder ".", "/vagrant", disabled: true
       end
+
       if provider['options']['ssh_insert_key']
         config.ssh.insert_key = provider['options']['ssh_insert_key']
       else
         config.ssh.insert_key = false
       end
+
     else
       config.vm.synced_folder ".", "/vagrant", disabled: true
       config.ssh.insert_key = false

--- a/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
+++ b/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
@@ -153,6 +153,23 @@ Vagrant.configure('2') do |config|
   if vagrant_config['provider']
     provider = vagrant_config['provider']
 
+    #Boot time optimization
+    if provider['options']
+      if provider['options']['synced_folder']
+        config.vm.synced_folder provider['options']['synced_folder']
+      else
+        config.vm.synced_folder ".", "/vagrant", disabled: true
+      end
+      if provider['options']['ssh_insert_key']
+        config.ssh.insert_key = provider['options']['ssh_insert_key']
+      else
+        config.ssh.insert_key = false
+      end
+    else
+      config.vm.synced_folder ".", "/vagrant", disabled: true
+      config.ssh.insert_key = false
+    end
+
     ##
     # Virtualbox
     ##


### PR DESCRIPTION
vagrant up time before : 25s
vagrant up time after : 19s

I gained 6-7 seconds in the create step disabling these options : 
by default vagrant recreate a ssh key, but we are in developpement envirronment and we don't care about security of temporary VM
by default vagrant copy .molecule direcory to /vagrant on the VM, this directory is not needed

ssh key renewing : 5-6s
rsync to /vagrant : 1s