### PR TITLE
Move Molecule playbook vars into host inventory

### DIFF
--- a/molecule/cookiecutter/scenario/driver/azure/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/azure/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -6,10 +6,6 @@
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
-
     resource_group_name: molecule
     location: westus
     ssh_user: molecule

--- a/molecule/cookiecutter/scenario/driver/azure/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/azure/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -6,10 +6,6 @@
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
-
     resource_group_name: molecule
   tasks:
     - name: Destroy molecule instance(s)

--- a/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -5,11 +5,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_ephemeral_directory: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}"
-    molecule_scenario_directory: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     # Developer must implement.
 

--- a/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -5,10 +5,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     # Developer must implement.
 

--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -5,11 +5,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_ephemeral_directory: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}"
-    molecule_scenario_directory: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - name: Log into a Docker registry
       docker_login:

--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -5,9 +5,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - name: Destroy molecule instance(s)
       docker_container:

--- a/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -6,10 +6,6 @@
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
-
     ssh_user: ubuntu
     ssh_port: 22
 

--- a/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -5,10 +5,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - block:
         - name: Populate instance config

--- a/molecule/cookiecutter/scenario/driver/gce/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/gce/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -6,10 +6,6 @@
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
-
     ssh_port: 22
     ssh_user: "{{ lookup('env', 'USER') }}"
     ssh_identity_file: "{{ lookup('env', 'HOME') }}/.ssh/google_compute_engine"

--- a/molecule/cookiecutter/scenario/driver/gce/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/gce/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -5,10 +5,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - name: Destroy molecule instance(s)
       gce:

--- a/molecule/cookiecutter/scenario/driver/lxc/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/lxc/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -5,9 +5,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - name: Create molecule instance(s)
       lxc_container:

--- a/molecule/cookiecutter/scenario/driver/lxc/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/lxc/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -5,9 +5,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - name: Destroy molecule instance(s)
       lxc_container:

--- a/molecule/cookiecutter/scenario/driver/lxd/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/lxd/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -5,9 +5,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - name: Create molecule instance(s)
       lxd_container:

--- a/molecule/cookiecutter/scenario/driver/lxd/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/lxd/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -5,9 +5,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - name: Destroy molecule instance(s)
       lxd_container:

--- a/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -6,10 +6,6 @@
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
-
     ssh_user: cloud-user
     ssh_port: 22
 

--- a/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -5,10 +5,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - name: Destroy molecule instance(s)
       os_server:

--- a/molecule/cookiecutter/scenario/driver/vagrant/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/vagrant/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -5,10 +5,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - name: Create molecule instance(s)
       molecule_vagrant:

--- a/molecule/cookiecutter/scenario/driver/vagrant/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/vagrant/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -5,10 +5,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_instance_config: "{{ lookup('env',' MOLECULE_INSTANCE_CONFIG') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - name: Destroy molecule instance(s)
       molecule_vagrant:

--- a/molecule/provisioner/ansible.py
+++ b/molecule/provisioner/ansible.py
@@ -441,8 +441,23 @@ class Ansible(base.Base):
             for group in platform.get('groups', ['ungrouped']):
                 instance_name = platform['name']
                 connection_options = self.connection_options(instance_name)
+                molecule_vars = {
+                    'molecule_file':
+                    "{{ lookup('env', 'MOLECULE_FILE') }}",
+                    'molecule_ephemeral_directory':
+                    "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}",
+                    'molecule_scenario_directory':
+                    "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}",
+                    'molecule_yml':
+                    "{{ lookup('file', molecule_file) | molecule_from_yaml }}",
+                }
+
+                # All group
                 dd['all']['hosts'][instance_name] = connection_options
+                dd['all']['vars'] = molecule_vars
+                # Named group
                 dd[group]['hosts'][instance_name] = connection_options
+                dd[group]['vars'] = molecule_vars
                 # Ungrouped
                 dd['ungrouped']['vars'] = {}
                 # Children

--- a/test/resources/playbooks/azure/create.yml
+++ b/test/resources/playbooks/azure/create.yml
@@ -5,10 +5,6 @@
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
-
     resource_group_name: molecule
 
     location: westus

--- a/test/resources/playbooks/azure/destroy.yml
+++ b/test/resources/playbooks/azure/destroy.yml
@@ -5,10 +5,6 @@
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
-
     resource_group_name: molecule
   tasks:
     - name: Destroy molecule instance(s)

--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -4,10 +4,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_ephemeral_directory: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - name: Log into a Docker registry
       docker_login:

--- a/test/resources/playbooks/docker/destroy.yml
+++ b/test/resources/playbooks/docker/destroy.yml
@@ -4,9 +4,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - name: Destroy molecule instance(s)
       docker_container:

--- a/test/resources/playbooks/ec2/create.yml
+++ b/test/resources/playbooks/ec2/create.yml
@@ -5,10 +5,6 @@
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
-
     ssh_user: ubuntu
     ssh_port: 22
 

--- a/test/resources/playbooks/ec2/destroy.yml
+++ b/test/resources/playbooks/ec2/destroy.yml
@@ -5,10 +5,6 @@
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
-
     resource_group_name: molecule
   tasks:
     - block:

--- a/test/resources/playbooks/gce/create.yml
+++ b/test/resources/playbooks/gce/create.yml
@@ -5,10 +5,6 @@
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
-
     ssh_port: 22
     ssh_user: "{{ lookup('env', 'USER') }}"
     ssh_identity_file: "{{ lookup('env', 'HOME') }}/.ssh/google_compute_engine"

--- a/test/resources/playbooks/gce/destroy.yml
+++ b/test/resources/playbooks/gce/destroy.yml
@@ -4,10 +4,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - name: Destroy molecule instance(s)
       gce:

--- a/test/resources/playbooks/lxc/create.yml
+++ b/test/resources/playbooks/lxc/create.yml
@@ -4,9 +4,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - name: Create molecule instance(s)
       lxc_container:

--- a/test/resources/playbooks/lxc/destroy.yml
+++ b/test/resources/playbooks/lxc/destroy.yml
@@ -4,9 +4,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - name: Destroy molecule instance(s)
       lxc_container:

--- a/test/resources/playbooks/lxd/create.yml
+++ b/test/resources/playbooks/lxd/create.yml
@@ -4,9 +4,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - name: Create molecule instance(s)
       lxd_container:

--- a/test/resources/playbooks/lxd/destroy.yml
+++ b/test/resources/playbooks/lxd/destroy.yml
@@ -4,9 +4,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - name: Destroy molecule instance(s)
       lxd_container:

--- a/test/resources/playbooks/openstack/create.yml
+++ b/test/resources/playbooks/openstack/create.yml
@@ -5,10 +5,6 @@
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
-
     ssh_user: cloud-user
     ssh_port: 22
 

--- a/test/resources/playbooks/openstack/destroy.yml
+++ b/test/resources/playbooks/openstack/destroy.yml
@@ -4,10 +4,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - name: Destroy molecule instance(s)
       os_server:

--- a/test/resources/playbooks/vagrant/create.yml
+++ b/test/resources/playbooks/vagrant/create.yml
@@ -4,10 +4,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - name: Create molecule instance(s)
       molecule_vagrant:

--- a/test/resources/playbooks/vagrant/destroy.yml
+++ b/test/resources/playbooks/vagrant/destroy.yml
@@ -4,10 +4,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
-    molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
-    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   tasks:
     - name: Destroy molecule instance(s)
       molecule_vagrant:

--- a/test/unit/provisioner/test_ansible.py
+++ b/test/unit/provisioner/test_ansible.py
@@ -290,84 +290,124 @@ def test_links_property(_instance):
 def test_inventory_property(_instance):
     x = {
         'ungrouped': {
-            'vars': {},
-        },
-        'all': {
-            'hosts': {
-                'instance-1': {
-                    'ansible_connection': 'docker',
-                    'foo': 'bar',
-                },
-                'instance-2': {
-                    'ansible_connection': 'docker',
-                    'foo': 'bar',
-                },
-            }
+            'vars': {}
         },
         'bar': {
             'hosts': {
                 'instance-1': {
-                    'ansible_connection': 'docker',
                     'foo': 'bar',
-                },
+                    'ansible_connection': 'docker'
+                }
             },
             'children': {
                 'child1': {
                     'hosts': {
                         'instance-1': {
-                            'ansible_connection': 'docker',
                             'foo': 'bar',
-                        },
+                            'ansible_connection': 'docker'
+                        }
                     }
                 }
+            },
+            'vars': {
+                'molecule_file':
+                "{{ lookup('env', 'MOLECULE_FILE') }}",
+                'molecule_ephemeral_directory':
+                "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}",
+                'molecule_scenario_directory':
+                "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}",
+                'molecule_yml':
+                "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
+            }
+        },
+        'all': {
+            'hosts': {
+                'instance-1': {
+                    'foo': 'bar',
+                    'ansible_connection': 'docker'
+                },
+                'instance-2': {
+                    'foo': 'bar',
+                    'ansible_connection': 'docker'
+                }
+            },
+            'vars': {
+                'molecule_file':
+                "{{ lookup('env', 'MOLECULE_FILE') }}",
+                'molecule_ephemeral_directory':
+                "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}",
+                'molecule_scenario_directory':
+                "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}",
+                'molecule_yml':
+                "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
             }
         },
         'foo': {
             'hosts': {
                 'instance-1': {
-                    'ansible_connection': 'docker',
                     'foo': 'bar',
+                    'ansible_connection': 'docker'
                 },
                 'instance-2': {
-                    'ansible_connection': 'docker',
                     'foo': 'bar',
-                },
+                    'ansible_connection': 'docker'
+                }
             },
             'children': {
                 'child1': {
                     'hosts': {
                         'instance-1': {
-                            'ansible_connection': 'docker',
                             'foo': 'bar',
-                        },
+                            'ansible_connection': 'docker'
+                        }
                     }
                 },
                 'child2': {
                     'hosts': {
                         'instance-2': {
-                            'ansible_connection': 'docker',
                             'foo': 'bar',
-                        },
+                            'ansible_connection': 'docker'
+                        }
                     }
-                },
+                }
+            },
+            'vars': {
+                'molecule_file':
+                "{{ lookup('env', 'MOLECULE_FILE') }}",
+                'molecule_ephemeral_directory':
+                "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}",
+                'molecule_scenario_directory':
+                "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}",
+                'molecule_yml':
+                "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
             }
         },
         'baz': {
             'hosts': {
                 'instance-2': {
-                    'ansible_connection': 'docker',
                     'foo': 'bar',
-                },
+                    'ansible_connection': 'docker'
+                }
             },
             'children': {
                 'child2': {
                     'hosts': {
                         'instance-2': {
-                            'ansible_connection': 'docker',
                             'foo': 'bar',
-                        },
+                            'ansible_connection': 'docker'
+                        }
                     }
-                },
+                }
+            },
+            'vars': {
+                'molecule_file':
+                "{{ lookup('env', 'MOLECULE_FILE') }}",
+                'molecule_ephemeral_directory':
+                "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}",
+                'molecule_scenario_directory':
+                "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}",
+                'molecule_yml':
+                "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
             }
         }
     }
@@ -382,30 +422,40 @@ def test_inventory_property_handles_missing_groups(temp_dir, _instance):
     _instance._config.config['platforms'] = platforms
 
     x = {
-        'all': {
-            'hosts': {
-                'instance-1': {
-                    'ansible_connection': 'docker',
-                    'foo': 'bar',
-                },
-                'instance-2': {
-                    'ansible_connection': 'docker',
-                    'foo': 'bar',
-                },
-            }
-        },
         'ungrouped': {
             'hosts': {
                 'instance-1': {
-                    'ansible_connection': 'docker',
                     'foo': 'bar',
+                    'ansible_connection': 'docker'
                 },
                 'instance-2': {
-                    'ansible_connection': 'docker',
                     'foo': 'bar',
-                },
+                    'ansible_connection': 'docker'
+                }
             },
-            'vars': {},
+            'vars': {}
+        },
+        'all': {
+            'hosts': {
+                'instance-1': {
+                    'foo': 'bar',
+                    'ansible_connection': 'docker'
+                },
+                'instance-2': {
+                    'foo': 'bar',
+                    'ansible_connection': 'docker'
+                }
+            },
+            'vars': {
+                'molecule_file':
+                "{{ lookup('env', 'MOLECULE_FILE') }}",
+                'molecule_ephemeral_directory':
+                "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}",
+                'molecule_scenario_directory':
+                "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}",
+                'molecule_yml':
+                "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
+            }
         }
     }
 
@@ -656,84 +706,124 @@ def test_write_inventory(temp_dir, _instance):
 
     x = {
         'ungrouped': {
-            'vars': {},
-        },
-        'all': {
-            'hosts': {
-                'instance-1': {
-                    'ansible_connection': 'docker',
-                    'foo': 'bar',
-                },
-                'instance-2': {
-                    'ansible_connection': 'docker',
-                    'foo': 'bar',
-                },
-            }
+            'vars': {}
         },
         'bar': {
             'hosts': {
                 'instance-1': {
-                    'ansible_connection': 'docker',
                     'foo': 'bar',
+                    'ansible_connection': 'docker'
                 }
             },
             'children': {
                 'child1': {
                     'hosts': {
                         'instance-1': {
-                            'ansible_connection': 'docker',
-                            'foo': 'bar'
-                        },
+                            'foo': 'bar',
+                            'ansible_connection': 'docker'
+                        }
                     }
                 }
+            },
+            'vars': {
+                'molecule_file':
+                "{{ lookup('env', 'MOLECULE_FILE') }}",
+                'molecule_ephemeral_directory':
+                "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}",
+                'molecule_scenario_directory':
+                "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}",
+                'molecule_yml':
+                "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
+            }
+        },
+        'all': {
+            'hosts': {
+                'instance-1': {
+                    'foo': 'bar',
+                    'ansible_connection': 'docker'
+                },
+                'instance-2': {
+                    'foo': 'bar',
+                    'ansible_connection': 'docker'
+                }
+            },
+            'vars': {
+                'molecule_file':
+                "{{ lookup('env', 'MOLECULE_FILE') }}",
+                'molecule_ephemeral_directory':
+                "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}",
+                'molecule_scenario_directory':
+                "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}",
+                'molecule_yml':
+                "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
             }
         },
         'foo': {
             'hosts': {
                 'instance-1': {
-                    'ansible_connection': 'docker',
                     'foo': 'bar',
+                    'ansible_connection': 'docker'
                 },
                 'instance-2': {
-                    'ansible_connection': 'docker',
                     'foo': 'bar',
-                },
+                    'ansible_connection': 'docker'
+                }
             },
             'children': {
                 'child1': {
                     'hosts': {
                         'instance-1': {
-                            'ansible_connection': 'docker',
-                            'foo': 'bar'
-                        },
+                            'foo': 'bar',
+                            'ansible_connection': 'docker'
+                        }
                     }
                 },
                 'child2': {
                     'hosts': {
                         'instance-2': {
-                            'ansible_connection': 'docker',
-                            'foo': 'bar'
-                        },
+                            'foo': 'bar',
+                            'ansible_connection': 'docker'
+                        }
                     }
-                },
+                }
+            },
+            'vars': {
+                'molecule_file':
+                "{{ lookup('env', 'MOLECULE_FILE') }}",
+                'molecule_ephemeral_directory':
+                "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}",
+                'molecule_scenario_directory':
+                "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}",
+                'molecule_yml':
+                "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
             }
         },
         'baz': {
             'hosts': {
                 'instance-2': {
-                    'ansible_connection': 'docker',
                     'foo': 'bar',
-                },
+                    'ansible_connection': 'docker'
+                }
             },
             'children': {
                 'child2': {
                     'hosts': {
                         'instance-2': {
-                            'ansible_connection': 'docker',
-                            'foo': 'bar'
-                        },
+                            'foo': 'bar',
+                            'ansible_connection': 'docker'
+                        }
                     }
-                },
+                }
+            },
+            'vars': {
+                'molecule_file':
+                "{{ lookup('env', 'MOLECULE_FILE') }}",
+                'molecule_ephemeral_directory':
+                "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}",
+                'molecule_scenario_directory':
+                "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}",
+                'molecule_yml':
+                "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
             }
         }
     }


### PR DESCRIPTION
No need for the user to continually define vars necessary for Molecule
to function inside the respective bootstrap playbooks.  Moved these
vars to Molecule's internal host inventory, and removed from
cookiecutter's templates.