### PR TITLE
Add parameter for vagrant provider override

### DIFF
--- a/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
+++ b/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
@@ -100,6 +100,11 @@ options:
       - Additional provider options not explcitly exposed by this module.
     required: False
     default: {}
+  provider_override_args:
+    description:
+      - Additional override options not explcitly exposed by this module.
+    required: False
+    default: None
   provider_raw_config_args:
     description:
       - Additional Vagrant options not explcitly exposed by this module.
@@ -181,7 +186,7 @@ Vagrant.configure('2') do |config|
   ##
 
   if provider['name'] == 'virtualbox'
-    config.vm.provider provider['name'] do |virtualbox|
+    config.vm.provider provider['name'] do |virtualbox, override|
       virtualbox.memory = provider_memory
       virtualbox.cpus = provider_cpus
 
@@ -208,6 +213,12 @@ Vagrant.configure('2') do |config|
           eval("virtualbox.#{raw_config_arg}")
         }
       end
+
+      if provider['override_args']
+        provider['override_args'].each { |override_arg|
+          eval("override.#{override_arg}")
+        }
+      end
     end
 
     # The vagrant-vbguest plugin attempts to update packages
@@ -225,7 +236,7 @@ Vagrant.configure('2') do |config|
   ##
 
   if provider['name'].start_with?('vmware_')
-    config.vm.provider provider['name'] do |vmware|
+    config.vm.provider provider['name'] do |vmware, override|
       vmware.vmx['memsize'] = provider_memory
       vmware.vmx['numvcpus'] = provider_cpus
 
@@ -240,6 +251,12 @@ Vagrant.configure('2') do |config|
           eval("vmware.#{raw_config_arg}")
         }
       end
+
+      if provider['override_args']
+        provider['override_args'].each { |override_arg|
+          eval("override.#{override_arg}")
+        }
+      end
     end
   end
 
@@ -248,7 +265,7 @@ Vagrant.configure('2') do |config|
   ##
 
   if provider['name'] == 'parallels'
-    config.vm.provider provider['name'] do |parallels|
+    config.vm.provider provider['name'] do |parallels, override|
       parallels.memory = provider_memory
       parallels.cpus = provider_cpus
 
@@ -263,6 +280,12 @@ Vagrant.configure('2') do |config|
           eval("parallels.#{raw_config_arg}")
         }
       end
+
+      if provider['override_args']
+        provider['override_args'].each { |override_arg|
+          eval("override.#{override_arg}")
+        }
+      end
     end
   end
 
@@ -271,7 +294,7 @@ Vagrant.configure('2') do |config|
   ##
 
   if provider['name'] == 'libvirt'
-    config.vm.provider provider['name'] do |libvirt|
+    config.vm.provider provider['name'] do |libvirt, override|
       libvirt.memory = provider_memory
       libvirt.cpus = provider_cpus
 
@@ -284,6 +307,12 @@ Vagrant.configure('2') do |config|
       if provider['raw_config_args']
         provider['raw_config_args'].each { |raw_config_arg|
           eval("libvirt.#{raw_config_arg}")
+        }
+      end
+
+      if provider['override_args']
+        provider['override_args'].each { |override_arg|
+          eval("override.#{override_arg}")
         }
       end
     end
@@ -431,6 +460,7 @@ class VagrantClient(object):
                 },
                 'raw_config_args':
                 self._module.params['provider_raw_config_args'],
+                'override_args': self._module.params['provider_override_args'],
             }
         }
 
@@ -457,6 +487,7 @@ def main():
             provider_memory=dict(type='int', default=512),
             provider_cpus=dict(type='int', default=2),
             provider_options=dict(type='dict', default={}),
+            provider_override_args=dict(type='list', default=None),
             provider_raw_config_args=dict(type='list', default=None),
             provision=dict(type='bool', default=False),
             force_stop=dict(type='bool', default=False),


### PR DESCRIPTION
See the docs for additional info on this option:
https://www.vagrantup.com/docs/providers/configuration.html#overriding-configuration

While trying to disable nfs explicitly on a box that had it enabled... doing an over-ride on the provider was the only way I could get it working :man_shrugging: This might be a libvirt specific problem but adding this option fixed it for me and its optional.