### PR TITLE
Correct verbose flag options with `--debug`

### DIFF
--- a/molecule/dependency/ansible_galaxy.py
+++ b/molecule/dependency/ansible_galaxy.py
@@ -36,6 +36,12 @@ class AnsibleGalaxy(base.Base):
     Additional options can be passed to `ansible-galaxy install` through the
     options dict.  Any option set in this section will override the defaults.
 
+    .. note::
+
+        Molecule will remove any options matching '^[v]+$', and pass `-vvv`
+        to the underlying `ansible-galaxy` command when executing
+        `molecule --debug`.
+
     .. code-block:: yaml
 
         dependency:
@@ -86,6 +92,17 @@ class AnsibleGalaxy(base.Base):
             d['vvv'] = True
 
         return d
+
+    # NOTE(retr0h): Override the base classes' options() to handle `ansible-galaxy`
+    # one-off.
+    @property
+    def options(self):
+        o = self._config.config['dependency']['options']
+        # NOTE(retr0h): Remove verbose options added by the user while in debug.
+        if self._config.debug:
+            o = util.filter_verbose_permutation(o)
+
+        return util.merge_dicts(self.default_options, o)
 
     @property
     def default_env(self):

--- a/molecule/provisioner/ansible.py
+++ b/molecule/provisioner/ansible.py
@@ -60,6 +60,12 @@ class Ansible(base.Base):
 
         Options do not affect the create and destroy actions.
 
+    .. note::
+
+        Molecule will remove any options matching '^[v]+$', and pass `-vvv`
+        to the underlying `ansible-playbook` command when executing
+        `molecule --debug`.
+
     .. code-block:: yaml
 
         provisioner:
@@ -350,8 +356,13 @@ class Ansible(base.Base):
     def options(self):
         if self._config.action in ['create', 'destroy']:
             return self.default_options
-        return util.merge_dicts(self.default_options,
-                                self._config.config['provisioner']['options'])
+
+        o = self._config.config['provisioner']['options']
+        # NOTE(retr0h): Remove verbose options added by the user while in debug.
+        if self._config.debug:
+            o = util.filter_verbose_permutation(o)
+
+        return util.merge_dicts(self.default_options, o)
 
     @property
     def env(self):

--- a/molecule/util.py
+++ b/molecule/util.py
@@ -231,6 +231,10 @@ def verbose_flag(options):
     return verbose_flag
 
 
+def filter_verbose_permutation(options):
+    return {k: options[k] for k in options if not re.match('^([v]+)$', k)}
+
+
 def title(word):
     return ' '.join(x.capitalize() or '_' for x in word.split('_'))
 

--- a/molecule/verifier/testinfra.py
+++ b/molecule/verifier/testinfra.py
@@ -37,6 +37,11 @@ class Testinfra(base.Base):
     Additional options can be passed to `testinfra` through the options
     dict.  Any option set in this section will override the defaults.
 
+    .. note::
+
+        Molecule will remove any options matching '^[v]+$', and pass `-vvv`
+        to the underlying `py.test` command when executing `molecule --debug`.
+
     .. code-block:: yaml
 
         verifier:
@@ -105,10 +110,22 @@ class Testinfra(base.Base):
         d = self._config.driver.testinfra_options
         if self._config.debug:
             d['debug'] = True
+            d['vvv'] = True
         if self._config.args.get('sudo'):
             d['sudo'] = True
 
         return d
+
+    # NOTE(retr0h): Override the base classes' options() to handle `ansible-galaxy`
+    # one-off.
+    @property
+    def options(self):
+        o = self._config.config['verifier']['options']
+        # NOTE(retr0h): Remove verbose options added by the user while in debug.
+        if self._config.debug:
+            o = util.filter_verbose_permutation(o)
+
+        return util.merge_dicts(self.default_options, o)
 
     @property
     def default_env(self):

--- a/test/unit/dependency/test_ansible_galaxy.py
+++ b/test/unit/dependency/test_ansible_galaxy.py
@@ -43,7 +43,7 @@ def _dependency_section_data():
             'name': 'galaxy',
             'options': {
                 'foo': 'bar',
-                'vvv': True,
+                'v': True,
             },
             'env': {
                 'FOO': 'bar',
@@ -108,7 +108,7 @@ def test_options_property(_instance, role_file, roles_path):
         'role-file': role_file,
         'roles-path': roles_path,
         'foo': 'bar',
-        'vvv': True,
+        'v': True,
     }
 
     assert x == _instance.options
@@ -141,7 +141,7 @@ def test_bake(_instance, role_file, roles_path):
     _instance.bake()
     x = [
         str(sh.ansible_galaxy), 'install', '--role-file={}'.format(role_file),
-        '--roles-path={}'.format(roles_path), '--force', '--foo=bar', '-vvv'
+        '--roles-path={}'.format(roles_path), '--force', '--foo=bar', '-v'
     ]
     result = str(_instance._sh_command).split()
 

--- a/test/unit/provisioner/test_ansible.py
+++ b/test/unit/provisioner/test_ansible.py
@@ -71,6 +71,7 @@ def _provisioner_section_data():
             'options': {
                 'foo': 'bar',
                 'become': True,
+                'v': True,
             },
             'env': {
                 'FOO': 'bar',
@@ -185,7 +186,7 @@ def test_config_options_property(_instance):
 @pytest.mark.parametrize(
     'config_instance', ['_provisioner_section_data'], indirect=True)
 def test_options_property(_instance):
-    x = {'become': True, 'foo': 'bar'}
+    x = {'become': True, 'foo': 'bar', 'v': True}
 
     assert x == _instance.options
 
@@ -199,9 +200,13 @@ def test_options_property_does_not_merge(_instance):
 
 def test_options_property_handles_cli_args(_instance):
     _instance._config.args = {'debug': True}
+    x = {
+        'vvv': True,
+        'become': True,
+        'diff': True,
+    }
 
-    assert _instance.options['vvv']
-    assert _instance.options['diff']
+    assert x == _instance.options
 
 
 @pytest.mark.parametrize(

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -308,6 +308,24 @@ def test_verbose_flag_preserves_verbose_option():
     assert {'verbose': True} == options
 
 
+def test_filter_verbose_permutation():
+    options = {
+        'v': True,
+        'vv': True,
+        'vvv': True,
+        'vfoo': True,
+        'foo': True,
+        'bar': True,
+    }
+
+    x = {
+        'vfoo': True,
+        'foo': True,
+        'bar': True,
+    }
+    assert x == util.filter_verbose_permutation(options)
+
+
 def test_title():
     assert 'Foo' == util.title('foo')
     assert 'Foo Bar' == util.title('foo_bar')

--- a/test/unit/verifier/test_testinfra.py
+++ b/test/unit/verifier/test_testinfra.py
@@ -48,7 +48,7 @@ def _verifier_section_data():
             'testinfra',
             'options': {
                 'foo': 'bar',
-                'vvv': True,
+                'v': True,
                 'verbose': True,
             },
             'additional_files_or_dirs': [
@@ -95,7 +95,8 @@ def test_default_options_property_updates_debug(inventory_file, _instance):
     x = {
         'connection': 'ansible',
         'ansible-inventory': inventory_file,
-        'debug': True
+        'debug': True,
+        'vvv': True,
     }
 
     assert x == _instance.default_options
@@ -204,7 +205,7 @@ def test_options_property(inventory_file, _instance):
         'connection': 'ansible',
         'ansible-inventory': inventory_file,
         'foo': 'bar',
-        'vvv': True,
+        'v': True,
         'verbose': True,
     }
 
@@ -241,7 +242,7 @@ def test_bake(_patched_testinfra_get_tests, inventory_file, _instance):
         str(sh.Command('py.test')),
         '--ansible-inventory={}'.format(inventory_file),
         '--connection=ansible',
-        '-vvv',
+        '-v',
         '--foo=bar',
         'foo.py',
         'bar.py',


### PR DESCRIPTION
The developer can provide additional command line options
the the provisioner (`ansible-playbook`).  If one of the options
is `-v`, Molecule would convert the options incorrectly under debug
mode.

Also corrected the `ansible-galaxy` dependency manager, since it
handles options similarly.

Fixes: #1195