### PR TITLE
Ensure prune properly removes empty dirs

### DIFF
--- a/molecule/command/base.py
+++ b/molecule/command/base.py
@@ -72,9 +72,9 @@ class Base(object):
 
         # Remove empty directories.
         for dirpath, dirs, files in os.walk(
-                self._config.scenario.ephemeral_directory):
+                self._config.scenario.ephemeral_directory, topdown=False):
             if not dirs and not files:
-                os.rmdir(dirpath)
+                os.removedirs(dirpath)
 
     def print_info(self):
         msg = "Scenario: '{}'".format(self._config.scenario.name)

--- a/test/unit/command/test_base.py
+++ b/test/unit/command/test_base.py
@@ -83,8 +83,12 @@ def test_prune(_instance):
     state_file = os.path.join(ephemeral_directory, 'state.yml')
     inventory_file = os.path.join(ephemeral_directory, 'ansible_inventory.yml')
     config_file = os.path.join(ephemeral_directory, 'ansible.cfg')
+    role_directory = os.path.join(ephemeral_directory, 'roles')
+    empty_role_directory = os.path.join(role_directory, 'foo')
 
     os.mkdir(baz_directory)
+    os.mkdir(role_directory)
+    os.mkdir(empty_role_directory)
     for f in [foo_file, bar_file, state_file]:
         util.write_file(f, '')
 
@@ -96,6 +100,7 @@ def test_prune(_instance):
     assert os.path.isfile(config_file)
     assert os.path.isfile(inventory_file)
     assert not os.path.isdir(baz_directory)
+    assert not os.path.isdir(role_directory)
 
 
 def test_print_info(mocker, patched_logger_info, _instance):


### PR DESCRIPTION
Prune would leave an empty role directory behind, unless destroy
was run twice.  Corrected to use os.removedirs, which "if the leaf
directory is successfully removed, removedirs() tries to successively
remove every parent directory".