### PR TITLE
Corrected synced_folders usage

### DIFF
--- a/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
+++ b/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
@@ -156,7 +156,7 @@ Vagrant.configure('2') do |config|
     # Boot time optimization
     if provider['options']
       if provider['options']['synced_folder']
-        config.vm.synced_folder provider['options']['synced_folder']
+        config.vm.synced_folder ".", "/vagrant"
       else
         config.vm.synced_folder ".", "/vagrant", disabled: true
       end
@@ -166,8 +166,6 @@ Vagrant.configure('2') do |config|
       else
         config.ssh.insert_key = true
       end
-    else
-      config.vm.synced_folder ".", "/vagrant", disabled: true
     end
 
     ##


### PR DESCRIPTION
PR #1147 introduced an issue where setting `synced_folder`
in the provider's option passes too many arguments to Vagrant's
`config.vm.synced_folder`.