### PR TITLE
Added Inspec verifier

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -300,6 +300,17 @@ Lint
 
 The Goss verifier does not utilize a linter.
 
+Inspec
+^^^^^^
+
+.. autoclass:: molecule.verifier.inspec.Inspec()
+   :undoc-members:
+
+Lint
+....
+
+The Inspec verifier does not utilize a linter.
+
 Testinfra
 ^^^^^^^^^
 

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -44,6 +44,7 @@ from molecule.lint import yamllint
 from molecule.model import schema_v2
 from molecule.provisioner import ansible
 from molecule.verifier import goss
+from molecule.verifier import inspec
 from molecule.verifier import testinfra
 
 LOG = logger.get_logger(__name__)
@@ -214,6 +215,8 @@ class Config(object):
         verifier_name = self.config['verifier']['name']
         if verifier_name == 'testinfra':
             return testinfra.Testinfra(self)
+        elif verifier_name == 'inspec':
+            return inspec.Inspec(self)
         elif verifier_name == 'goss':
             return goss.Goss(self)
 
@@ -415,4 +418,8 @@ def molecule_drivers():
 
 
 def molecule_verifiers():
-    return [goss.Goss(None).name, testinfra.Testinfra(None).name]
+    return [
+        goss.Goss(None).name,
+        inspec.Inspec(None).name,
+        testinfra.Testinfra(None).name,
+    ]

--- a/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
+++ b/molecule/cookiecutter/molecule/{{cookiecutter.role_name}}/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
@@ -47,6 +47,6 @@ verifier:
   name: {{ cookiecutter.verifier_name }}
   lint:
     name: {{ cookiecutter.verifier_lint_name }}
-{%- if cookiecutter.verifier_name == 'goss' %}
+{%- if cookiecutter.verifier_name == 'goss' or cookiecutter.verifier_name == 'inspec' %}
     enabled: false
 {%- endif %}

--- a/molecule/cookiecutter/scenario/verifier/goss/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
+++ b/molecule/cookiecutter/scenario/verifier/goss/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
@@ -2,12 +2,6 @@
 # This is an example playbook to execute goss tests.
 # Tests need distributed to the appropriate ansible host/groups
 # prior to execution by `goss validate`.
-#
-# The goss ansible module is installed with molecule.  The ANSIBLE_LIBRARY
-# path is updated appropriately on `molecule verify`.
-
-# Details about ansible module:
-#  - https://github.com/indusbox/goss-ansible
 
 {% raw -%}
 - name: Verify
@@ -48,7 +42,7 @@
       register: test_results
       with_items: "{{ test_files.stdout_lines }}"
 
-    - name: Display details about the goss results
+    - name: Display details about the Goss results
       debug:
         msg: "{{ item.stdout_lines }}"
       with_items: "{{ test_results.results }}"

--- a/molecule/cookiecutter/scenario/verifier/inspec/cookiecutter.json
+++ b/molecule/cookiecutter/scenario/verifier/inspec/cookiecutter.json
@@ -1,0 +1,7 @@
+{
+    "molecule_directory": "molecule",
+
+    "role_name": "OVERRIDEN",
+    "scenario_name": "default",
+    "verifier_directory": "tests"
+}

--- a/molecule/cookiecutter/scenario/verifier/inspec/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
+++ b/molecule/cookiecutter/scenario/verifier/inspec/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
@@ -1,0 +1,64 @@
+---
+# This is an example playbook to execute inspec tests.
+# Tests need distributed to the appropriate ansible host/groups
+# prior to execution by `inspec exec`.
+
+{% raw -%}
+- name: Verify
+  hosts: all
+  become: true
+  vars:
+    inspec_download_url: "https://packages.chef.io/files/stable/inspec/2.1.43/el/7/inspec-2.1.43-1.el7.x86_64.rpm"
+    inspec_download_source_dir: /usr/local/src
+    inspec_download_sha256sum: bf36072724322fcca708467e5fc1973e838f605d655d72a2ba17f3365b39cd08
+
+    inspec_package_name: "{{ inspec_download_url.split('/')[-1] }}"
+    inspec_bin: /opt/inspec/bin/inspec
+
+    inspec_test_directory: "/tmp/molecule/inspec"
+  tasks:
+    - name: Download Inspec
+      get_url:
+        url: "{{ inspec_download_url }}"
+        dest: "{{ inspec_download_source_dir }}"
+        sha256sum: "{{ inspec_download_sha256sum }}"
+        mode: 0755
+
+    - name: Install Inspec
+      yum:
+        name: "{{ inspec_download_source_dir }}/{{ inspec_package_name }}"
+        state: latest
+
+    - name: Create Molecule directory for test files
+      file:
+        path: "{{ inspec_test_directory }}"
+        state: directory
+
+    - name: Copy Inspec tests to remote
+      copy:
+        src: "{{ item }}"
+        dest: "{{ inspec_test_directory }}/{{ item | basename }}"
+      with_fileglob:
+        - "{{ playbook_dir }}/tests/test_*.rb"
+
+    - name: Register test files
+      shell: "ls {{ inspec_test_directory }}/test_*.rb"
+      register: test_files
+
+    - name: Execute Inspec tests
+      command: "{{ inspec_bin }} exec {{ item }}"
+      register: test_results
+      with_items: "{{ test_files.stdout_lines }}"
+      ignore_errors: true
+
+    - name: Display details about the Inspec results
+      debug:
+        msg: "{{ item.stdout_lines }}"
+      with_items: "{{ test_results.results }}"
+
+    - name: Fail when tests fail
+      fail:
+        msg: "Inspec failed to validate"
+      when: item.rc != 0
+      with_items: "{{ test_results.results }}"
+{% endraw -%}

--- a/molecule/cookiecutter/scenario/verifier/inspec/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/{{cookiecutter.verifier_directory}}/test_default.rb
+++ b/molecule/cookiecutter/scenario/verifier/inspec/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/{{cookiecutter.verifier_directory}}/test_default.rb
@@ -1,0 +1,7 @@
+# Molecule managed
+
+describe file('/etc/hosts') do
+  its('owner') { should eq 'root' }
+  its('group') { should eq 'root' }
+  its('mode') { should cmp '0644' }
+end

--- a/molecule/model/schema_v2.py
+++ b/molecule/model/schema_v2.py
@@ -310,6 +310,7 @@ base_schema = {
                 'type': 'string',
                 'allowed': [
                     'testinfra',
+                    'inspec',
                     'goss',
                 ],
             },

--- a/molecule/verifier/inspec.py
+++ b/molecule/verifier/inspec.py
@@ -27,19 +27,23 @@ from molecule.verifier import base
 LOG = logger.get_logger(__name__)
 
 
-class Goss(base.Base):
+class Inspec(base.Base):
     """
-    `Goss`_ is not the default test runner.
+    `Inspec`_ is not the default test runner.
 
-    `Goss`_ is a YAML based serverspec-like tool for validating a server's
-    configuration.  `Goss`_ is `not` the default verifier used in Molecule.
+    `InSpec`_ is Chef's open-source language for describing security &
+    compliance rules that can be shared between software engineers, operations,
+    and security engineers. Your compliance, security, and other policy
+    requirements become automated tests throughout all stages of the software
+    delivery process. `Inspec`_ is `not` the default verifier used in Molecule.
 
     Molecule executes a playbook (`verify.yml`) located in the role's
-    `scenario.directory`.  This playbook will copy YAML files to the instances,
-    and execute Goss using a community written Goss Ansible module bundled with
-    Molecule.
+    `scenario.directory`.  This playbook will copy test files to the instances,
+    and execute Inspec locally over Ansible.  Molecule executes Inspec over an
+    Ansible transport, in an attempt to provide Inspec support across all
+    Molecule drivers.
 
-    Additional options can be passed to `goss validate` by modifying the verify
+    Additional options can be passed to `inspec exec` by modifying the verify
     playbook.
 
     The testing can be disabled by setting `enabled` to False.
@@ -47,7 +51,7 @@ class Goss(base.Base):
     .. code-block:: yaml
 
         verifier:
-          name: goss
+          name: inspec
           enabled: False
 
     .. important::
@@ -55,23 +59,23 @@ class Goss(base.Base):
         Due to the nature of this verifier.  Molecule does not perform options
         handling in the same fashion as Testinfra.
 
-    .. _`Goss`: https://github.com/aelsabbahy/goss
+    .. _`Inspec`: https://www.chef.io/inspec/
     """
 
     def __init__(self, config):
         """
-        Sets up the requirements to execute `goss` and returns None.
+        Sets up the requirements to execute `inspec` and returns None.
 
         :param config: An instance of a Molecule config.
         :return: None
         """
-        super(Goss, self).__init__(config)
+        super(Inspec, self).__init__(config)
         if config:
             self._tests = self._get_tests()
 
     @property
     def name(self):
-        return 'goss'
+        return 'inspec'
 
     @property
     def default_options(self):
@@ -95,7 +99,7 @@ class Goss(base.Base):
             LOG.warn(msg)
             return
 
-        msg = 'Executing Goss tests found in {}/...'.format(self.directory)
+        msg = 'Executing Inspec tests found in {}/...'.format(self.directory)
         LOG.info(msg)
 
         self._config.provisioner.verify()
@@ -110,5 +114,5 @@ class Goss(base.Base):
         :return: list
         """
         return [
-            filename for filename in util.os_walk(self.directory, 'test_*.yml')
+            filename for filename in util.os_walk(self.directory, 'test_*.rb')
         ]

--- a/test/functional/docker/test_scenarios.py
+++ b/test/functional/docker/test_scenarios.py
@@ -64,6 +64,43 @@ def test_command_side_effect(scenario_to_test, with_scenario, scenario_name):
     pytest.helpers.run_command(cmd)
 
 
+def test_command_init_role_inspec(temp_dir):
+    role_directory = os.path.join(temp_dir.strpath, 'test-init')
+    options = {
+        'role_name': 'test-init',
+        'verifier_name': 'inspec',
+    }
+    cmd = sh.molecule.bake('init', 'role', **options)
+    pytest.helpers.run_command(cmd)
+
+    os.chdir(role_directory)
+
+    sh.molecule('test')
+
+
+def test_command_init_scenario_inspec(temp_dir):
+    options = {
+        'role_name': 'test-init',
+    }
+    cmd = sh.molecule.bake('init', 'role', **options)
+    pytest.helpers.run_command(cmd)
+
+    role_directory = os.path.join(temp_dir.strpath, 'test-init')
+    os.chdir(role_directory)
+
+    molecule_directory = pytest.helpers.molecule_directory()
+    scenario_directory = os.path.join(molecule_directory, 'test-scenario')
+    options = {
+        'scenario_name': 'test-scenario',
+        'role_name': 'test-init',
+        'verifier_name': 'inspec',
+    }
+    cmd = sh.molecule.bake('init', 'scenario', **options)
+    pytest.helpers.run_command(cmd)
+
+    assert os.path.isdir(scenario_directory)
+
+
 def test_command_init_role_goss(temp_dir):
     role_directory = os.path.join(temp_dir.strpath, 'test-init')
     options = {

--- a/test/scenarios/verifier/molecule/goss/verify.yml
+++ b/test/scenarios/verifier/molecule/goss/verify.yml
@@ -33,7 +33,7 @@
       register: test_results
       with_items: "{{ test_files.stdout_lines }}"
 
-    - name: Display details about the goss results
+    - name: Display details about the Goss results
       debug:
         msg: "{{ item.stdout_lines }}"
       with_items: "{{ test_results.results }}"

--- a/test/scenarios/verifier/molecule/inspec/molecule.yml
+++ b/test/scenarios/verifier/molecule/inspec/molecule.yml
@@ -1,0 +1,26 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+  options:
+    config-file: ../../resources/.yamllint
+platforms:
+  - name: instance
+    image: centos:latest
+provisioner:
+  name: ansible
+  playbooks:
+    create: ../../../../resources/playbooks/docker/create.yml
+    destroy: ../../../../resources/playbooks/docker/destroy.yml
+  lint:
+    name: ansible-lint
+scenario:
+  name: inspec
+verifier:
+  name: inspec
+  lint:
+    name: flake8
+    enabled: false

--- a/test/scenarios/verifier/molecule/inspec/playbook.yml
+++ b/test/scenarios/verifier/molecule/inspec/playbook.yml
@@ -1,0 +1,19 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Create /etc/molecule
+      file:
+        dest: /etc/molecule
+        group: root
+        owner: root
+        mode: 0755
+        state: directory
+
+    - name: Create /etc/molecule/{{ ansible_hostname }}
+      copy:
+        dest: "/etc/molecule/{{ ansible_hostname }}"
+        group: root
+        owner: root
+        mode: 0644
+        content: "{{ ansible_hostname }}"

--- a/test/scenarios/verifier/molecule/inspec/prepare.yml
+++ b/test/scenarios/verifier/molecule/inspec/prepare.yml
@@ -1,0 +1,5 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  tasks: []

--- a/test/scenarios/verifier/molecule/inspec/tests/test_default.rb
+++ b/test/scenarios/verifier/molecule/inspec/tests/test_default.rb
@@ -1,0 +1,14 @@
+# Molecule managed
+
+describe directory('/etc/molecule') do
+  its('owner') { should eq 'root' }
+  its('group') { should eq 'root' }
+  its('mode') { should cmp '0755' }
+end
+
+describe file('/etc/molecule/instance') do
+  its('owner') { should eq 'root' }
+  its('group') { should eq 'root' }
+  its('mode') { should cmp '0644' }
+  its('content') { should match(%r{instance}) }
+end

--- a/test/scenarios/verifier/molecule/inspec/verify.yml
+++ b/test/scenarios/verifier/molecule/inspec/verify.yml
@@ -1,0 +1,58 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  vars:
+    inspec_download_url: "https://packages.chef.io/files/stable/inspec/2.1.43/el/7/inspec-2.1.43-1.el7.x86_64.rpm"
+    inspec_download_source_dir: /usr/local/src
+    inspec_download_sha256sum: bf36072724322fcca708467e5fc1973e838f605d655d72a2ba17f3365b39cd08
+
+    inspec_package_name: "{{ inspec_download_url.split('/')[-1] }}"
+    inspec_bin: /opt/inspec/bin/inspec
+
+    inspec_test_directory: "/tmp/molecule/inspec"
+  tasks:
+    - name: Download Inspec
+      get_url:
+        url: "{{ inspec_download_url }}"
+        dest: "{{ inspec_download_source_dir }}"
+        sha256sum: "{{ inspec_download_sha256sum }}"
+        mode: 0755
+
+    - name: Install Inspec
+      yum:
+        name: "{{ inspec_download_source_dir }}/{{ inspec_package_name }}"
+        state: latest
+
+    - name: Create Molecule directory for test files
+      file:
+        path: "{{ inspec_test_directory }}"
+        state: directory
+
+    - name: Copy Inspec tests to remote
+      copy:
+        src: "{{ item }}"
+        dest: "{{ inspec_test_directory }}/{{ item | basename }}"
+      with_fileglob:
+        - "{{ playbook_dir }}/tests/test_*.rb"
+
+    - name: Register test files
+      shell: "ls {{ inspec_test_directory }}/test_*.rb"
+      register: test_files
+
+    - name: Execute Inspec tests
+      command: "{{ inspec_bin }} exec {{ item }}"
+      register: test_results
+      with_items: "{{ test_files.stdout_lines }}"
+      ignore_errors: true
+
+    - name: Display details about the Inspec results
+      debug:
+        msg: "{{ item.stdout_lines }}"
+      with_items: "{{ test_results.results }}"
+
+    - name: Fail when tests fail
+      fail:
+        msg: "Inspec failed to validate"
+      when: item.rc != 0
+      with_items: "{{ test_results.results }}"

--- a/test/unit/cookiecutter/test_molecule.py
+++ b/test/unit/cookiecutter/test_molecule.py
@@ -114,6 +114,20 @@ def test_drivers(driver, temp_dir, _molecule_file, _role_directory,
     pytest.helpers.run_command(cmd)
 
 
+def test_verifier_lint_when_verifier_inspec(
+        temp_dir, _molecule_file, _role_directory, _command_args, _instance):
+    _command_args['verifier_name'] = 'inspec'
+    _instance._process_templates('molecule', _command_args, _role_directory)
+
+    data = util.safe_load_file(_molecule_file)
+
+    assert {} == schema_v2.validate(data)
+    assert not data['verifier']['lint']['enabled']
+
+    cmd = sh.yamllint.bake('-s', _molecule_file)
+    pytest.helpers.run_command(cmd)
+
+
 def test_verifier_lint_when_verifier_goss(
         temp_dir, _molecule_file, _role_directory, _command_args, _instance):
     _command_args['verifier_name'] = 'goss'

--- a/test/unit/model/v2/test_verifier_section.py
+++ b/test/unit/model/v2/test_verifier_section.py
@@ -133,6 +133,18 @@ def _model_verifier_allows_ansible_lint_section_data():
 
 
 @pytest.fixture
+def _model_verifier_allows_inspec_section_data():
+    return {
+        'verifier': {
+            'name': 'inspec',
+            'lint': {
+                'name': 'flake8',
+            },
+        }
+    }
+
+
+@pytest.fixture
 def _model_verifier_allows_goss_section_data():
     return {
         'verifier': {
@@ -147,6 +159,7 @@ def _model_verifier_allows_goss_section_data():
 @pytest.mark.parametrize(
     '_config', [
         ('_model_verifier_allows_ansible_lint_section_data'),
+        ('_model_verifier_allows_inspec_section_data'),
         ('_model_verifier_allows_goss_section_data'),
     ],
     indirect=True)

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -42,6 +42,7 @@ from molecule.driver import vagrant
 from molecule.lint import yamllint
 from molecule.provisioner import ansible
 from molecule.verifier import goss
+from molecule.verifier import inspec
 from molecule.verifier import testinfra
 
 
@@ -331,6 +332,21 @@ def test_verifier_property(config_instance):
 
 
 @pytest.fixture
+def _config_verifier_inspec_section_data():
+    return {
+        'verifier': {
+            'name': 'inspec'
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    'config_instance', ['_config_verifier_inspec_section_data'], indirect=True)
+def test_verifier_property_is_inspec(config_instance):
+    assert isinstance(config_instance.verifier, inspec.Inspec)
+
+
+@pytest.fixture
 def _config_verifier_goss_section_data():
     return {
         'verifier': {
@@ -346,7 +362,7 @@ def test_verifier_property_is_goss(config_instance):
 
 
 def test_verifiers_property(config_instance):
-    x = ['goss', 'testinfra']
+    x = ['goss', 'inspec', 'testinfra']
 
     assert x == config_instance.verifiers
 
@@ -461,6 +477,6 @@ def test_molecule_drivers():
 
 
 def test_molecule_verifiers():
-    x = ['goss', 'testinfra']
+    x = ['goss', 'inspec', 'testinfra']
 
     assert x == config.molecule_verifiers()

--- a/test/unit/verifier/test_inspec.py
+++ b/test/unit/verifier/test_inspec.py
@@ -23,7 +23,7 @@ import os
 import pytest
 
 from molecule import config
-from molecule.verifier import goss
+from molecule.verifier import inspec
 
 
 @pytest.fixture
@@ -35,11 +35,11 @@ def _patched_ansible_verify(mocker):
 
 
 @pytest.fixture
-def _patched_goss_get_tests(mocker):
-    m = mocker.patch('molecule.verifier.goss.Goss._get_tests')
+def _patched_inspec_get_tests(mocker):
+    m = mocker.patch('molecule.verifier.inspec.Inspec._get_tests')
     m.return_value = [
-        'foo.py',
-        'bar.py',
+        'foo.rb',
+        'bar.rb',
     ]
 
     return m
@@ -49,7 +49,7 @@ def _patched_goss_get_tests(mocker):
 def _verifier_section_data():
     return {
         'verifier': {
-            'name': 'goss',
+            'name': 'inspec',
             'env': {
                 'FOO': 'bar',
             },
@@ -66,7 +66,7 @@ def _verifier_section_data():
 @pytest.fixture
 def _instance(_verifier_section_data, patched_config_validate,
               config_instance):
-    return goss.Goss(config_instance)
+    return inspec.Inspec(config_instance)
 
 
 def test_config_private_member(_instance):
@@ -97,7 +97,7 @@ def test_lint_property(_instance):
 
 
 def test_name_property(_instance):
-    assert 'goss' == _instance.name
+    assert 'inspec' == _instance.name
 
 
 def test_enabled_property(_instance):
@@ -124,7 +124,7 @@ def test_options_property_handles_cli_args(_instance):
     _instance._config.args = {'debug': True}
     x = {}
 
-    # Does nothing.  The `goss` command does not support
+    # Does nothing.  The `inspec` command does not support
     # a `debug` flag.
     assert x == _instance.options
 
@@ -134,12 +134,12 @@ def test_bake(_instance):
 
 
 def test_execute(patched_logger_info, _patched_ansible_verify,
-                 _patched_goss_get_tests, patched_logger_success, _instance):
+                 _patched_inspec_get_tests, patched_logger_success, _instance):
     _instance.execute()
 
     _patched_ansible_verify.assert_called_once_with()
 
-    msg = 'Executing Goss tests found in {}/...'.format(_instance.directory)
+    msg = 'Executing Inspec tests found in {}/...'.format(_instance.directory)
     patched_logger_info.assert_called_once_with(msg)
 
     msg = 'Verifier completed successfully.'


### PR DESCRIPTION
The community would like an inspec verifier.  Inspec's Train does not
support all of the drivers Molecule supports.  Treat inspec similar
to the goss verifier, and simply use Ansible as the transport which
executes inspec locally via an Ansible playbook.

Fixes: #1072