### PR TITLE
Converge with built in Molecule skip tags

### DIFF
--- a/molecule/provisioner/ansible.py
+++ b/molecule/provisioner/ansible.py
@@ -41,6 +41,9 @@ class Ansible(base.Base):
     must provide the create, destroy, and converge playbooks.  Molecule's
     `init` subcommand will provide the necessary files for convenience.
 
+    Molecule will skip tasks which are taged with either `molecule-notest` or
+    `notest`.
+
     .. important::
 
         Reserve the create and destroy playbooks for provisioning.  Do not
@@ -294,7 +297,9 @@ class Ansible(base.Base):
 
     @property
     def default_options(self):
-        d = {}
+        d = {
+            'skip-tags': 'molecule-notest,notest',
+        }
         if self._config.debug:
             d['vvv'] = True
             d['diff'] = True

--- a/test/unit/provisioner/test_ansible.py
+++ b/test/unit/provisioner/test_ansible.py
@@ -137,7 +137,9 @@ def test_default_config_options_property(_instance):
 
 
 def test_default_options_property(_instance):
-    assert {} == _instance.default_options
+    assert {
+        'skip-tags': 'molecule-notest,notest',
+    } == _instance.default_options
 
 
 def test_default_env_property(_instance):
@@ -186,7 +188,12 @@ def test_config_options_property(_instance):
 @pytest.mark.parametrize(
     'config_instance', ['_provisioner_section_data'], indirect=True)
 def test_options_property(_instance):
-    x = {'become': True, 'foo': 'bar', 'v': True}
+    x = {
+        'become': True,
+        'foo': 'bar',
+        'v': True,
+        'skip-tags': 'molecule-notest,notest',
+    }
 
     assert x == _instance.options
 
@@ -195,15 +202,20 @@ def test_options_property_does_not_merge(_instance):
     for action in ['create', 'destroy']:
         _instance._config.action = action
 
-        assert {} == _instance.options
+        assert {
+            'skip-tags': 'molecule-notest,notest',
+        } == _instance.options
 
 
 def test_options_property_handles_cli_args(_instance):
-    _instance._config.args = {'debug': True}
+    _instance._config.args = {
+        'debug': True,
+    }
     x = {
         'vvv': True,
         'become': True,
         'diff': True,
+        'skip-tags': 'molecule-notest,notest',
     }
 
     assert x == _instance.options

--- a/test/unit/provisioner/test_ansible_playbook.py
+++ b/test/unit/provisioner/test_ansible_playbook.py
@@ -56,6 +56,7 @@ def test_bake(_inventory_file, _instance):
         str(sh.ansible_playbook),
         '--become',
         '--inventory={}'.format(_inventory_file),
+        '--skip-tags=molecule-notest,notest',
         pb,
     ]
     result = str(_instance._ansible_command).split()
@@ -67,8 +68,9 @@ def test_bake_removes_non_interactive_options_from_non_converge_playbooks(
         _inventory_file, _instance):
     _instance.bake()
 
-    x = '{} --inventory={} playbook'.format(
-        str(sh.ansible_playbook), _inventory_file)
+    x = ('{} --skip-tags=molecule-notest,notest '
+         '--inventory={} playbook').format(
+             str(sh.ansible_playbook), _inventory_file)
 
     assert x == _instance._ansible_command
 
@@ -77,8 +79,9 @@ def test_bake_has_ansible_args(_inventory_file, _instance):
     _instance._config.ansible_args = ('foo', 'bar')
     _instance.bake()
 
-    x = '{} --inventory={} playbook foo bar'.format(
-        str(sh.ansible_playbook), _inventory_file)
+    x = ('{} --skip-tags=molecule-notest,notest '
+         '--inventory={} playbook foo bar').format(
+             str(sh.ansible_playbook), _inventory_file)
 
     assert x == _instance._ansible_command
 
@@ -89,8 +92,9 @@ def test_bake_does_not_have_ansible_args(_inventory_file, _instance):
         _instance._config.action = action
         _instance.bake()
 
-        x = '{} --inventory={} playbook'.format(
-            str(sh.ansible_playbook), _inventory_file)
+        x = ('{} --skip-tags=molecule-notest,notest '
+             '--inventory={} playbook').format(
+                 str(sh.ansible_playbook), _inventory_file)
 
         assert x == _instance._ansible_command
 
@@ -108,8 +112,9 @@ def test_execute_bakes(_inventory_file, patched_run_command, _instance):
 
     assert _instance._ansible_command is not None
 
-    cmd = '{} --inventory={} playbook'.format(
-        str(sh.ansible_playbook), _inventory_file)
+    cmd = ('{} --skip-tags=molecule-notest,notest '
+           '--inventory={} playbook').format(
+               str(sh.ansible_playbook), _inventory_file)
     patched_run_command.assert_called_once_with(cmd, debug=False)
 
 
@@ -120,8 +125,9 @@ def test_execute_bakes_with_ansible_args(_inventory_file, patched_run_command,
 
     assert _instance._ansible_command is not None
 
-    cmd = '{} --inventory={} playbook --foo --bar'.format(
-        str(sh.ansible_playbook), _inventory_file)
+    cmd = ('{} --skip-tags=molecule-notest,notest --inventory={} '
+           'playbook --foo --bar').format(
+               str(sh.ansible_playbook), _inventory_file)
     patched_run_command.assert_called_once_with(cmd, debug=False)
 
 


### PR DESCRIPTION
Molecule will always converge with `--skip-tags=molecule-notest,notest`.
This allows the developer to easily mark tasks they wish Molecule
to skip.