### PR TITLE
Relaxed schema validation

### DIFF
--- a/molecule/model/schema_v2.py
+++ b/molecule/model/schema_v2.py
@@ -597,7 +597,7 @@ def validate(c):
     else:
         util.merge_dicts(schema, platforms_base_schema)
 
-    v = Validator()
+    v = Validator(allow_unknown=True)
     v.validate(c, schema)
 
     return v.errors

--- a/test/unit/model/v2/test_driver_section.py
+++ b/test/unit/model/v2/test_driver_section.py
@@ -91,7 +91,6 @@ def test_driver_has_errors(_config):
             }],
             'name': ['must be of string type'],
             'provider': [{
-                'foo': ['unknown field'],
                 'name': ['must be of string type'],
             }],
         }]


### PR DESCRIPTION
Allow unknown keys anywhere in the config.  We are still validating
the expected values are what we expect.  However, the user may wish
to configure additional yaml (such as yaml anchors).