### PR TITLE
Correct Docker container terminal sizing

### DIFF
--- a/molecule/command/login.py
+++ b/molecule/command/login.py
@@ -109,11 +109,13 @@ class Login(base.Base):
         return match[0]
 
     def _get_login(self, hostname):  # pragma: no cover
+        lines, columns = os.popen('stty size', 'r').read().split()
         login_options = self._config.driver.login_options(hostname)
+        login_options['columns'] = columns
+        login_options['lines'] = lines
         login_cmd = self._config.driver.login_cmd_template.format(
             **login_options)
 
-        lines, columns = os.popen('stty size', 'r').read().split()
         dimensions = (int(lines), int(columns))
         cmd = '/usr/bin/env {}'.format(login_cmd)
         self._pt = pexpect.spawn(cmd, dimensions=dimensions)

--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -103,7 +103,11 @@ class Docker(base.Base):
 
     @property
     def login_cmd_template(self):
-        return 'docker exec -ti {instance} bash'
+        return ('docker exec '
+                '-e COLUMNS={columns} '
+                '-e LINES={lines} '
+                '-e TERM=bash '
+                '-ti {instance} bash')
 
     @property
     def default_safe_files(self):

--- a/test/unit/driver/test_docker.py
+++ b/test/unit/driver/test_docker.py
@@ -53,7 +53,11 @@ def test_options_property(_instance):
 
 
 def test_login_cmd_template_property(_instance):
-    x = 'docker exec -ti {instance} bash'
+    x = ('docker exec '
+         '-e COLUMNS={columns} '
+         '-e LINES={lines} '
+         '-e TERM=bash '
+         '-ti {instance} bash')
 
     assert x == _instance.login_cmd_template
 


### PR DESCRIPTION
Containers accessed via `molecule login` are not getting
$COLUMNS and $LINES set.  Update docker exec to pass the
proper $COLUMNS and $LINES env vars [1] as a work-a-round.

    [1] https://github.com/moby/moby/issues/35407

Fixes: #1244