### PR TITLE
Delegated driver should report unknown on list

### DIFF
--- a/molecule/driver/base.py
+++ b/molecule/driver/base.py
@@ -174,8 +174,8 @@ class Base(object):
         status_list = []
         for platform in self._config.platforms.instances:
             instance_name = platform['name']
-            driver_name = self.name.capitalize()
-            provisioner_name = self._config.provisioner.name.capitalize()
+            driver_name = self.name
+            provisioner_name = self._config.provisioner.name
             scenario_name = self._config.scenario.name
 
             status_list.append(
@@ -184,8 +184,9 @@ class Base(object):
                     driver_name=driver_name,
                     provisioner_name=provisioner_name,
                     scenario_name=scenario_name,
-                    created=str(self._config.state.created),
-                    converged=str(self._config.state.converged)))
+                    created=self._created(),
+                    converged=self._converged(),
+                ))
 
         return status_list
 
@@ -197,3 +198,9 @@ class Base(object):
             '-o IdentitiesOnly=yes',
             '-o StrictHostKeyChecking=no',
         ]
+
+    def _created(self):
+        return str(self._config.state.created).lower()
+
+    def _converged(self):
+        return str(self._config.state.converged).lower()

--- a/molecule/driver/delegated.py
+++ b/molecule/driver/delegated.py
@@ -119,3 +119,8 @@ class Delegated(base.Base):
 
     def ansible_connection_options(self, instance_name):
         return self.options['ansible_connection_options']
+
+    def _created(self):
+        if self.managed:
+            return super(Delegated, self)._created()
+        return 'unknown'

--- a/test/functional/test_command.py
+++ b/test/functional/test_command.py
@@ -341,67 +341,67 @@ def test_command_lint(scenario_to_test, with_scenario, scenario_name):
 
 Instance Name    Driver Name    Provisioner Name    Scenario Name    Created    Converged
 ---------------  -------------  ------------------  ---------------  ---------  -----------
-instance         Azure          Ansible             default          False      False
-instance-1       Azure          Ansible             multi-node       False      False
-instance-2       Azure          Ansible             multi-node       False      False
+instance         azure          ansible             default          false      false
+instance-1       azure          ansible             multi-node       false      false
+instance-2       azure          ansible             multi-node       false      false
 """.strip()),  # noqa
         ('driver/docker', 'docker', """
 Instance Name    Driver Name    Provisioner Name    Scenario Name    Created    Converged
 ---------------  -------------  ------------------  ---------------  ---------  -----------
-instance         Docker         Ansible             default          False      False
-instance-1       Docker         Ansible             multi-node       False      False
-instance-2       Docker         Ansible             multi-node       False      False
+instance         docker         ansible             default          false      false
+instance-1       docker         ansible             multi-node       false      false
+instance-2       docker         ansible             multi-node       false      false
 """.strip()),  # noqa
         ('driver/ec2', 'ec2', """
 Instance Name    Driver Name    Provisioner Name    Scenario Name    Created    Converged
 ---------------  -------------  ------------------  ---------------  ---------  -----------
-instance         Ec2            Ansible             default          False      False
-instance-1       Ec2            Ansible             multi-node       False      False
-instance-2       Ec2            Ansible             multi-node       False      False
+instance         ec2            ansible             default          false      false
+instance-1       ec2            ansible             multi-node       false      false
+instance-2       ec2            ansible             multi-node       false      false
 """.strip()),  # noqa
         ('driver/gce', 'gce', """
 Instance Name    Driver Name    Provisioner Name    Scenario Name    Created    Converged
 ---------------  -------------  ------------------  ---------------  ---------  -----------
-instance         Gce            Ansible             default          False      False
-instance-1       Gce            Ansible             multi-node       False      False
-instance-2       Gce            Ansible             multi-node       False      False
+instance         gce            ansible             default          false      false
+instance-1       gce            ansible             multi-node       false      false
+instance-2       gce            ansible             multi-node       false      false
 """.strip()),  # noqa
         ('driver/lxc', 'lxc', """
 Instance Name    Driver Name    Provisioner Name    Scenario Name    Created    Converged
 ---------------  -------------  ------------------  ---------------  ---------  -----------
-instance         Lxc            Ansible             default          False      False
-instance-1       Lxc            Ansible             multi-node       False      False
-instance-2       Lxc            Ansible             multi-node       False      False
+instance         lxc            ansible             default          false      false
+instance-1       lxc            ansible             multi-node       false      false
+instance-2       lxc            ansible             multi-node       false      false
 """.strip()),  # noqa
         ('driver/lxd', 'lxd', """
 Instance Name    Driver Name    Provisioner Name    Scenario Name    Created    Converged
 ---------------  -------------  ------------------  ---------------  ---------  -----------
-instance         Lxd            Ansible             default          False      False
-instance-1       Lxd            Ansible             multi-node       False      False
-instance-2       Lxd            Ansible             multi-node       False      False
+instance         lxd            ansible             default          false      false
+instance-1       lxd            ansible             multi-node       false      false
+instance-2       lxd            ansible             multi-node       false      false
 """.strip()),  # noqa
         ('driver/openstack', 'openstack', """
 Instance Name    Driver Name    Provisioner Name    Scenario Name    Created    Converged
 ---------------  -------------  ------------------  ---------------  ---------  -----------
-instance         Openstack      Ansible             default          False      False
-instance-1       Openstack      Ansible             multi-node       False      False
-instance-2       Openstack      Ansible             multi-node       False      False
+instance         openstack      ansible             default          false      false
+instance-1       openstack      ansible             multi-node       false      false
+instance-2       openstack      ansible             multi-node       false      false
 """.strip()),  # noqa
         ('driver/delegated', 'delegated', """
 Instance Name                 Driver Name    Provisioner Name    Scenario Name    Created    Converged
 ----------------------------  -------------  ------------------  ---------------  ---------  -----------
-delegated-instance-docker     Delegated      Ansible             docker           False      True
-delegated-instance-ec2        Delegated      Ansible             ec2              False      True
-delegated-instance-gce        Delegated      Ansible             gce              False      True
-delegated-instance-openstack  Delegated      Ansible             openstack        False      True
-delegated-instance-vagrant    Delegated      Ansible             vagrant          False      False
+delegated-instance-docker     delegated      ansible             docker           unknown    true
+delegated-instance-ec2        delegated      ansible             ec2              unknown    true
+delegated-instance-gce        delegated      ansible             gce              unknown    true
+delegated-instance-openstack  delegated      ansible             openstack        unknown    true
+delegated-instance-vagrant    delegated      ansible             vagrant          unknown    false
 """.strip()),  # noqa
         ('driver/vagrant', 'vagrant', """
 Instance Name    Driver Name    Provisioner Name    Scenario Name    Created    Converged
 ---------------  -------------  ------------------  ---------------  ---------  -----------
-instance         Vagrant        Ansible             default          False      False
-instance-1       Vagrant        Ansible             multi-node       False      False
-instance-2       Vagrant        Ansible             multi-node       False      False
+instance         vagrant        ansible             default          false      false
+instance-1       vagrant        ansible             multi-node       false      false
+instance-2       vagrant        ansible             multi-node       false      false
 """.strip()),  # noqa
     ],
     indirect=[
@@ -415,51 +415,51 @@ def test_command_list(scenario_to_test, with_scenario, expected):
 @pytest.mark.parametrize(
     'scenario_to_test, driver_name, expected', [
         ('driver/azure', 'azure', """
-instance    Azure  Ansible  default     False  False
-instance-1  Azure  Ansible  multi-node  False  False
-instance-2  Azure  Ansible  multi-node  False  False
+instance    azure  ansible  default     false  false
+instance-1  azure  ansible  multi-node  false  false
+instance-2  azure  ansible  multi-node  false  false
 """.strip()),
         ('driver/docker', 'docker', """
-instance    Docker  Ansible  default     False  False
-instance-1  Docker  Ansible  multi-node  False  False
-instance-2  Docker  Ansible  multi-node  False  False
+instance    docker  ansible  default     false  false
+instance-1  docker  ansible  multi-node  false  false
+instance-2  docker  ansible  multi-node  false  false
 """.strip()),
         ('driver/ec2', 'ec2', """
-instance    Ec2  Ansible  default     False  False
-instance-1  Ec2  Ansible  multi-node  False  False
-instance-2  Ec2  Ansible  multi-node  False  False
+instance    ec2  ansible  default     false  false
+instance-1  ec2  ansible  multi-node  false  false
+instance-2  ec2  ansible  multi-node  false  false
 """.strip()),
         ('driver/gce', 'gce', """
-instance    Gce  Ansible  default     False  False
-instance-1  Gce  Ansible  multi-node  False  False
-instance-2  Gce  Ansible  multi-node  False  False
+instance    gce  ansible  default     false  false
+instance-1  gce  ansible  multi-node  false  false
+instance-2  gce  ansible  multi-node  false  false
 """.strip()),
         ('driver/lxc', 'lxc', """
-instance    Lxc  Ansible  default     False  False
-instance-1  Lxc  Ansible  multi-node  False  False
-instance-2  Lxc  Ansible  multi-node  False  False
+instance    lxc  ansible  default     false  false
+instance-1  lxc  ansible  multi-node  false  false
+instance-2  lxc  ansible  multi-node  false  false
 """.strip()),
         ('driver/lxd', 'lxd', """
-instance    Lxd  Ansible  default     False  False
-instance-1  Lxd  Ansible  multi-node  False  False
-instance-2  Lxd  Ansible  multi-node  False  False
+instance    lxd  ansible  default     false  false
+instance-1  lxd  ansible  multi-node  false  false
+instance-2  lxd  ansible  multi-node  false  false
 """.strip()),
         ('driver/openstack', 'openstack', """
-instance    Openstack  Ansible  default     False  False
-instance-1  Openstack  Ansible  multi-node  False  False
-instance-2  Openstack  Ansible  multi-node  False  False
+instance    openstack  ansible  default     false  false
+instance-1  openstack  ansible  multi-node  false  false
+instance-2  openstack  ansible  multi-node  false  false
 """.strip()),
         ('driver/delegated', 'delegated', """
-delegated-instance-docker     Delegated  Ansible  docker     False  True
-delegated-instance-ec2        Delegated  Ansible  ec2        False  True
-delegated-instance-gce        Delegated  Ansible  gce        False  True
-delegated-instance-openstack  Delegated  Ansible  openstack  False  True
-delegated-instance-vagrant    Delegated  Ansible  vagrant    False  False
+delegated-instance-docker     delegated  ansible  docker     unknown  true
+delegated-instance-ec2        delegated  ansible  ec2        unknown  true
+delegated-instance-gce        delegated  ansible  gce        unknown  true
+delegated-instance-openstack  delegated  ansible  openstack  unknown  true
+delegated-instance-vagrant    delegated  ansible  vagrant    unknown  false
 """.strip()),
         ('driver/vagrant', 'vagrant', """
-instance    Vagrant  Ansible  default     False  False
-instance-1  Vagrant  Ansible  multi-node  False  False
-instance-2  Vagrant  Ansible  multi-node  False  False
+instance    vagrant  ansible  default     false  false
+instance-1  vagrant  ansible  multi-node  false  false
+instance-2  vagrant  ansible  multi-node  false  false
 """.strip()),
     ],
     indirect=[

--- a/test/unit/command/test_list.py
+++ b/test/unit/command/test_list.py
@@ -27,18 +27,18 @@ def test_execute(capsys, config_instance):
     x = [
         base.Status(
             instance_name='instance-1',
-            driver_name='Docker',
-            provisioner_name='Ansible',
+            driver_name='docker',
+            provisioner_name='ansible',
             scenario_name='default',
-            created='False',
-            converged='False'),
+            created='false',
+            converged='false'),
         base.Status(
             instance_name='instance-2',
-            driver_name='Docker',
-            provisioner_name='Ansible',
+            driver_name='docker',
+            provisioner_name='ansible',
             scenario_name='default',
-            created='False',
-            converged='False'),
+            created='false',
+            converged='false'),
     ]
 
     assert x == l.execute()

--- a/test/unit/driver/test_azure.py
+++ b/test/unit/driver/test_azure.py
@@ -195,18 +195,18 @@ def test_status(mocker, _instance):
     assert 2 == len(result)
 
     assert result[0].instance_name == 'instance-1'
-    assert result[0].driver_name == 'Azure'
-    assert result[0].provisioner_name == 'Ansible'
+    assert result[0].driver_name == 'azure'
+    assert result[0].provisioner_name == 'ansible'
     assert result[0].scenario_name == 'default'
-    assert result[0].created == 'False'
-    assert result[0].converged == 'False'
+    assert result[0].created == 'false'
+    assert result[0].converged == 'false'
 
     assert result[1].instance_name == 'instance-2'
-    assert result[1].driver_name == 'Azure'
-    assert result[1].provisioner_name == 'Ansible'
+    assert result[1].driver_name == 'azure'
+    assert result[1].provisioner_name == 'ansible'
     assert result[1].scenario_name == 'default'
-    assert result[1].created == 'False'
-    assert result[1].converged == 'False'
+    assert result[1].created == 'false'
+    assert result[1].converged == 'false'
 
 
 def test_get_instance_config(mocker, _instance):
@@ -221,3 +221,11 @@ def test_get_instance_config(mocker, _instance):
         'instance': 'foo',
     }
     assert x == _instance._get_instance_config('foo')
+
+
+def test_created(_instance):
+    assert 'false' == _instance._created()
+
+
+def test_converged(_instance):
+    assert 'false' == _instance._converged()

--- a/test/unit/driver/test_delegated.py
+++ b/test/unit/driver/test_delegated.py
@@ -132,15 +132,41 @@ def test_status(mocker, _instance):
     assert 2 == len(result)
 
     assert result[0].instance_name == 'instance-1'
-    assert result[0].driver_name == 'Delegated'
-    assert result[0].provisioner_name == 'Ansible'
+    assert result[0].driver_name == 'delegated'
+    assert result[0].provisioner_name == 'ansible'
     assert result[0].scenario_name == 'default'
-    assert result[0].created == 'False'
-    assert result[0].converged == 'False'
+    assert result[0].created == 'false'
+    assert result[0].converged == 'false'
 
     assert result[1].instance_name == 'instance-2'
-    assert result[1].driver_name == 'Delegated'
-    assert result[1].provisioner_name == 'Ansible'
+    assert result[1].driver_name == 'delegated'
+    assert result[1].provisioner_name == 'ansible'
     assert result[1].scenario_name == 'default'
-    assert result[1].created == 'False'
-    assert result[1].converged == 'False'
+    assert result[1].created == 'false'
+    assert result[1].converged == 'false'
+
+
+def test_created(_instance):
+    assert 'false' == _instance._created()
+
+
+@pytest.fixture
+def _driver_options_managed_section_data():
+    return {
+        'driver': {
+            'options': {
+                'managed': False,
+            },
+        }
+    }
+
+
+@pytest.mark.parametrize(
+    'config_instance', ['_driver_options_managed_section_data'], indirect=True)
+def test_created_unknown_when_managed_false(
+        _driver_options_managed_section_data, _instance):
+    assert 'unknown' == _instance._created()
+
+
+def test_property(_instance):
+    assert 'false' == _instance._converged()

--- a/test/unit/driver/test_docker.py
+++ b/test/unit/driver/test_docker.py
@@ -119,15 +119,23 @@ def test_status(mocker, _instance):
     assert 2 == len(result)
 
     assert result[0].instance_name == 'instance-1'
-    assert result[0].driver_name == 'Docker'
-    assert result[0].provisioner_name == 'Ansible'
+    assert result[0].driver_name == 'docker'
+    assert result[0].provisioner_name == 'ansible'
     assert result[0].scenario_name == 'default'
-    assert result[0].created == 'False'
-    assert result[0].converged == 'False'
+    assert result[0].created == 'false'
+    assert result[0].converged == 'false'
 
     assert result[1].instance_name == 'instance-2'
-    assert result[1].driver_name == 'Docker'
-    assert result[1].provisioner_name == 'Ansible'
+    assert result[1].driver_name == 'docker'
+    assert result[1].provisioner_name == 'ansible'
     assert result[1].scenario_name == 'default'
-    assert result[1].created == 'False'
-    assert result[1].converged == 'False'
+    assert result[1].created == 'false'
+    assert result[1].converged == 'false'
+
+
+def test_created(_instance):
+    assert 'false' == _instance._created()
+
+
+def test_converged(_instance):
+    assert 'false' == _instance._converged()

--- a/test/unit/driver/test_ec2.py
+++ b/test/unit/driver/test_ec2.py
@@ -195,18 +195,18 @@ def test_status(mocker, _instance):
     assert 2 == len(result)
 
     assert result[0].instance_name == 'instance-1'
-    assert result[0].driver_name == 'Ec2'
-    assert result[0].provisioner_name == 'Ansible'
+    assert result[0].driver_name == 'ec2'
+    assert result[0].provisioner_name == 'ansible'
     assert result[0].scenario_name == 'default'
-    assert result[0].created == 'False'
-    assert result[0].converged == 'False'
+    assert result[0].created == 'false'
+    assert result[0].converged == 'false'
 
     assert result[1].instance_name == 'instance-2'
-    assert result[1].driver_name == 'Ec2'
-    assert result[1].provisioner_name == 'Ansible'
+    assert result[1].driver_name == 'ec2'
+    assert result[1].provisioner_name == 'ansible'
     assert result[1].scenario_name == 'default'
-    assert result[1].created == 'False'
-    assert result[1].converged == 'False'
+    assert result[1].created == 'false'
+    assert result[1].converged == 'false'
 
 
 def test_get_instance_config(mocker, _instance):
@@ -221,3 +221,11 @@ def test_get_instance_config(mocker, _instance):
         'instance': 'foo',
     }
     assert x == _instance._get_instance_config('foo')
+
+
+def test_created(_instance):
+    assert 'false' == _instance._created()
+
+
+def test_converged(_instance):
+    assert 'false' == _instance._converged()

--- a/test/unit/driver/test_gce.py
+++ b/test/unit/driver/test_gce.py
@@ -195,18 +195,18 @@ def test_status(mocker, _instance):
     assert 2 == len(result)
 
     assert result[0].instance_name == 'instance-1'
-    assert result[0].driver_name == 'Gce'
-    assert result[0].provisioner_name == 'Ansible'
+    assert result[0].driver_name == 'gce'
+    assert result[0].provisioner_name == 'ansible'
     assert result[0].scenario_name == 'default'
-    assert result[0].created == 'False'
-    assert result[0].converged == 'False'
+    assert result[0].created == 'false'
+    assert result[0].converged == 'false'
 
     assert result[1].instance_name == 'instance-2'
-    assert result[1].driver_name == 'Gce'
-    assert result[1].provisioner_name == 'Ansible'
+    assert result[1].driver_name == 'gce'
+    assert result[1].provisioner_name == 'ansible'
     assert result[1].scenario_name == 'default'
-    assert result[1].created == 'False'
-    assert result[1].converged == 'False'
+    assert result[1].created == 'false'
+    assert result[1].converged == 'false'
 
 
 def test_get_instance_config(mocker, _instance):
@@ -221,3 +221,11 @@ def test_get_instance_config(mocker, _instance):
         'instance': 'foo',
     }
     assert x == _instance._get_instance_config('foo')
+
+
+def test_created(_instance):
+    assert 'false' == _instance._created()
+
+
+def test_converged(_instance):
+    assert 'false' == _instance._converged()

--- a/test/unit/driver/test_lxc.py
+++ b/test/unit/driver/test_lxc.py
@@ -103,15 +103,23 @@ def test_status(mocker, _instance):
     assert 2 == len(result)
 
     assert result[0].instance_name == 'instance-1'
-    assert result[0].driver_name == 'Lxc'
-    assert result[0].provisioner_name == 'Ansible'
+    assert result[0].driver_name == 'lxc'
+    assert result[0].provisioner_name == 'ansible'
     assert result[0].scenario_name == 'default'
-    assert result[0].created == 'False'
-    assert result[0].converged == 'False'
+    assert result[0].created == 'false'
+    assert result[0].converged == 'false'
 
     assert result[1].instance_name == 'instance-2'
-    assert result[1].driver_name == 'Lxc'
-    assert result[1].provisioner_name == 'Ansible'
+    assert result[1].driver_name == 'lxc'
+    assert result[1].provisioner_name == 'ansible'
     assert result[1].scenario_name == 'default'
-    assert result[1].created == 'False'
-    assert result[1].converged == 'False'
+    assert result[1].created == 'false'
+    assert result[1].converged == 'false'
+
+
+def test_created_property(_instance):
+    assert 'false' == _instance._created()
+
+
+def test_converged_property(_instance):
+    assert 'false' == _instance._converged()

--- a/test/unit/driver/test_lxd.py
+++ b/test/unit/driver/test_lxd.py
@@ -103,15 +103,23 @@ def test_status(mocker, _instance):
     assert 2 == len(result)
 
     assert result[0].instance_name == 'instance-1'
-    assert result[0].driver_name == 'Lxd'
-    assert result[0].provisioner_name == 'Ansible'
+    assert result[0].driver_name == 'lxd'
+    assert result[0].provisioner_name == 'ansible'
     assert result[0].scenario_name == 'default'
-    assert result[0].created == 'False'
-    assert result[0].converged == 'False'
+    assert result[0].created == 'false'
+    assert result[0].converged == 'false'
 
     assert result[1].instance_name == 'instance-2'
-    assert result[1].driver_name == 'Lxd'
-    assert result[1].provisioner_name == 'Ansible'
+    assert result[1].driver_name == 'lxd'
+    assert result[1].provisioner_name == 'ansible'
     assert result[1].scenario_name == 'default'
-    assert result[1].created == 'False'
-    assert result[1].converged == 'False'
+    assert result[1].created == 'false'
+    assert result[1].converged == 'false'
+
+
+def test_created(_instance):
+    assert 'false' == _instance._created()
+
+
+def test_converged(_instance):
+    assert 'false' == _instance._converged()

--- a/test/unit/driver/test_openstack.py
+++ b/test/unit/driver/test_openstack.py
@@ -197,18 +197,18 @@ def test_status(mocker, _instance):
     assert 2 == len(result)
 
     assert result[0].instance_name == 'instance-1'
-    assert result[0].driver_name == 'Openstack'
-    assert result[0].provisioner_name == 'Ansible'
+    assert result[0].driver_name == 'openstack'
+    assert result[0].provisioner_name == 'ansible'
     assert result[0].scenario_name == 'default'
-    assert result[0].created == 'False'
-    assert result[0].converged == 'False'
+    assert result[0].created == 'false'
+    assert result[0].converged == 'false'
 
     assert result[1].instance_name == 'instance-2'
-    assert result[1].driver_name == 'Openstack'
-    assert result[1].provisioner_name == 'Ansible'
+    assert result[1].driver_name == 'openstack'
+    assert result[1].provisioner_name == 'ansible'
     assert result[1].scenario_name == 'default'
-    assert result[1].created == 'False'
-    assert result[1].converged == 'False'
+    assert result[1].created == 'false'
+    assert result[1].converged == 'false'
 
 
 def test_get_instance_config(mocker, _instance):
@@ -223,3 +223,11 @@ def test_get_instance_config(mocker, _instance):
         'instance': 'foo',
     }
     assert x == _instance._get_instance_config('foo')
+
+
+def test_created(_instance):
+    assert 'false' == _instance._created()
+
+
+def test_converged(_instance):
+    assert 'false' == _instance._converged()

--- a/test/unit/driver/test_vagrant.py
+++ b/test/unit/driver/test_vagrant.py
@@ -227,18 +227,18 @@ def test_status(mocker, _instance):
     assert 2 == len(result)
 
     assert result[0].instance_name == 'instance-1'
-    assert result[0].driver_name == 'Vagrant'
-    assert result[0].provisioner_name == 'Ansible'
+    assert result[0].driver_name == 'vagrant'
+    assert result[0].provisioner_name == 'ansible'
     assert result[0].scenario_name == 'default'
-    assert result[0].created == 'False'
-    assert result[0].converged == 'False'
+    assert result[0].created == 'false'
+    assert result[0].converged == 'false'
 
     assert result[1].instance_name == 'instance-2'
-    assert result[1].driver_name == 'Vagrant'
-    assert result[1].provisioner_name == 'Ansible'
+    assert result[1].driver_name == 'vagrant'
+    assert result[1].provisioner_name == 'ansible'
     assert result[1].scenario_name == 'default'
-    assert result[1].created == 'False'
-    assert result[1].converged == 'False'
+    assert result[1].created == 'false'
+    assert result[1].converged == 'false'
 
 
 def test_get_instance_config(mocker, _instance):
@@ -253,3 +253,11 @@ def test_get_instance_config(mocker, _instance):
         'instance': 'foo',
     }
     assert x == _instance._get_instance_config('foo')
+
+
+def test_created(_instance):
+    assert 'false' == _instance._created()
+
+
+def test_converged(_instance):
+    assert 'false' == _instance._converged()


### PR DESCRIPTION
When executing `molecule list` on the delegated driver, it should
display created as unknown when marked as `unmanaged`.