### PR TITLE
Disallow  verifier.options with goss and inspec

### DIFF
--- a/molecule/model/schema_v2.py
+++ b/molecule/model/schema_v2.py
@@ -84,7 +84,6 @@ base_schema = {
             },
             'options': {
                 'type': 'dict',
-                'allow_unknown': True,
                 'schema': {
                     'managed': {
                         'type': 'boolean',
@@ -141,7 +140,6 @@ base_schema = {
             },
             'config_options': {
                 'type': 'dict',
-                'allow_unknown': True,
                 'schema': {
                     'defaults': {
                         'type': 'dict',
@@ -174,7 +172,6 @@ base_schema = {
             },
             'env': {
                 'type': 'dict',
-                'allow_unknown': True,
                 'keyschema': {
                     'type': 'string',
                     'regex': '^[A-Z0-9_-]+$',
@@ -216,7 +213,6 @@ base_schema = {
             },
             'playbooks': {
                 'type': 'dict',
-                'allow_unknown': True,
                 'schema': {
                     'create': {
                         'type': 'string',
@@ -400,7 +396,6 @@ platforms_base_schema = {
         'type': 'list',
         'schema': {
             'type': 'dict',
-            'allow_unknown': True,
             'schema': {
                 'name': {
                     'type': 'string',
@@ -576,6 +571,19 @@ platforms_docker_schema = {
     },
 }
 
+verifier_options_readonly_schema = {
+    'verifier': {
+        'type': 'dict',
+        'schema': {
+            'options': {
+                'keyschema': {
+                    'readonly': True,
+                },
+            },
+        }
+    },
+}
+
 
 class Validator(cerberus.Validator):
     def __init__(self, *args, **kwargs):
@@ -604,6 +612,8 @@ def validate(c):
         util.merge_dicts(schema, platforms_vagrant_schema)
     else:
         util.merge_dicts(schema, platforms_base_schema)
+    if c['verifier']['name'] != 'testinfra':
+        util.merge_dicts(schema, verifier_options_readonly_schema)
 
     v = Validator(allow_unknown=True)
     v.validate(c, schema)

--- a/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
+++ b/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
@@ -475,7 +475,8 @@ class VagrantClient(object):
                 self._module.params['instance_raw_config_args'],
             },
             'provider': {
-                'name': self._module.params['provider_name'],
+                'name':
+                self._module.params['provider_name'],
                 # NOTE(retr0h): Options provided here will be passed to
                 # Vagrant as "$provider_name.#{key} = #{value}".
                 'options': {
@@ -484,7 +485,8 @@ class VagrantClient(object):
                 },
                 'raw_config_args':
                 self._module.params['provider_raw_config_args'],
-                'override_args': self._module.params['provider_override_args'],
+                'override_args':
+                self._module.params['provider_override_args'],
             }
         }
 

--- a/test/unit/model/v2/test_verifier_section.py
+++ b/test/unit/model/v2/test_verifier_section.py
@@ -168,6 +168,42 @@ def test_verifier_allows_name(_config):
 
 
 @pytest.fixture
+def _model_verifier_errors_inspec_readonly_options_section_data():
+    return {
+        'verifier': {
+            'name': 'inspec',
+            'options': {
+                'foo': 'bar',
+            },
+        }
+    }
+
+
+@pytest.fixture
+def _model_verifier_errors_goss_readonly_options_section_data():
+    return {
+        'verifier': {
+            'name': 'goss',
+            'options': {
+                'foo': 'bar',
+            },
+        }
+    }
+
+
+@pytest.mark.parametrize(
+    '_config', [
+        ('_model_verifier_errors_inspec_readonly_options_section_data'),
+        ('_model_verifier_errors_goss_readonly_options_section_data'),
+    ],
+    indirect=True)
+def test_verifier_errors_readonly_options_section_data(_config):
+    x = {'verifier': [{'options': [{'foo': ['field is read-only']}]}]}
+
+    assert x == schema_v2.validate(_config)
+
+
+@pytest.fixture
 def _model_verifier_errors_invalid_section_data():
     return {
         'verifier': {


### PR DESCRIPTION
Goss and Inspec use Ansible to execute the verifier.  The verifier
does not support options passed through molecule.yml.  Update the
model to perform this checking.  Really not a fan of the schema
merging, but don't know another way to do this.