### PR TITLE
Bumped testinfra version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@ psutil==5.2.2; sys_platform!="win32" and sys_platform!="cygwin"
 PyYAML==3.12
 sh==1.12.14
 tabulate==0.8.2
-testinfra==1.11.1
+testinfra==1.12.0
 tree-format==0.1.2
 yamllint==1.11.1

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
     ansible22: ansible==2.2.3.0
     ansible23: ansible==2.3.3.0
     ansible24: ansible==2.4.4.0
-    ansible25: ansible==2.5.0
+    ansible25: ansible==2.5.1
 commands =
     unit: py.test -vv --cov-report=term-missing --cov={toxinidir}/molecule/ --no-cov-on-fail {posargs}
     functional: py.test -vv -x test/functional/ {posargs}


### PR DESCRIPTION
Testinfra was not compatible with Ansible 2.5.1.  Bumped to new
version.

Fixes: #1262