### PR TITLE
openstack: set delete_fip = yes for os_server resources

### DIFF
--- a/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -47,6 +47,7 @@
         key_name: "{{ keypair_name }}"
         nics:
           - net-id: "{{ openstack_networks[0]['id'] }}"
+        delete_fip: yes
       register: server
       with_items: "{{ molecule_yml.platforms }}"
       async: 7200

--- a/test/resources/playbooks/delegated/create/openstack.yml
+++ b/test/resources/playbooks/delegated/create/openstack.yml
@@ -36,6 +36,7 @@
     key_name: "{{ openstack.key_name }}"
     nics:
       - net-id: "{{ openstack_networks[0]['id'] }}"
+    delete_fip: yes
   register: server
 
 - name: Persist ssh config

--- a/test/resources/playbooks/openstack/create.yml
+++ b/test/resources/playbooks/openstack/create.yml
@@ -63,6 +63,7 @@
         key_name: "{{ keypair_name }}"
         nics:
           - net-id: "{{ openstack_networks[0]['id'] }}"
+        delete_fip: yes
       register: server
       with_items: "{{ molecule_yml.platforms }}"
       async: 7200


### PR DESCRIPTION
Floating IP associated with created instances will be deleted
along with the instance.