### PR TITLE
Moved functional test provisioning vars

### DIFF
--- a/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
+++ b/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
@@ -39,6 +39,81 @@ platforms:
 {%- endif %}
 provisioner:
   name: {{ cookiecutter.provisioner_name }}
+{%- if cookiecutter.driver_name == 'azure' %}
+  inventory:
+    group_vars:
+      all:
+        {% raw -%}
+        resource_group_name: molecule
+        location: westus
+        ssh_user: molecule
+        ssh_port: 22
+        virtual_network_name: molecule_vnet
+        subnet_name: molecule_subnet
+        keypair_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
+        {%- endraw -%}
+{%- elif cookiecutter.driver_name == 'ec2' %}
+  inventory:
+    group_vars:
+      all:
+        {% raw -%}
+        ssh_user: ubuntu
+        ssh_port: 22
+        security_group_name: molecule
+        security_group_description: Security group for testing Molecule
+        security_group_rules:
+          - proto: tcp
+            from_port: "{{ ssh_port }}"
+            to_port: "{{ ssh_port }}"
+            cidr_ip: '0.0.0.0/0'
+          - proto: icmp
+            from_port: 8
+            to_port: -1
+            cidr_ip: '0.0.0.0/0'
+        security_group_rules_egress:
+          - proto: -1
+            from_port: 0
+            to_port: 0
+            cidr_ip: '0.0.0.0/0'
+        keypair_name: molecule_key
+        keypair_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
+        {%- endraw -%}
+{%- elif cookiecutter.driver_name == 'gce' %}
+  inventory:
+    group_vars:
+      all:
+        {% raw -%}
+        ssh_port: 22
+        ssh_user: "{{ lookup('env', 'USER') }}"
+        ssh_identity_file: "{{ lookup('env', 'HOME') }}/.ssh/google_compute_engine"
+        {%- endraw -%}
+{%- elif cookiecutter.driver_name == 'openstack' %}
+  inventory:
+    group_vars:
+      all:
+        {% raw -%}
+        ssh_user: cloud-user
+        ssh_port: 22
+        security_group_name: molecule
+        security_group_description: "Security group for testing Molecule"
+        security_group_rules:
+          - proto: tcp
+            port: "{{ ssh_port }}"
+            cidr: '0.0.0.0/0'
+          - proto: icmp
+            port: -1
+            cidr: '0.0.0.0/0'
+          - ethertype: IPv4
+            group: "{{ security_group.id }}"
+          - ethertype: IPv6
+            group: "{{ security_group.id }}"
+        neutron_network_name: molecule
+        keypair_name: molecule_key
+        keypair_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
+        nova_image: Ubuntu-16.04
+        nova_flavor: NO-Nano
+        {%- endraw -%}
+{%- endif %}
   lint:
     name: {{ cookiecutter.provisioner_lint_name }}
 scenario:

--- a/molecule/cookiecutter/scenario/driver/azure/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/azure/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -5,14 +5,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    resource_group_name: molecule
-    location: westus
-    ssh_user: molecule
-    ssh_port: 22
-    virtual_network_name: molecule_vnet
-    subnet_name: molecule_subnet
-    keypair_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
   tasks:
     - name: Create resource group
       azure_rm_resourcegroup:

--- a/molecule/cookiecutter/scenario/driver/azure/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/azure/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -5,8 +5,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    resource_group_name: molecule
   tasks:
     - name: Destroy molecule instance(s)
       azure_rm_virtualmachine:

--- a/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -5,29 +5,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    ssh_user: ubuntu
-    ssh_port: 22
-
-    security_group_name: molecule
-    security_group_description: Security group for testing Molecule
-    security_group_rules:
-      - proto: tcp
-        from_port: "{{ ssh_port }}"
-        to_port: "{{ ssh_port }}"
-        cidr_ip: '0.0.0.0/0'
-      - proto: icmp
-        from_port: 8
-        to_port: -1
-        cidr_ip: '0.0.0.0/0'
-    security_group_rules_egress:
-      - proto: -1
-        from_port: 0
-        to_port: 0
-        cidr_ip: '0.0.0.0/0'
-
-    keypair_name: molecule_key
-    keypair_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
   tasks:
     - name: Create security group
       ec2_group:

--- a/molecule/cookiecutter/scenario/driver/gce/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/gce/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -5,10 +5,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    ssh_port: 22
-    ssh_user: "{{ lookup('env', 'USER') }}"
-    ssh_identity_file: "{{ lookup('env', 'HOME') }}/.ssh/google_compute_engine"
   tasks:
     - name: Create molecule instance(s)
       gce:

--- a/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -5,31 +5,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    ssh_user: cloud-user
-    ssh_port: 22
-
-    security_group_name: molecule
-    security_group_description: "Security group for testing Molecule"
-    security_group_rules:
-      - proto: tcp
-        port: "{{ ssh_port }}"
-        cidr: '0.0.0.0/0'
-      - proto: icmp
-        port: -1
-        cidr: '0.0.0.0/0'
-      - ethertype: IPv4
-        group: "{{ security_group.id }}"
-      - ethertype: IPv6
-        group: "{{ security_group.id }}"
-
-    neutron_network_name: molecule
-
-    keypair_name: molecule_key
-    keypair_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
-
-    nova_image: Ubuntu-16.04
-    nova_flavor: NO-Nano
   tasks:
     - name: Create security group
       os_security_group:

--- a/test/resources/playbooks/azure/create.yml
+++ b/test/resources/playbooks/azure/create.yml
@@ -4,14 +4,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    resource_group_name: molecule
-    location: westus
-    ssh_user: molecule
-    ssh_port: 22
-    virtual_network_name: molecule_vnet
-    subnet_name: molecule_subnet
-    keypair_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
   tasks:
     - name: Create resource group
       azure_rm_resourcegroup:

--- a/test/resources/playbooks/azure/destroy.yml
+++ b/test/resources/playbooks/azure/destroy.yml
@@ -4,8 +4,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    resource_group_name: molecule
   tasks:
     - name: Destroy molecule instance(s)
       azure_rm_virtualmachine:

--- a/test/resources/playbooks/ec2/create.yml
+++ b/test/resources/playbooks/ec2/create.yml
@@ -4,29 +4,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    ssh_user: ubuntu
-    ssh_port: 22
-
-    security_group_name: molecule
-    security_group_description: Security group for testing Molecule
-    security_group_rules:
-      - proto: tcp
-        from_port: "{{ ssh_port }}"
-        to_port: "{{ ssh_port }}"
-        cidr_ip: '0.0.0.0/0'
-      - proto: icmp
-        from_port: 8
-        to_port: -1
-        cidr_ip: '0.0.0.0/0'
-    security_group_rules_egress:
-      - proto: -1
-        from_port: 0
-        to_port: 0
-        cidr_ip: '0.0.0.0/0'
-
-    keypair_name: molecule_key
-    keypair_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
   tasks:
     - name: Create security group
       ec2_group:

--- a/test/resources/playbooks/ec2/destroy.yml
+++ b/test/resources/playbooks/ec2/destroy.yml
@@ -4,8 +4,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    resource_group_name: molecule
   tasks:
     - block:
         - name: Populate instance config

--- a/test/resources/playbooks/gce/create.yml
+++ b/test/resources/playbooks/gce/create.yml
@@ -4,10 +4,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    ssh_port: 22
-    ssh_user: "{{ lookup('env', 'USER') }}"
-    ssh_identity_file: "{{ lookup('env', 'HOME') }}/.ssh/google_compute_engine"
   tasks:
     - name: Create molecule instance(s)
       gce:

--- a/test/resources/playbooks/openstack/create.yml
+++ b/test/resources/playbooks/openstack/create.yml
@@ -4,31 +4,6 @@
   connection: local
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-  vars:
-    ssh_user: cloud-user
-    ssh_port: 22
-
-    security_group_name: molecule
-    security_group_description: "Security group for testing Molecule"
-    security_group_rules:
-      - proto: tcp
-        port: "{{ ssh_port }}"
-        cidr: '0.0.0.0/0'
-      - proto: icmp
-        port: -1
-        cidr: '0.0.0.0/0'
-      - ethertype: IPv4
-        group: "{{ security_group.id }}"
-      - ethertype: IPv6
-        group: "{{ security_group.id }}"
-
-    neutron_network_name: molecule
-
-    keypair_name: molecule_key
-    keypair_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
-
-    nova_image: Ubuntu-16.04
-    nova_flavor: NO-Nano
   tasks:
     - name: Create security group
       os_security_group:

--- a/test/scenarios/driver/azure/molecule/default/molecule.yml
+++ b/test/scenarios/driver/azure/molecule/default/molecule.yml
@@ -16,6 +16,16 @@ provisioner:
     destroy: ../../../../../resources/playbooks/azure/destroy.yml
   env:
     ANSIBLE_ROLES_PATH: ../../../../../resources/roles/
+  inventory:
+    group_vars:
+      all:
+        resource_group_name: molecule
+        location: westus
+        ssh_user: molecule
+        ssh_port: 22
+        virtual_network_name: molecule_vnet
+        subnet_name: molecule_subnet
+        keypair_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
   lint:
     name: ansible-lint
 scenario:

--- a/test/scenarios/driver/azure/molecule/multi-node/molecule.yml
+++ b/test/scenarios/driver/azure/molecule/multi-node/molecule.yml
@@ -21,6 +21,8 @@ provisioner:
   playbooks:
     create: ../../../../../resources/playbooks/azure/create.yml
     destroy: ../../../../../resources/playbooks/azure/destroy.yml
+  env:
+    ANSIBLE_ROLES_PATH: ../../../../../resources/roles/
   inventory:
     group_vars:
       all:
@@ -31,8 +33,6 @@ provisioner:
         virtual_network_name: molecule_vnet
         subnet_name: molecule_subnet
         keypair_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
-  env:
-    ANSIBLE_ROLES_PATH: ../../../../../resources/roles/
   lint:
     name: ansible-lint
 scenario:

--- a/test/scenarios/driver/ec2/molecule/default/molecule.yml
+++ b/test/scenarios/driver/ec2/molecule/default/molecule.yml
@@ -19,6 +19,29 @@ provisioner:
     destroy: ../../../../../resources/playbooks/ec2/destroy.yml
   env:
     ANSIBLE_ROLES_PATH: ../../../../../resources/roles/
+  inventory:
+    group_vars:
+      all:
+        ssh_user: ubuntu
+        ssh_port: 22
+        security_group_name: molecule
+        security_group_description: Security group for testing Molecule
+        security_group_rules:
+          - proto: tcp
+            from_port: "{{ ssh_port }}"
+            to_port: "{{ ssh_port }}"
+            cidr_ip: '0.0.0.0/0'
+          - proto: icmp
+            from_port: 8
+            to_port: -1
+            cidr_ip: '0.0.0.0/0'
+        security_group_rules_egress:
+          - proto: -1
+            from_port: 0
+            to_port: 0
+            cidr_ip: '0.0.0.0/0'
+        keypair_name: molecule_key
+        keypair_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
   lint:
     name: ansible-lint
 scenario:

--- a/test/scenarios/driver/ec2/molecule/multi-node/molecule.yml
+++ b/test/scenarios/driver/ec2/molecule/multi-node/molecule.yml
@@ -29,6 +29,29 @@ provisioner:
     destroy: ../../../../../resources/playbooks/ec2/destroy.yml
   env:
     ANSIBLE_ROLES_PATH: ../../../../../resources/roles/
+  inventory:
+    group_vars:
+      all:
+        ssh_user: ubuntu
+        ssh_port: 22
+        security_group_name: molecule
+        security_group_description: Security group for testing Molecule
+        security_group_rules:
+          - proto: tcp
+            from_port: "{{ ssh_port }}"
+            to_port: "{{ ssh_port }}"
+            cidr_ip: '0.0.0.0/0'
+          - proto: icmp
+            from_port: 8
+            to_port: -1
+            cidr_ip: '0.0.0.0/0'
+        security_group_rules_egress:
+          - proto: -1
+            from_port: 0
+            to_port: 0
+            cidr_ip: '0.0.0.0/0'
+        keypair_name: molecule_key
+        keypair_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
   lint:
     name: ansible-lint
 scenario:

--- a/test/scenarios/driver/gce/molecule/default/molecule.yml
+++ b/test/scenarios/driver/gce/molecule/default/molecule.yml
@@ -19,6 +19,12 @@ provisioner:
     destroy: ../../../../../resources/playbooks/gce/destroy.yml
   env:
     ANSIBLE_ROLES_PATH: ../../../../../resources/roles/
+  inventory:
+    group_vars:
+      all:
+        ssh_port: 22
+        ssh_user: "{{ lookup('env', 'USER') }}"
+        ssh_identity_file: "{{ lookup('env', 'HOME') }}/.ssh/google_compute_engine"
   lint:
     name: ansible-lint
 scenario:

--- a/test/scenarios/driver/gce/molecule/multi-node/molecule.yml
+++ b/test/scenarios/driver/gce/molecule/multi-node/molecule.yml
@@ -29,6 +29,12 @@ provisioner:
     destroy: ../../../../../resources/playbooks/gce/destroy.yml
   env:
     ANSIBLE_ROLES_PATH: ../../../../../resources/roles/
+  inventory:
+    group_vars:
+      all:
+        ssh_port: 22
+        ssh_user: "{{ lookup('env', 'USER') }}"
+        ssh_identity_file: "{{ lookup('env', 'HOME') }}/.ssh/google_compute_engine"
   lint:
     name: ansible-lint
 scenario:

--- a/test/scenarios/driver/openstack/molecule/default/molecule.yml
+++ b/test/scenarios/driver/openstack/molecule/default/molecule.yml
@@ -16,6 +16,29 @@ provisioner:
     destroy: ../../../../../resources/playbooks/openstack/destroy.yml
   env:
     ANSIBLE_ROLES_PATH: ../../../../../resources/roles/
+  inventory:
+    group_vars:
+      all:
+        ssh_user: cloud-user
+        ssh_port: 22
+        security_group_name: molecule
+        security_group_description: "Security group for testing Molecule"
+        security_group_rules:
+          - proto: tcp
+            port: "{{ ssh_port }}"
+            cidr: '0.0.0.0/0'
+          - proto: icmp
+            port: -1
+            cidr: '0.0.0.0/0'
+          - ethertype: IPv4
+            group: "{{ security_group.id }}"
+          - ethertype: IPv6
+            group: "{{ security_group.id }}"
+        neutron_network_name: molecule
+        keypair_name: molecule_key
+        keypair_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
+        nova_image: Ubuntu-16.04
+        nova_flavor: NO-Nano
   lint:
     name: ansible-lint
 scenario:

--- a/test/scenarios/driver/openstack/molecule/multi-node/molecule.yml
+++ b/test/scenarios/driver/openstack/molecule/multi-node/molecule.yml
@@ -23,6 +23,29 @@ provisioner:
     destroy: ../../../../../resources/playbooks/openstack/destroy.yml
   env:
     ANSIBLE_ROLES_PATH: ../../../../../resources/roles/
+  inventory:
+    group_vars:
+      all:
+        ssh_user: cloud-user
+        ssh_port: 22
+        security_group_name: molecule
+        security_group_description: "Security group for testing Molecule"
+        security_group_rules:
+          - proto: tcp
+            port: "{{ ssh_port }}"
+            cidr: '0.0.0.0/0'
+          - proto: icmp
+            port: -1
+            cidr: '0.0.0.0/0'
+          - ethertype: IPv4
+            group: "{{ security_group.id }}"
+          - ethertype: IPv6
+            group: "{{ security_group.id }}"
+        neutron_network_name: molecule
+        keypair_name: molecule_key
+        keypair_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
+        nova_image: Ubuntu-16.04
+        nova_flavor: NO-Nano
   lint:
     name: ansible-lint
 scenario:

--- a/test/unit/cookiecutter/test_molecule.py
+++ b/test/unit/cookiecutter/test_molecule.py
@@ -66,6 +66,16 @@ def _molecule_file(_role_directory):
                         'molecule.yml')
 
 
+def yamllint(molecule_file):
+    config_file = os.path.join(
+        os.path.dirname(__file__), os.path.pardir, os.path.pardir,
+        os.path.pardir, '.yamllint')
+    options = {'config-file': config_file}
+    cmd = sh.yamllint.bake('-s', molecule_file, **options)
+
+    pytest.helpers.run_command(cmd)
+
+
 def test_valid(temp_dir, _molecule_file, _role_directory, _command_args,
                _instance):
     _instance._process_templates('molecule', _command_args, _role_directory)
@@ -74,8 +84,7 @@ def test_valid(temp_dir, _molecule_file, _role_directory, _command_args,
 
     assert {} == schema_v2.validate(data)
 
-    cmd = sh.yamllint.bake('-s', _molecule_file)
-    pytest.helpers.run_command(cmd)
+    yamllint(_molecule_file)
 
 
 def test_vagrant_driver(temp_dir, _molecule_file, _role_directory,
@@ -87,8 +96,7 @@ def test_vagrant_driver(temp_dir, _molecule_file, _role_directory,
 
     assert {} == schema_v2.validate(data)
 
-    cmd = sh.yamllint.bake('-s', _molecule_file)
-    pytest.helpers.run_command(cmd)
+    yamllint(_molecule_file)
 
 
 @pytest.mark.parametrize('driver', [
@@ -110,8 +118,7 @@ def test_drivers(driver, temp_dir, _molecule_file, _role_directory,
 
     assert {} == schema_v2.validate(data)
 
-    cmd = sh.yamllint.bake('-s', _molecule_file)
-    pytest.helpers.run_command(cmd)
+    yamllint(_molecule_file)
 
 
 def test_verifier_lint_when_verifier_goss(
@@ -124,5 +131,4 @@ def test_verifier_lint_when_verifier_goss(
     assert {} == schema_v2.validate(data)
     assert not data['verifier']['lint']['enabled']
 
-    cmd = sh.yamllint.bake('-s', _molecule_file)
-    pytest.helpers.run_command(cmd)
+    yamllint(_molecule_file)


### PR DESCRIPTION
Moved vars into `molecule.yml` instead of the playbook.  This is
now the recommended way to manage data between `molecule.yml`
and the provisioning playbooks.