### PR TITLE
Forward port Molecule v1 shell dependency manager

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -31,6 +31,12 @@ Gilt
 .. autoclass:: molecule.dependency.gilt.Gilt()
    :undoc-members:
 
+Shell
+^^^^^
+
+.. autoclass:: molecule.dependency.shell.Shell()
+   :undoc-members:
+
 Driver
 ------
 

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -30,6 +30,7 @@ from molecule import state
 from molecule import util
 from molecule.dependency import ansible_galaxy
 from molecule.dependency import gilt
+from molecule.dependency import shell
 from molecule.driver import azure
 from molecule.driver import delegated
 from molecule.driver import docker
@@ -91,6 +92,10 @@ class Config(object):
         self.config = self._combine()
         self._action = None
 
+        self.config['dependency']['command'] = self.dependency.command
+
+        schema.validate(self.config)
+
     @property
     def debug(self):
         return self.args.get('debug', False)
@@ -122,6 +127,8 @@ class Config(object):
             return ansible_galaxy.AnsibleGalaxy(self)
         elif dependency_name == 'gilt':
             return gilt.Gilt(self)
+        elif dependency_name == 'shell':
+            return shell.Shell(self)
         else:
             util.exit_with_invalid_section('dependency', dependency_name)
 
@@ -262,14 +269,13 @@ class Config(object):
                        '{}\n{}'.format(self.molecule_file, e.place, e.string))
                 util.sysexit_with_message(msg)
 
-        schema.validate(base)
-
         return base
 
     def _get_defaults(self):
         return {
             'dependency': {
                 'name': 'galaxy',
+                'command': None,
                 'enabled': True,
                 'options': {},
                 'env': {},

--- a/molecule/model/schema.py
+++ b/molecule/model/schema.py
@@ -31,6 +31,7 @@ class DependencySchema(base.BaseUnknown):
     enabled = marshmallow.fields.Bool()
     options = marshmallow.fields.Dict()
     env = marshmallow.fields.Dict()
+    command = marshmallow.fields.Str()
 
 
 class DriverProviderSchema(base.BaseUnknown):

--- a/test/functional/test_command.py
+++ b/test/functional/test_command.py
@@ -183,6 +183,33 @@ def test_command_dependency_gilt(scenario_to_test, with_scenario,
 
 
 @pytest.mark.parametrize(
+    'scenario_to_test, driver_name, scenario_name', [
+        ('dependency', 'azure', 'shell'),
+        ('dependency', 'docker', 'shell'),
+        ('dependency', 'ec2', 'shell'),
+        ('dependency', 'gce', 'shell'),
+        ('dependency', 'lxc', 'shell'),
+        ('dependency', 'lxd', 'shell'),
+        ('dependency', 'openstack', 'shell'),
+        ('dependency', 'vagrant', 'shell'),
+    ],
+    indirect=[
+        'scenario_to_test',
+        'driver_name',
+        'scenario_name',
+    ])
+def test_command_dependency_shell(scenario_to_test, with_scenario,
+                                  scenario_name):
+    options = {'scenario_name': scenario_name}
+    cmd = sh.molecule.bake('dependency', **options)
+    pytest.helpers.run_command(cmd)
+
+    dependency_role = os.path.join('molecule', 'shell', '.molecule', 'roles',
+                                   'yatesr.timezone')
+    assert os.path.isdir(dependency_role)
+
+
+@pytest.mark.parametrize(
     'scenario_to_test, driver_name, scenario_name',
     [
         ('driver/azure', 'azure', 'default'),

--- a/test/scenarios/dependency/molecule/shell/molecule.yml
+++ b/test/scenarios/dependency/molecule/shell/molecule.yml
@@ -1,0 +1,26 @@
+---
+dependency:
+  name: shell
+  command: ./run.bash
+driver:
+  name: docker
+lint:
+  name: yamllint
+  options:
+    config-file: ../../resources/.yamllint
+platforms:
+  - name: instance
+    image: centos:latest
+provisioner:
+  name: ansible
+  playbooks:
+    create: ../../../../resources/playbooks/docker/create.yml
+    destroy: ../../../../resources/playbooks/docker/destroy.yml
+  lint:
+    name: ansible-lint
+scenario:
+  name: shell
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/test/scenarios/dependency/molecule/shell/playbook.yml
+++ b/test/scenarios/dependency/molecule/shell/playbook.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - yatesr.timezone

--- a/test/scenarios/dependency/molecule/shell/prepare.yml
+++ b/test/scenarios/dependency/molecule/shell/prepare.yml
@@ -1,0 +1,5 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  tasks: []

--- a/test/scenarios/dependency/run.bash
+++ b/test/scenarios/dependency/run.bash
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+ansible-galaxy install \
+	-vvv \
+	--force \
+	--roles-path ${MOLECULE_EPHEMERAL_DIRECTORY}/roles/ \
+	yatesr.timezone
+
+
+exit 0

--- a/test/scenarios/driver/vagrant/molecule/multi-node/molecule.yml
+++ b/test/scenarios/driver/vagrant/molecule/multi-node/molecule.yml
@@ -22,7 +22,7 @@ platforms:
     memory: 1024
     cpus: 1
     config_options:
-      synced_folder: True
+      synced_folder: true
   - name: instance-2
     box: centos/7
     interfaces:
@@ -48,6 +48,6 @@ scenario:
 verifier:
   name: testinfra
   options:
-    sudo: True
+    sudo: true
   lint:
     name: flake8

--- a/test/unit/dependency/test_ansible_galaxy.py
+++ b/test/unit/dependency/test_ansible_galaxy.py
@@ -125,7 +125,7 @@ def test_bake(ansible_galaxy_instance, role_file, roles_path):
         str(sh.ansible_galaxy), 'install', '--role-file={}'.format(role_file),
         '--roles-path={}'.format(roles_path), '--force', '--foo=bar', '-vvv'
     ]
-    result = str(ansible_galaxy_instance._ansible_galaxy_command).split()
+    result = str(ansible_galaxy_instance._sh_command).split()
 
     assert sorted(x) == sorted(result)
 
@@ -133,7 +133,7 @@ def test_bake(ansible_galaxy_instance, role_file, roles_path):
 def test_execute(patched_run_command,
                  patched_ansible_galaxy_has_requirements_file,
                  patched_logger_success, ansible_galaxy_instance):
-    ansible_galaxy_instance._ansible_galaxy_command = 'patched-command'
+    ansible_galaxy_instance._sh_command = 'patched-command'
     ansible_galaxy_instance.execute()
 
     role_directory = os.path.join(
@@ -174,7 +174,7 @@ def test_execute_bakes(patched_run_command, ansible_galaxy_instance, role_file,
                        patched_ansible_galaxy_has_requirements_file,
                        roles_path):
     ansible_galaxy_instance.execute()
-    assert ansible_galaxy_instance._ansible_galaxy_command is not None
+    assert ansible_galaxy_instance._sh_command is not None
 
     assert 1 == patched_run_command.call_count
 
@@ -199,6 +199,10 @@ def test_setup(ansible_galaxy_instance):
     ansible_galaxy_instance._setup()
 
     assert os.path.isdir(role_directory)
+
+
+def test_role_file(role_file, ansible_galaxy_instance):
+    assert role_file == ansible_galaxy_instance._role_file()
 
 
 def test_has_requirements_file(ansible_galaxy_instance):

--- a/test/unit/dependency/test_gilt.py
+++ b/test/unit/dependency/test_gilt.py
@@ -102,14 +102,14 @@ def test_bake(gilt_config, gilt_instance):
     x = [
         str(sh.gilt), '--foo=bar', '--config={}'.format(gilt_config), 'overlay'
     ]
-    result = str(gilt_instance._gilt_command).split()
+    result = str(gilt_instance._sh_command).split()
 
     assert sorted(x) == sorted(result)
 
 
 def test_execute(patched_run_command, patched_gilt_has_requirements_file,
                  patched_logger_success, gilt_instance):
-    gilt_instance._gilt_command = 'patched-command'
+    gilt_instance._sh_command = 'patched-command'
     gilt_instance.execute()
 
     patched_run_command.assert_called_once_with('patched-command', debug=False)
@@ -144,7 +144,7 @@ def test_execute_does_not_execute_when_no_requirements_file(
 def test_execute_bakes(patched_run_command, gilt_config,
                        patched_gilt_has_requirements_file, gilt_instance):
     gilt_instance.execute()
-    assert gilt_instance._gilt_command is not None
+    assert gilt_instance._sh_command is not None
 
     assert 1 == patched_run_command.call_count
 
@@ -152,12 +152,15 @@ def test_execute_bakes(patched_run_command, gilt_config,
 def test_executes_catches_and_exits_return_code(
         patched_run_command, patched_gilt_has_requirements_file,
         gilt_instance):
-    patched_run_command.side_effect = sh.ErrorReturnCode_1(
-        sh.ansible_galaxy, b'', b'')
+    patched_run_command.side_effect = sh.ErrorReturnCode_1(sh.gilt, b'', b'')
     with pytest.raises(SystemExit) as e:
         gilt_instance.execute()
 
     assert 1 == e.value.code
+
+
+def test_config_file(gilt_instance, gilt_config):
+    assert gilt_config == gilt_instance._config_file()
 
 
 def test_has_requirements_file(gilt_instance):

--- a/test/unit/dependency/test_shell.py
+++ b/test/unit/dependency/test_shell.py
@@ -1,0 +1,146 @@
+#  Copyright (c) 2015-2017 Cisco Systems, Inc.
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to
+#  deal in the Software without restriction, including without limitation the
+#  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+#  sell copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#  DEALINGS IN THE SOFTWARE.
+
+import pytest
+import sh
+
+from molecule import config
+from molecule.dependency import shell
+
+
+@pytest.fixture
+def molecule_dependency_section_data():
+    return {
+        'dependency': {
+            'name': 'shell',
+            'command': 'ls -l -a /tmp',
+            'options': {
+                'foo': 'bar',
+            },
+            'env': {
+                'foo': 'bar',
+            }
+        }
+    }
+
+
+@pytest.fixture
+def shell_instance(molecule_dependency_section_data, config_instance):
+    config_instance.merge_dicts(config_instance.config,
+                                molecule_dependency_section_data)
+
+    return shell.Shell(config_instance)
+
+
+def test_config_private_member(shell_instance):
+    assert isinstance(shell_instance._config, config.Config)
+
+
+def test_default_options_property(shell_instance):
+    x = {}
+
+    assert x == shell_instance.default_options
+
+
+def test_default_env_property(shell_instance):
+    assert 'MOLECULE_FILE' in shell_instance.default_env
+    assert 'MOLECULE_INVENTORY_FILE' in shell_instance.default_env
+    assert 'MOLECULE_SCENARIO_DIRECTORY' in shell_instance.default_env
+    assert 'MOLECULE_INSTANCE_CONFIG' in shell_instance.default_env
+
+
+def test_name_property(shell_instance):
+    assert 'shell' == shell_instance.name
+
+
+def test_enabled_property(shell_instance):
+    assert shell_instance.enabled
+
+
+def test_options_property(shell_instance):
+    x = {'foo': 'bar'}
+
+    assert x == shell_instance.options
+
+
+def test_options_property_handles_cli_args(shell_instance):
+    shell_instance._config.args = {}
+    x = {'foo': 'bar'}
+
+    assert x == shell_instance.options
+
+
+def test_env_property(shell_instance):
+    assert 'bar' == shell_instance.env['foo']
+
+
+def test_bake(shell_instance):
+    shell_instance.bake()
+
+    x = [
+        str(sh.ls),
+        '-l',
+        '-a',
+        '/tmp',
+    ]
+    result = str(shell_instance._sh_command).split()
+
+    assert sorted(x) == sorted(result)
+
+
+def test_execute(patched_run_command, patched_logger_success, shell_instance):
+    shell_instance._sh_command = 'patched-command'
+    shell_instance.execute()
+
+    patched_run_command.assert_called_once_with('patched-command', debug=False)
+
+    msg = 'Dependency completed successfully.'
+    patched_logger_success.assert_called_once_with(msg)
+
+
+def test_execute_does_not_execute_when_disabled(
+        patched_run_command, patched_logger_warn, shell_instance):
+    shell_instance._config.config['dependency']['enabled'] = False
+    shell_instance.execute()
+
+    assert not patched_run_command.called
+
+    msg = 'Skipping, dependency is disabled.'
+    patched_logger_warn.assert_called_once_with(msg)
+
+
+def test_execute_bakes(patched_run_command, shell_instance):
+    shell_instance.execute()
+    assert shell_instance._sh_command is not None
+
+    assert 1 == patched_run_command.call_count
+
+
+def test_executes_catches_and_exits_return_code(patched_run_command,
+                                                shell_instance):
+    patched_run_command.side_effect = sh.ErrorReturnCode_1(sh.ls, b'', b'')
+    with pytest.raises(SystemExit) as e:
+        shell_instance.execute()
+
+    assert 1 == e.value.code
+
+
+def test_has_command_configured(shell_instance):
+    assert shell_instance._has_command_configured()

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -29,6 +29,7 @@ from molecule import state
 from molecule import util
 from molecule.dependency import ansible_galaxy
 from molecule.dependency import gilt
+from molecule.dependency import shell
 from molecule.driver import azure
 from molecule.driver import delegated
 from molecule.driver import docker
@@ -105,6 +106,23 @@ def test_dependency_property_is_gilt(molecule_dependency_gilt_section_data,
                                 molecule_dependency_gilt_section_data)
 
     assert isinstance(config_instance.dependency, gilt.Gilt)
+
+
+@pytest.fixture
+def molecule_dependency_shell_section_data():
+    return {
+        'dependency': {
+            'name': 'shell'
+        },
+    }
+
+
+def test_dependency_property_is_shell(molecule_dependency_shell_section_data,
+                                      config_instance):
+    config_instance.merge_dicts(config_instance.config,
+                                molecule_dependency_shell_section_data)
+
+    assert isinstance(config_instance.dependency, shell.Shell)
 
 
 @pytest.fixture


### PR DESCRIPTION
Forward ported Molecule's v1 shell dependency manager to v1,
which mostly turned into a rewrite due to the differences between
v1 and v2, but :shussh: who is really looking at this message
anyway.

Fixes: #1182