### PR TITLE
Bumped Ansible 2.4 minor version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
     -rtest-requirements.txt
     ansible22: ansible==2.2.3.0
     ansible23: ansible==2.3.3.0
-    ansible24: ansible==2.4.3.0
+    ansible24: ansible==2.4.4.0
     ansible25: ansible==2.5.0
 commands =
     unit: py.test -vv --cov-report=term-missing --cov={toxinidir}/molecule/ --no-cov-on-fail {posargs}


### PR DESCRIPTION
These versions are used by tests to ensure Molecule compatibility
with Ansible releases.