### PR TITLE
Render inventory links relative to scenario dir

### DIFF
--- a/molecule/provisioner/ansible.py
+++ b/molecule/provisioner/ansible.py
@@ -230,8 +230,8 @@ class Ansible(base.Base):
 
     .. note::
 
-        The source directory linking is relative to the scenario's ephemeral
-        directory (`molecule/$scenario_name/.molecule/`).
+        The source directory linking is relative to the scenario's
+        directory.
 
         The only valid keys are `group_vars` and `host_vars`.  Molecule's
         schema validator will enforce this.
@@ -677,8 +677,7 @@ class Ansible(base.Base):
         """
         for d, source in self.links.items():
             target = os.path.join(self._config.scenario.ephemeral_directory, d)
-            source = os.path.join(self._config.scenario.ephemeral_directory,
-                                  source)
+            source = os.path.join(self._config.scenario.directory, source)
 
             if not os.path.exists(source):
                 msg = "The source path '{}' does not exist.".format(source)

--- a/test/scenarios/host_group_vars/group_vars/example/all.yml
+++ b/test/scenarios/host_group_vars/group_vars/example/all.yml
@@ -1,0 +1,2 @@
+---
+host_group_vars_group_vars_linked: true

--- a/test/scenarios/host_group_vars/host_vars/instance/all.yml
+++ b/test/scenarios/host_group_vars/host_vars/instance/all.yml
@@ -1,0 +1,2 @@
+---
+host_group_vars_host_vars_linked: true

--- a/test/scenarios/host_group_vars/molecule/links/molecule.yml
+++ b/test/scenarios/host_group_vars/molecule/links/molecule.yml
@@ -1,0 +1,33 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+  options:
+    config-file: ../../resources/.yamllint
+platforms:
+  - name: instance
+    image: centos:latest
+    groups:
+      - example
+    children:
+      - example_1
+provisioner:
+  name: ansible
+  inventory:
+    links:
+      host_vars: ../../host_vars
+      group_vars: ../../group_vars
+  playbooks:
+    create: ../../../../resources/playbooks/docker/create.yml
+    destroy: ../../../../resources/playbooks/docker/destroy.yml
+  lint:
+    name: ansible-lint
+scenario:
+  name: links
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/test/scenarios/host_group_vars/molecule/links/playbook.yml
+++ b/test/scenarios/host_group_vars/molecule/links/playbook.yml
@@ -1,0 +1,10 @@
+---
+- hosts: all
+  tasks:
+    - name: Host vars from host_vars links
+      command: echo "{{ host_group_vars_host_vars_linked }}"
+      changed_when: false
+
+    - name: Group vars from group_vars links
+      command: echo "{{ host_group_vars_group_vars_linked }}"
+      changed_when: false

--- a/test/scenarios/host_group_vars/molecule/links/prepare.yml
+++ b/test/scenarios/host_group_vars/molecule/links/prepare.yml
@@ -1,0 +1,5 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  tasks: []

--- a/test/unit/provisioner/test_ansible.py
+++ b/test/unit/provisioner/test_ansible.py
@@ -909,10 +909,11 @@ def test_link_vars(_instance):
         'host_vars': '../host_vars'
     }
     ephemeral_dir = _instance._config.scenario.ephemeral_directory
-    source_group_vars = os.path.join(ephemeral_dir, os.path.pardir,
+    scenario_dir = _instance._config.scenario.directory
+    source_group_vars = os.path.join(scenario_dir, os.path.pardir,
                                      'group_vars')
     target_group_vars = os.path.join(ephemeral_dir, 'group_vars')
-    source_host_vars = os.path.join(ephemeral_dir, os.path.pardir, 'host_vars')
+    source_host_vars = os.path.join(scenario_dir, os.path.pardir, 'host_vars')
     target_host_vars = os.path.join(ephemeral_dir, 'host_vars')
 
     os.mkdir(source_group_vars)
@@ -934,8 +935,8 @@ def test_link_vars_raises_when_source_not_found(_instance,
 
     assert 1 == e.value.code
 
-    source = os.path.join(_instance._config.scenario.ephemeral_directory,
-                          os.path.pardir, 'bar')
+    source = os.path.join(_instance._config.scenario.directory, os.path.pardir,
+                          'bar')
     msg = "The source path '{}' does not exist.".format(source)
     patched_logger_critical.assert_called_once_with(msg)
 


### PR DESCRIPTION
Due to the nature of #1218, we cannot fix
this in a non-breaking way.  The links are now relative
to the scenario_directory vs the old ephemeral directory
which used to live under the current directory.

Added functional tests to ensure this does not happen again
in the future.

Fixes: #1252