### PR TITLE
yamllint: exclude .venv directory

### DIFF
--- a/molecule/lint/yamllint.py
+++ b/molecule/lint/yamllint.py
@@ -126,10 +126,11 @@ class Yamllint(base.Base):
         :return: list
         """
         excludes = [
-            '.tox',
             '.git',
-            '.vagrant',
             '.molecule',
+            '.tox',
+            '.vagrant',
+            '.venv',
         ]
         generators = [
             util.os_walk(self._config.project_directory, '*.yml', excludes),


### PR DESCRIPTION
.venv is a common directory name when working with virtualenv and
should be excluded.