### PR TITLE
Properly skipping Vagrant speedup keys in provider

### DIFF
--- a/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
+++ b/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
@@ -162,13 +162,13 @@ Vagrant.configure('2') do |config|
       end
 
       if provider['options']['ssh_insert_key']
-        config.ssh.insert_key = provider['options']['ssh_insert_key']
-      else
         config.ssh.insert_key = true
+      else
+        config.ssh.insert_key = false
       end
     else
       config.vm.synced_folder ".", "/vagrant", disabled: true
-      config.ssh.insert_key = false
+      config.ssh.insert_key = true
     end
 
     ##
@@ -179,7 +179,7 @@ Vagrant.configure('2') do |config|
         virtualbox.memory = provider['options']['memory']
         virtualbox.cpus = provider['options']['cpus']
 
-        if provider['options'] and provider['options']['linked_clone']
+        if provider['options'] && provider['options']['linked_clone']
           if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('1.8.0')
             virtualbox.linked_clone = provider['options']['linked_clone']
           end
@@ -192,7 +192,7 @@ Vagrant.configure('2') do |config|
         # Custom
         if provider['options']
           provider['options'].each { |key, value|
-            if key != 'memory' and key != 'cpus' and key != 'linked_clone' and key != 'ssh_insert_key'
+            if key != 'memory' && key != 'cpus' && key != 'linked_clone' && key != 'ssh_insert_key' && key != 'synced_folder'
               eval("virtualbox.#{key} = #{value}")
             end
           }
@@ -227,7 +227,7 @@ Vagrant.configure('2') do |config|
         # Custom
         if provider['options']
           provider['options'].each { |key, value|
-            if key != 'memory' and key != 'cpus'
+            if key != 'memory' && key != 'cpus' && key != 'ssh_insert_key' && key != 'synced_folder'
               eval("vmware.#{key} = #{value}")
             end
           }
@@ -253,7 +253,7 @@ Vagrant.configure('2') do |config|
         # Custom
         if provider['options']
           provider['options'].each { |key, value|
-            if key != 'memory' and key != 'cpus'
+            if key != 'memory' && key != 'cpus' && key != 'ssh_insert_key' && key != 'synced_folder'
               eval("parallels.#{key} = #{value}")
             end
           }
@@ -279,7 +279,7 @@ Vagrant.configure('2') do |config|
         # Custom
         if provider['options']
           provider['options'].each { |key, value|
-            if key != 'memory' and key != 'cpus'
+            if key != 'memory' && key != 'cpus' && key != 'ssh_insert_key' && key != 'synced_folder'
               eval("libvirt.#{key} = #{value}")
             end
           }


### PR DESCRIPTION
PR #1168 skipped `ssh_insert_key` key in the Virtualbox provider.
However, it missed skipping in remaining providers.

* Skipping `synced_folder` key across all providers due to issue
  introduced by #1147.
* Skipping `ssh_insert_key` across missing providers.
* Updated the Pythonic Vagrantfile to a little more ruby like by
  changing `and` to `&&`.
* Corrected numbskull change made in #1172.  Didn't actually fix
   until now.

https://stackoverflow.com/questions/1426826/difference-between-and-and-in-ruby

> and is the same as && but with lower precedence. They both use
  short-circuit evaluation.

> WARNING: and even has lower precedence than = so you'll want to avoid
  and always