### PR TITLE
Disallow null provider.env values

### DIFF
--- a/molecule/model/schema_v2.py
+++ b/molecule/model/schema_v2.py
@@ -179,6 +179,9 @@ base_schema = {
                     'type': 'string',
                     'regex': '^[A-Z0-9_-]+$',
                 },
+                'valueschema': {
+                    'nullable': False,
+                },
                 'schema': {
                     'ANSIBLE_BECOME': {
                         'type': 'string',

--- a/test/unit/model/v2/test_provisioner_section.py
+++ b/test/unit/model/v2/test_provisioner_section.py
@@ -97,6 +97,7 @@ def _model_provisioner_errors_section_data():
             'env': {
                 'foo': 'foo',
                 'foo-bar': 'foo-bar',
+                'foo-bar-baz': None,
             },
             'inventory': {
                 'host_vars': [],
@@ -156,6 +157,10 @@ def test_provisioner_has_errors(_config):
             'env': [{
                 'foo': ["value does not match regex '^[A-Z0-9_-]+$'"],
                 'foo-bar': ["value does not match regex '^[A-Z0-9_-]+$'"],
+                'foo-bar-baz': [
+                    "value does not match regex '^[A-Z0-9_-]+$'",
+                    'null value not allowed'
+                ],
             }],
             'options': ['must be of dict type'],
             'name': ['must be of string type'],


### PR DESCRIPTION
Update the v2 schema to disallow null provider.env values.

Fixes: #1253