### PR TITLE
Ability to log into a Docker registry

### DIFF
--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -11,6 +11,18 @@
     molecule_scenario_directory: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}"
     molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
+    - name: Log into a Docker registry
+      docker_login:
+        username: "{{ item.registry.credentials.username }}"
+        password: "{{ item.registry.credentials.passsword }}"
+        email: "{{ item.registry.credentials.email | default(omit) }}"
+        registry: "{{ item.registry.url }}"
+      with_items: "{{ molecule_yml.platforms }}"
+      when:
+        - item.registry is defined
+        - item.registry.credentials is defined
+        - item.registry.credentials.username is defined
+
     - name: Create Dockerfiles from image names
       template:
         src: "{{ molecule_scenario_directory }}/Dockerfile.j2"

--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -48,6 +48,10 @@ class Docker(base.Base):
             image: image_name:tag
             registry:
               url: registry.example.com
+              credentials:
+                username: $USERNAME
+                passsword: $PASSWORD
+                email: user@example.com
             command: sleep infinity
             privileged: "{{ item.privileged | default(omit) }}"
             volumes:

--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -9,6 +9,18 @@
     molecule_ephemeral_directory: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}"
     molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
+    - name: Log into a Docker registry
+      docker_login:
+        username: "{{ item.registry.credentials.username }}"
+        password: "{{ item.registry.credentials.passsword }}"
+        email: "{{ item.registry.credentials.email | default(omit) }}"
+        registry: "{{ item.registry.url }}"
+      with_items: "{{ molecule_yml.platforms }}"
+      when:
+        - item.registry is defined
+        - item.registry.credentials is defined
+        - item.registry.credentials.username is defined
+
     - name: Create Dockerfiles from image names
       template:
         src: Dockerfile.j2


### PR DESCRIPTION
Use the `docker_login` Ansible module to log into a Docker
registry when molecule.yml configured to do so.

!!! This can be dangerous.  Don't be a knucklehead and check
!!! your username/password in.

Fixes: #1144