### PR TITLE
add docker_host attribute to templates to allow talking to a remote n…

### DIFF
--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -12,6 +12,7 @@
         password: "{{ item.registry.credentials.password }}"
         email: "{{ item.registry.credentials.email | default(omit) }}"
         registry: "{{ item.registry.url }}"
+        docker_host: "{{ item.docker_host | default('unix://var/run/docker.sock') }}"
       with_items: "{{ molecule_yml.platforms }}"
       when:
         - item.registry is defined
@@ -28,6 +29,7 @@
     - name: Discover local Docker images
       docker_image_facts:
         name: "molecule_local/{{ item.item.name }}"
+        docker_host: "{{ item.item.docker_host | default('unix://var/run/docker.sock') }}"
       with_items: "{{ platforms.results }}"
       register: docker_images
 
@@ -35,6 +37,7 @@
       docker_image:
         path: "{{ molecule_ephemeral_directory }}"
         name: "molecule_local/{{ item.item.image }}"
+        docker_host: "{{ item.item.docker_host | default('unix://var/run/docker.sock') }}"
         dockerfile: "{{ item.item.dockerfile | default(item.invocation.module_args.dest) }}"
         force: "{{ item.item.force | default(true) }}"
       with_items: "{{ platforms.results }}"
@@ -43,12 +46,14 @@
     - name: Create docker network(s)
       docker_network:
         name: "{{ item }}"
+        docker_host: "{{ item.docker_host | default('unix://var/run/docker.sock') }}"
         state: present
       with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks }}"
 
     - name: Create molecule instance(s)
       docker_container:
         name: "{{ item.name }}"
+        docker_host: "{{ item.docker_host | default('unix://var/run/docker.sock') }}"
         hostname: "{{ item.name }}"
         image: "molecule_local/{{ item.image }}"
         state: started

--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -9,6 +9,7 @@
     - name: Destroy molecule instance(s)
       docker_container:
         name: "{{ item.name }}"
+        docker_host: "{{ item.docker_host | default('unix://var/run/docker.sock') }}"
         state: absent
         force_kill: "{{ item.force_kill | default(true) }}"
       register: server
@@ -27,6 +28,7 @@
     - name: Delete docker network(s)
       docker_network:
         name: "{{ item }}"
+        docker_host: "{{ item.docker_host | default('unix://var/run/docker.sock') }}"
         state: absent
       with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks }}"
 {%- endraw %}

--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -86,6 +86,22 @@ class Docker(base.Base):
             - foo
             - .molecule/bar
 
+    To use a URL to connect to the Docker API instead of the default Unix socket
+    path `unix://var/run/docker.sock`.
+
+    .. code-block:: yaml
+
+        driver:
+          name: docker
+        platforms:
+          - name: instance
+            image: centos:7
+            docker_host: 'tcp://localhost:12376'
+        provisioner:
+          name: ansible
+          env:
+            DOCKER_HOST: 'tcp://localhost:12376'
+
     .. _`Docker`: https://www.docker.com
     """  # noqa
 


### PR DESCRIPTION
add the attribute to support talking to docker over tcp. `molecule.yml` looks like;

```
---
dependency:
  name: galaxy
driver:
  name: docker
lint:
  name: yamllint
platforms:
  - name: instance
    image: centos:7
    docker_host: 'tcp://localhost:12376'
provisioner:
  name: ansible
  lint:
    name: ansible-lint
  env:
    DOCKER_HOST: 'tcp://localhost:12376'
scenario:
  name: default
verifier:
  name: testinfra
  lint:
    name: flake8

```