### PR TITLE
Added cookiecutter tests

### DIFF
--- a/molecule/command/init/role.py
+++ b/molecule/command/init/role.py
@@ -118,8 +118,5 @@ def role(ctx, dependency_name, driver_name, lint_name, provisioner_name,
         'verifier_name': verifier_name,
     }
 
-    if verifier_name == 'goss':
-        command_args.update({'verifier_lint_enabled': False})
-
     r = Role(command_args)
     r.execute()

--- a/molecule/command/init/scenario.py
+++ b/molecule/command/init/scenario.py
@@ -160,8 +160,5 @@ def scenario(ctx, dependency_name, driver_name, lint_name, provisioner_name,
         'verifier_name': verifier_name,
     }
 
-    if verifier_name == 'goss':
-        command_args.update({'verifier_lint_enabled': False})
-
     s = Scenario(command_args)
     s.execute()

--- a/molecule/cookiecutter/molecule/cookiecutter.json
+++ b/molecule/cookiecutter/molecule/cookiecutter.json
@@ -8,6 +8,5 @@
     "scenario_name": "OVERRIDEN",
     "role_name": "OVERRIDEN",
     "verifier_name": "OVERRIDEN",
-    "verifier_lint_name": "flake8",
-    "verifier_lint_enabled": "true"
+    "verifier_lint_name": "flake8"
 }

--- a/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
+++ b/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
@@ -47,6 +47,6 @@ verifier:
   name: {{ cookiecutter.verifier_name }}
   lint:
     name: {{ cookiecutter.verifier_lint_name }}
-{%- if cookiecutter.verifier_lint_enabled == 'false' %}
-    enabled: {{ cookiecutter.verifier_lint_enabled }}
+{%- if cookiecutter.verifier_name == 'goss' %}
+    enabled: false
 {%- endif %}

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -18,7 +18,6 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 
-import logging
 import os
 import random
 import shutil
@@ -27,10 +26,24 @@ import string
 import pytest
 
 from molecule import config
+from molecule import logger
+from molecule import util
 
-logging.getLogger('sh').setLevel(logging.WARNING)
+LOG = logger.get_logger(__name__)
 
 pytest_plugins = ['helpers_namespace']
+
+
+@pytest.helpers.register
+def run_command(cmd, env=os.environ, log=True):
+    if log:
+        cmd = _rebake_command(cmd, env)
+
+    return util.run_command(cmd)
+
+
+def _rebake_command(cmd, env, out=LOG.out, err=LOG.error):
+    return cmd.bake(_env=env, _out=out, _err=err)
 
 
 @pytest.fixture

--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -49,7 +49,7 @@ def with_scenario(request, scenario_to_test, driver_name, scenario_name,
                 'all': True,
             }
             cmd = sh.molecule.bake('destroy', **options)
-            run_command(cmd)
+            pytest.helpers.run_command(cmd)
 
     request.addfinalizer(cleanup)
 
@@ -75,19 +75,19 @@ def idempotence(scenario_name):
         'scenario_name': scenario_name,
     }
     cmd = sh.molecule.bake('create', **options)
-    run_command(cmd)
+    pytest.helpers.run_command(cmd)
 
     options = {
         'scenario_name': scenario_name,
     }
     cmd = sh.molecule.bake('converge', **options)
-    run_command(cmd)
+    pytest.helpers.run_command(cmd)
 
     options = {
         'scenario_name': scenario_name,
     }
     cmd = sh.molecule.bake('idempotence', **options)
-    run_command(cmd)
+    pytest.helpers.run_command(cmd)
 
 
 @pytest.helpers.register
@@ -98,14 +98,14 @@ def init_role(temp_dir, driver_name):
         'driver-name': driver_name,
         'role-name': 'test-init'
     })
-    run_command(cmd)
+    pytest.helpers.run_command(cmd)
 
     os.chdir(role_directory)
     options = {
         'all': True,
     }
     cmd = sh.molecule.bake('test', **options)
-    run_command(cmd)
+    pytest.helpers.run_command(cmd)
 
 
 @pytest.helpers.register
@@ -116,7 +116,7 @@ def init_scenario(temp_dir, driver_name):
         'driver-name': driver_name,
         'role-name': 'test-init'
     })
-    run_command(cmd)
+    pytest.helpers.run_command(cmd)
     os.chdir(role_directory)
 
     # Create scenario
@@ -128,7 +128,7 @@ def init_scenario(temp_dir, driver_name):
         'role_name': 'test-init',
     }
     cmd = sh.molecule.bake('init', 'scenario', **options)
-    run_command(cmd)
+    pytest.helpers.run_command(cmd)
 
     assert os.path.isdir(scenario_directory)
 
@@ -137,13 +137,13 @@ def init_scenario(temp_dir, driver_name):
         'all': True,
     }
     cmd = sh.molecule.bake('test', **options)
-    run_command(cmd)
+    pytest.helpers.run_command(cmd)
 
 
 @pytest.helpers.register
 def list(x):
     cmd = sh.molecule.bake('list')
-    out = run_command(cmd, log=False)
+    out = pytest.helpers.run_command(cmd, log=False)
     out = out.stdout
     out = util.strip_ansi_color(out)
 
@@ -153,7 +153,7 @@ def list(x):
 @pytest.helpers.register
 def list_with_format_plain(x):
     cmd = sh.molecule.bake('list', {'format': 'plain'})
-    out = run_command(cmd, log=False)
+    out = pytest.helpers.run_command(cmd, log=False)
     out = out.stdout
     out = util.strip_ansi_color(out)
 
@@ -166,13 +166,13 @@ def login(login_args, scenario_name='default'):
         'scenario_name': scenario_name,
     }
     cmd = sh.molecule.bake('destroy', **options)
-    run_command(cmd)
+    pytest.helpers.run_command(cmd)
 
     options = {
         'scenario_name': scenario_name,
     }
     cmd = sh.molecule.bake('create', **options)
-    run_command(cmd)
+    pytest.helpers.run_command(cmd)
 
     for instance, regexp in login_args:
         if len(login_args) > 1:
@@ -200,7 +200,7 @@ def test(driver_name, scenario_name='default'):
         }
 
     cmd = sh.molecule.bake('test', **options)
-    run_command(cmd)
+    pytest.helpers.run_command(cmd)
 
 
 @pytest.helpers.register
@@ -209,31 +209,19 @@ def verify(scenario_name='default'):
         'scenario_name': scenario_name,
     }
     cmd = sh.molecule.bake('create', **options)
-    run_command(cmd)
+    pytest.helpers.run_command(cmd)
 
     options = {
         'scenario_name': scenario_name,
     }
     cmd = sh.molecule.bake('converge', **options)
-    run_command(cmd)
+    pytest.helpers.run_command(cmd)
 
     options = {
         'scenario_name': scenario_name,
     }
     cmd = sh.molecule.bake('verify', **options)
-    run_command(cmd)
-
-
-@pytest.helpers.register
-def run_command(cmd, env=os.environ, log=True):
-    if log:
-        cmd = _rebake_command(cmd, env)
-
-    return util.run_command(cmd)
-
-
-def _rebake_command(cmd, env, out=LOG.out, err=LOG.error):
-    return cmd.bake(_env=env, _out=out, _err=err)
+    pytest.helpers.run_command(cmd)
 
 
 def get_docker_executable():

--- a/test/unit/cookiecutter/test_molecule.py
+++ b/test/unit/cookiecutter/test_molecule.py
@@ -1,0 +1,128 @@
+#  Copyright (c) 2015-2017 Cisco Systems, Inc.
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to
+#  deal in the Software without restriction, including without limitation the
+#  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+#  sell copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#  DEALINGS IN THE SOFTWARE.
+
+import os
+
+import pytest
+import sh
+
+from molecule import util
+from molecule.command.init import base
+from molecule.model import schema_v2
+
+
+class CommandBase(base.Base):
+    pass
+
+
+@pytest.fixture
+def _base_class():
+    return CommandBase
+
+
+@pytest.fixture
+def _instance(_base_class):
+    return _base_class()
+
+
+@pytest.fixture
+def _command_args():
+    return {
+        "dependency_name": "galaxy",
+        "driver_name": "docker",
+        "lint_name": "yamllint",
+        "provisioner_name": "ansible",
+        "scenario_name": "default",
+        "role_name": "test-role",
+        "verifier_name": "testinfra",
+    }
+
+
+@pytest.fixture
+def _role_directory():
+    return '.'
+
+
+@pytest.fixture
+def _molecule_file(_role_directory):
+    return os.path.join(_role_directory, 'test-role', 'molecule', 'default',
+                        'molecule.yml')
+
+
+def test_valid(temp_dir, _molecule_file, _role_directory, _command_args,
+               _instance):
+    _instance._process_templates('molecule', _command_args, _role_directory)
+
+    data = util.safe_load_file(_molecule_file)
+
+    assert {} == schema_v2.validate(data)
+
+    cmd = sh.yamllint.bake('-s', _molecule_file)
+    pytest.helpers.run_command(cmd)
+
+
+def test_vagrant_driver(temp_dir, _molecule_file, _role_directory,
+                        _command_args, _instance):
+    _command_args['driver_name'] = 'vagrant'
+    _instance._process_templates('molecule', _command_args, _role_directory)
+
+    data = util.safe_load_file(_molecule_file)
+
+    assert {} == schema_v2.validate(data)
+
+    cmd = sh.yamllint.bake('-s', _molecule_file)
+    pytest.helpers.run_command(cmd)
+
+
+@pytest.mark.parametrize('driver', [
+    ('azure'),
+    ('docker'),
+    ('ec2'),
+    ('gce'),
+    ('lxc'),
+    ('lxd'),
+    ('openstack'),
+    ('vagrant'),
+])
+def test_drivers(driver, temp_dir, _molecule_file, _role_directory,
+                 _command_args, _instance):
+    _command_args['driver_name'] = driver
+    _instance._process_templates('molecule', _command_args, _role_directory)
+
+    data = util.safe_load_file(_molecule_file)
+
+    assert {} == schema_v2.validate(data)
+
+    cmd = sh.yamllint.bake('-s', _molecule_file)
+    pytest.helpers.run_command(cmd)
+
+
+def test_verifier_lint_when_verifier_goss(
+        temp_dir, _molecule_file, _role_directory, _command_args, _instance):
+    _command_args['verifier_name'] = 'goss'
+    _instance._process_templates('molecule', _command_args, _role_directory)
+
+    data = util.safe_load_file(_molecule_file)
+
+    assert {} == schema_v2.validate(data)
+    assert not data['verifier']['lint']['enabled']
+
+    cmd = sh.yamllint.bake('-s', _molecule_file)
+    pytest.helpers.run_command(cmd)


### PR DESCRIPTION
Cookiecutter tests will render molecule.yml and validate it.
In addition runs yamllint to ensure the generated templates
are in good standing.