### PR TITLE
Enable py36 with Ansible 2.4

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -16,7 +16,7 @@ See `INSTALL.rst`, which is created when initializing a new scenario.
 
 * Ansible >= 2.2
 * Python 2.7
-* Python 3.6 with Ansible >= 2.5
+* Python 3.6 with Ansible >= 2.4
 
 CentOS 7
 --------

--- a/molecule/shell.py
+++ b/molecule/shell.py
@@ -61,7 +61,7 @@ def _supported_ansible_version():  # pragma: no cover
         pass
     elif _supported_python3_version():
         if (distutils.version.LooseVersion(_get_ansible_version()) <
-                distutils.version.LooseVersion('2.5')):
+                distutils.version.LooseVersion('2.4')):
             msg = ("Ansible version '{}' not supported.  "
                    'Molecule only supports Ansible versions '
                    "'>=2.5' with Python version '{}'").format(

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ minversion = 1.8
 envlist =
     py{27}-ansible{22,23,24,25}-functional
     py{27,36}-ansible{22,23,24,25}-unit
-    py{36}-ansible{25}-functional
+    py{36}-ansible{24,25}-functional
     py{27,36}-lint
     format-check
     doc


### PR DESCRIPTION
Ansible 2.4 is passing Molecule functional tests with py36.