### PR TITLE
Correct Vagrant to automatically insert a keypair

### DIFF
--- a/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
+++ b/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
@@ -161,14 +161,13 @@ Vagrant.configure('2') do |config|
         config.vm.synced_folder ".", "/vagrant", disabled: true
       end
 
-      if provider['options']['ssh_insert_key']
-        config.ssh.insert_key = true
+      if provider['options'].has_key?('ssh_insert_key')
+        config.ssh.insert_key = provider['options']['ssh_insert_key']
       else
-        config.ssh.insert_key = false
+        config.ssh.insert_key = true
       end
     else
       config.vm.synced_folder ".", "/vagrant", disabled: true
-      config.ssh.insert_key = true
     end
 
     ##


### PR DESCRIPTION
Had a bug where Vagrant was not injecting the ssh key due to
poor logic on my part.

Fixes: #1161