### PR TITLE
Moved temporary files to $TMPDIR

### DIFF
--- a/molecule/config.py
+++ b/molecule/config.py
@@ -119,6 +119,7 @@ class Config(object):
         return molecule_directory(self.project_directory)
 
     @property
+    @util.memoize
     def dependency(self):
         dependency_name = self.config['dependency']['name']
         if dependency_name == 'galaxy':
@@ -129,6 +130,7 @@ class Config(object):
             return shell.Shell(self)
 
     @property
+    @util.memoize
     def driver(self):
         driver_name = self._get_driver_name()
         driver = None
@@ -178,30 +180,36 @@ class Config(object):
         }
 
     @property
+    @util.memoize
     def lint(self):
         lint_name = self.config['lint']['name']
         if lint_name == 'yamllint':
             return yamllint.Yamllint(self)
 
     @property
+    @util.memoize
     def platforms(self):
         return platforms.Platforms(self)
 
     @property
+    @util.memoize
     def provisioner(self):
         provisioner_name = self.config['provisioner']['name']
         if provisioner_name == 'ansible':
             return ansible.Ansible(self)
 
     @property
+    @util.memoize
     def scenario(self):
         return scenario.Scenario(self)
 
     @property
+    @util.memoize
     def state(self):
         return state.State(self)
 
     @property
+    @util.memoize
     def verifier(self):
         verifier_name = self.config['verifier']['name']
         if verifier_name == 'testinfra':
@@ -210,6 +218,7 @@ class Config(object):
             return goss.Goss(self)
 
     @property
+    @util.memoize
     def verifiers(self):
         return molecule_verifiers()
 
@@ -371,10 +380,7 @@ class Config(object):
         # Prior to validation, we must set values.  This allows us to perform
         # validation in one place.  This feels gross.
         self.config['dependency']['command'] = self.dependency.command
-        try:
-            self.config['driver']['name'] = self.driver.name
-        except AttributeError:
-            pass
+        self.config['driver']['name'] = self.driver.name
 
         errors = schema_v2.validate(self.config)
         if errors:

--- a/molecule/provisioner/base.py
+++ b/molecule/provisioner/base.py
@@ -20,6 +20,7 @@
 
 import abc
 
+from molecule import util
 from molecule.provisioner.lint import ansible_lint
 
 
@@ -64,6 +65,7 @@ class Base(object):
         pass
 
     @property
+    @util.memoize
     def lint(self):
         lint_name = self._config.config['provisioner']['lint']['name']
         if lint_name == 'ansible-lint':

--- a/molecule/scenario.py
+++ b/molecule/scenario.py
@@ -19,6 +19,7 @@
 #  DEALINGS IN THE SOFTWARE.
 
 import os
+import tempfile
 
 from molecule import logger
 from molecule import scenarios
@@ -91,7 +92,13 @@ class Scenario(object):
 
     @property
     def ephemeral_directory(self):
-        return ephemeral_directory(self.directory)
+        project_directory = os.path.basename(self.config.project_directory)
+        scenario_name = self.name
+        project_scenario_directory = os.path.join(
+            'molecule', project_directory, scenario_name)
+        path = ephemeral_directory(project_scenario_directory)
+
+        return ephemeral_directory(path)
 
     @property
     def check_sequence(self):
@@ -167,11 +174,11 @@ class Scenario(object):
          :return: None
          """
         if not os.path.isdir(self.ephemeral_directory):
-            os.mkdir(self.ephemeral_directory)
+            os.makedirs(self.ephemeral_directory)
 
 
 def ephemeral_directory(path):
     d = os.getenv('MOLECULE_EPHEMERAL_DIRECTORY')
     if d:
-        return os.path.join(path, d)
-    return os.path.join(path, '.molecule')
+        return os.path.join(tempfile.gettempdir(), d)
+    return os.path.join(tempfile.gettempdir(), path)

--- a/molecule/util.py
+++ b/molecule/util.py
@@ -294,3 +294,17 @@ def merge_dicts(a, b):
     anyconfig.merge(a, b, ac_merge=MERGE_STRATEGY)
 
     return a
+
+
+def memoize(function):
+    memo = {}
+
+    def wrapper(*args, **kwargs):
+        if args not in memo:
+            rv = function(*args, **kwargs)
+            memo[args] = rv
+
+            return rv
+        return memo[args]
+
+    return wrapper

--- a/molecule/verifier/base.py
+++ b/molecule/verifier/base.py
@@ -94,6 +94,7 @@ class Base(object):
                                 self._config.config['verifier']['env'])
 
     @property
+    @util.memoize
     def lint(self):
         lint_name = self._config.config['verifier']['lint']['name']
         if lint_name == 'flake8':

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -436,14 +436,6 @@ def test_validate_exists_when_validation_fails(mocker, patched_logger_critical,
     patched_logger_critical.assert_called_once_with(msg)
 
 
-def test_validate_handles_unknown_driver_name(mocker, config_instance):
-    m = mocker.patch('molecule.config.Config._get_driver_name')
-    m.side_effect = AttributeError()
-
-    config_instance._validate()
-    assert 'docker' == config_instance.config['driver']['name']
-
-
 def test_molecule_directory():
     assert '/foo/bar/molecule' == config.molecule_directory('/foo/bar')
 

--- a/test/unit/test_scenario.py
+++ b/test/unit/test_scenario.py
@@ -20,6 +20,7 @@
 
 import os
 import shutil
+import tempfile
 
 import pytest
 
@@ -51,9 +52,12 @@ def test_directory_property(molecule_scenario_directory_fixture, _instance):
     assert molecule_scenario_directory_fixture == _instance.directory
 
 
-def test_ephemeral_directory_property(molecule_scenario_directory_fixture,
-                                      _instance):
-    x = os.path.join(molecule_scenario_directory_fixture, '.molecule')
+def test_ephemeral_directory_property(_instance):
+    project_directory = os.path.basename(_instance.config.project_directory)
+    scenario_name = _instance.name
+    project_scenario_directory = os.path.join('molecule', project_directory,
+                                              scenario_name)
+    x = os.path.join(tempfile.gettempdir(), project_scenario_directory)
 
     assert x == _instance.ephemeral_directory
 
@@ -161,10 +165,20 @@ def test_setup_creates_ephemeral_directory(_instance):
 
 
 def test_ephemeral_directory():
-    assert '/foo/bar/.molecule' == scenario.ephemeral_directory('/foo/bar')
+    x = os.path.join(tempfile.gettempdir(), 'foo/bar')
+
+    assert x == scenario.ephemeral_directory('foo/bar')
 
 
 def test_ephemeral_directory_overriden_via_env_var(monkeypatch):
-    monkeypatch.setenv('MOLECULE_EPHEMERAL_DIRECTORY', '.foo')
+    monkeypatch.setenv('MOLECULE_EPHEMERAL_DIRECTORY', 'foo/bar')
+    x = os.path.join(tempfile.gettempdir(), 'foo/bar')
 
-    assert '/foo/bar/.foo' == scenario.ephemeral_directory('/foo/bar')
+    assert x == scenario.ephemeral_directory('foo/bar')
+
+
+def test_ephemeral_directory_overriden_via_env_var_uses_absolute_path(
+        monkeypatch):
+    monkeypatch.setenv('MOLECULE_EPHEMERAL_DIRECTORY', '/foo/bar')
+
+    assert '/foo/bar' == scenario.ephemeral_directory('foo/bar')

--- a/test/unit/test_state.py
+++ b/test/unit/test_state.py
@@ -22,7 +22,6 @@ import os
 
 import pytest
 
-from molecule import config
 from molecule import state
 from molecule import util
 
@@ -107,26 +106,17 @@ def test_change_state_raises(_instance):
         _instance.change_state('invalid-state', True)
 
 
-def test_get_data_loads_existing_state_file(temp_dir, molecule_data):
-    molecule_directory = pytest.helpers.molecule_directory()
-    scenario_directory = os.path.join(molecule_directory, 'default')
-    molecule_file = pytest.helpers.get_molecule_file(scenario_directory)
-    ephemeral_directory = pytest.helpers.molecule_ephemeral_directory()
-    state_file = os.path.join(ephemeral_directory, 'state.yml')
-
-    os.makedirs(ephemeral_directory)
-
+def test_get_data_loads_existing_state_file(_instance, molecule_data,
+                                            config_instance):
     data = {
         'converged': False,
         'created': True,
         'driver': None,
         'prepared': None,
     }
-    util.write_file(state_file, util.safe_dump(data))
+    util.write_file(_instance._state_file, util.safe_dump(data))
 
-    pytest.helpers.write_molecule_file(molecule_file, molecule_data)
-    c = config.Config(molecule_file)
-    s = state.State(c)
+    s = state.State(config_instance)
 
     assert not s.converged
     assert s.created


### PR DESCRIPTION
* Temporary files are now created under $TEMPDIR.  This is
  especially useful for users which run Molecule under a ro
  docker volume.
* Wrapped properties which instantiate a class with a simple
  memoize decorator.  Molecule was instantiating classes on each
  property access.

Fixes: #1141