### PR TITLE
Allow Vagrant to automatically insert a keypair

### DIFF
--- a/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
+++ b/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
@@ -164,7 +164,7 @@ Vagrant.configure('2') do |config|
       if provider['options']['ssh_insert_key']
         config.ssh.insert_key = provider['options']['ssh_insert_key']
       else
-        config.ssh.insert_key = false
+        config.ssh.insert_key = true
       end
     else
       config.vm.synced_folder ".", "/vagrant", disabled: true


### PR DESCRIPTION
Issue #1147 introduced an issue where `vagrant ssh-config` does
not return `IdentityFile` for some users.  This PR changes Molecule
back to Vagrant's default of 'true'.  Where `true` means the following:

> config.ssh.insert_key - If true, Vagrant will automatically insert a
  keypair to use for SSH, replacing Vagrant's default insecure key inside
  the machine if detected. By default, this is true.

Fixes: #1161