### PR TITLE
Fixing functional tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 .coverage
 .coverage.*
 .eggs/
-.molecule/
 .pytest_cache/
 .tox/
 .vagrant/

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -22,6 +22,7 @@ import os
 import random
 import shutil
 import string
+import tempfile
 
 import pytest
 
@@ -91,7 +92,11 @@ def get_molecule_file(path):
 
 @pytest.helpers.register
 def molecule_ephemeral_directory():
-    return os.path.join(molecule_scenario_directory(), '.molecule')
+    project_directory = 'test-project'
+    scenario_name = 'test-instance'
+
+    return os.path.join(tempfile.gettempdir(), 'molecule', project_directory,
+                        scenario_name)
 
 
 def pytest_addoption(parser):

--- a/test/functional/test_command.py
+++ b/test/functional/test_command.py
@@ -19,6 +19,8 @@
 #  DEALINGS IN THE SOFTWARE.
 
 import os
+import tempfile
+
 import pytest
 import sh
 
@@ -150,8 +152,9 @@ def test_command_dependency_ansible_galaxy(scenario_to_test, with_scenario,
     cmd = sh.molecule.bake('dependency', **options)
     pytest.helpers.run_command(cmd)
 
-    dependency_role = os.path.join('molecule', 'ansible-galaxy', '.molecule',
-                                   'roles', 'timezone')
+    dependency_role = os.path.join(tempfile.gettempdir(), 'molecule',
+                                   'dependency', 'ansible-galaxy', 'roles',
+                                   'timezone')
     assert os.path.isdir(dependency_role)
 
 
@@ -177,8 +180,8 @@ def test_command_dependency_gilt(scenario_to_test, with_scenario,
     cmd = sh.molecule.bake('dependency', **options)
     pytest.helpers.run_command(cmd)
 
-    dependency_role = os.path.join('molecule', 'gilt', '.molecule', 'roles',
-                                   'timezone')
+    dependency_role = os.path.join(tempfile.gettempdir(), 'molecule',
+                                   'dependency', 'gilt', 'roles', 'timezone')
     assert os.path.isdir(dependency_role)
 
 
@@ -204,7 +207,8 @@ def test_command_dependency_shell(scenario_to_test, with_scenario,
     cmd = sh.molecule.bake('dependency', **options)
     pytest.helpers.run_command(cmd)
 
-    dependency_role = os.path.join('molecule', 'shell', '.molecule', 'roles',
+    dependency_role = os.path.join(tempfile.gettempdir(), 'molecule',
+                                   'dependency', 'shell', 'roles',
                                    'yatesr.timezone')
     assert os.path.isdir(dependency_role)
 

--- a/test/scenarios/dependency/molecule/gilt/gilt.yml
+++ b/test/scenarios/dependency/molecule/gilt/gilt.yml
@@ -1,4 +1,4 @@
 ---
 - git: https://github.com/yatesr/ansible-timezone.git
   version: master
-  dst: molecule/gilt/.molecule/roles/timezone/
+  dst: $MOLECULE_EPHEMERAL_DIRECTORY/roles/timezone/

--- a/test/scenarios/plugins/molecule/default/gilt.yml
+++ b/test/scenarios/plugins/molecule/default/gilt.yml
@@ -1,12 +1,12 @@
 ---
 - git: https://github.com/yatesr/ansible-timezone.git
   version: master
-  dst: molecule/default/.molecule/roles/yatesr.ansible-timezone/
+  dst: $MOLECULE_EPHEMERAL_DIRECTORY/roles/yatesr.ansible-timezone/
 
 - git: https://github.com/retr0h/ansible-plugins.git
   version: master
   files:
     - src: library/library.py
-      dst: molecule/default/.molecule/library/dependency_library.py
+      dst: $MOLECULE_EPHEMERAL_DIRECTORY/library/dependency_library.py
     - src: plugins/filters/core.py
-      dst: molecule/default/.molecule/plugins/filters/dependency_filter.py
+      dst: $MOLECULE_EPHEMERAL_DIRECTORY/plugins/filters/dependency_filter.py


### PR DESCRIPTION
* Corrected a few functional tests which were incorrectly passing
  due to a stale `.molecule` directory existing on the file system
  while implementing #1218.
* Removed `.molecule` from .gitignore.