### PR TITLE
Bundle common playbooks

### DIFF
--- a/molecule/command/prepare.py
+++ b/molecule/command/prepare.py
@@ -18,8 +18,6 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 
-import os
-
 import click
 
 from molecule import config
@@ -79,7 +77,7 @@ class Prepare(base.Base):
         self._config.state.change_state('prepared', True)
 
     def _has_prepare_playbook(self):
-        return os.path.exists(self._config.provisioner.playbooks.prepare)
+        return self._config.provisioner.playbooks.prepare is not None
 
 
 @click.command()

--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -1,5 +1,4 @@
 ---
-{% raw -%}
 - name: Create
   hosts: localhost
   connection: local
@@ -80,4 +79,3 @@
       until: docker_jobs.finished
       retries: 300
       with_items: "{{ server.results }}"
-{%- endraw %}

--- a/molecule/provisioner/ansible/playbooks/docker/destroy.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/destroy.yml
@@ -1,5 +1,4 @@
 ---
-{% raw -%}
 - name: Destroy
   hosts: localhost
   connection: local
@@ -31,4 +30,3 @@
         docker_host: "{{ item.docker_host | default('unix://var/run/docker.sock') }}"
         state: absent
       with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks }}"
-{%- endraw %}

--- a/molecule/provisioner/ansible/playbooks/vagrant/create.yml
+++ b/molecule/provisioner/ansible/playbooks/vagrant/create.yml
@@ -1,5 +1,4 @@
 ---
-{% raw -%}
 - name: Create
   hosts: localhost
   connection: local
@@ -59,4 +58,3 @@
         content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
         dest: "{{ molecule_instance_config }}"
       when: server.changed | bool
-{%- endraw %}

--- a/molecule/provisioner/ansible/playbooks/vagrant/destroy.yml
+++ b/molecule/provisioner/ansible/playbooks/vagrant/destroy.yml
@@ -1,5 +1,4 @@
 ---
-{% raw %}
 - name: Destroy
   hosts: localhost
   connection: local
@@ -34,4 +33,3 @@
         content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
         dest: "{{ molecule_instance_config }}"
       when: server.changed | bool
-{%- endraw %}

--- a/molecule/provisioner/ansible_playbooks.py
+++ b/molecule/provisioner/ansible_playbooks.py
@@ -20,7 +20,10 @@
 
 from __future__ import absolute_import
 
+import os
+
 from molecule import logger
+from molecule import util
 
 LOG = logger.get_logger(__name__)
 
@@ -39,44 +42,56 @@ class AnsiblePlaybooks(object):
 
     @property
     def create(self):
-        return self._get_ansible_playbook('create')
+        return self._get_playbook('create')
 
     @property
     def converge(self):
         c = self._config.config
 
-        return self._config.provisioner.get_abs_path(
+        return self._config.provisioner.abs_path(
             c['provisioner']['playbooks']['converge'])
 
     @property
     def destroy(self):
-        return self._get_ansible_playbook('destroy')
+        return self._get_playbook('destroy')
 
     @property
     def prepare(self):
-        return self._get_ansible_playbook('prepare')
+        return self._get_playbook('prepare')
 
     @property
     def side_effect(self):
-        return self._get_ansible_playbook('side_effect')
+        return self._get_playbook('side_effect')
 
     @property
     def verify(self):
-        return self._get_ansible_playbook('verify')
+        return self._get_playbook('verify')
 
-    def _get_ansible_playbook(self, section):
+    def _get_playbook_directory(self):
+        return util.abs_path(
+            os.path.join(self._config.provisioner.directory, 'playbooks'))
+
+    def _get_playbook(self, section):
         c = self._config.config
         driver_dict = c['provisioner']['playbooks'].get(
             self._config.driver.name)
 
+        playbook = c['provisioner']['playbooks'][section]
         if driver_dict:
             try:
                 playbook = driver_dict[section]
-            except KeyError:
-                playbook = c['provisioner']['playbooks'][section]
-        else:
-            playbook = c['provisioner']['playbooks'][section]
+            except Exception:
+                pass
 
         if playbook is not None:
-            return self._config.provisioner.get_abs_path(playbook)
-        return
+            playbook = self._config.provisioner.abs_path(playbook)
+
+            if os.path.exists(playbook):
+                return playbook
+            elif os.path.exists(self._get_bundled_driver_playbook(section)):
+                return self._get_bundled_driver_playbook(section)
+
+    def _get_bundled_driver_playbook(self, section):
+        return os.path.join(
+            self._get_playbook_directory(), self._config.driver.name,
+            self._config.config['provisioner']['playbooks'][section])

--- a/test/unit/command/test_prepare.py
+++ b/test/unit/command/test_prepare.py
@@ -18,8 +18,11 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 
+import os
+
 import pytest
 
+from molecule import util
 from molecule.command import prepare
 
 
@@ -96,6 +99,15 @@ def test_execute_logs_deprecation_when_prepare_yml_missing(
 
 
 def test_has_prepare_playbook(config_instance):
+    pb = os.path.join(config_instance.scenario.directory, 'prepare.yml')
+    util.write_file(pb, '')
+
+    p = prepare.Prepare(config_instance)
+
+    assert p._has_prepare_playbook()
+
+
+def test_has_prepare_playbook_missing_prepare_playbook(config_instance):
     p = prepare.Prepare(config_instance)
 
     assert not p._has_prepare_playbook()

--- a/test/unit/command/test_side_effect.py
+++ b/test/unit/command/test_side_effect.py
@@ -18,8 +18,11 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 
+import os
+
 import pytest
 
+from molecule import util
 from molecule.command import side_effect
 
 
@@ -48,6 +51,9 @@ def _patched_ansible_side_effect(mocker):
     indirect=True)
 def test_execute(mocker, _patched_ansible_side_effect, patched_logger_info,
                  patched_config_validate, config_instance):
+    pb = os.path.join(config_instance.scenario.directory, 'side_effect.yml')
+    util.write_file(pb, '')
+
     se = side_effect.SideEffect(config_instance)
     se.execute()
 
@@ -62,6 +68,7 @@ def test_execute(mocker, _patched_ansible_side_effect, patched_logger_info,
 
 def test_execute_skips_when_playbook_not_configured(
         patched_logger_warn, _patched_ansible_side_effect, config_instance):
+
     se = side_effect.SideEffect(config_instance)
     se.execute()
 

--- a/test/unit/lint/test_yamllint.py
+++ b/test/unit/lint/test_yamllint.py
@@ -124,9 +124,16 @@ def test_options_property_handles_cli_args(_instance):
     'config_instance', ['_lint_section_data'], indirect=True)
 def test_bake(_patched_get_files, _instance):
     _instance.bake()
-    x = '{} -s --foo=bar foo.yml bar.yaml'.format(str(sh.yamllint))
+    x = [
+        str(sh.Command('yamllint')),
+        '-s',
+        '--foo=bar',
+        'foo.yml',
+        'bar.yaml',
+    ]
 
-    assert x == _instance._yamllint_command
+    result = str(_instance._yamllint_command).split()
+    assert sorted(x) == sorted(result)
 
 
 def test_execute(_patched_get_files, patched_logger_info,

--- a/test/unit/provisioner/test_ansible.py
+++ b/test/unit/provisioner/test_ansible.py
@@ -113,11 +113,6 @@ def test_config_private_member(_instance):
     assert isinstance(_instance._config, config.Config)
 
 
-def test_ansible_playbooks_private_member(_instance):
-    assert isinstance(_instance._ansible_playbooks,
-                      ansible_playbooks.AnsiblePlaybooks)
-
-
 def test_default_config_options_property(_instance):
     x = {
         'defaults': {
@@ -498,8 +493,25 @@ def test_config_file_property(_instance):
     assert x == _instance.config_file
 
 
+def test_playbooks_property(_instance):
+    assert isinstance(_instance.playbooks, ansible_playbooks.AnsiblePlaybooks)
+
+
+def test_directory_property(_instance):
+    result = _instance.directory
+    parts = pytest.helpers.os_split(result)
+
+    assert (
+        'molecule',
+        'provisioner',
+        'ansible',
+    ) == parts[-3:]
+
+
 def test_playbooks_create_property(_instance):
-    x = os.path.join(_instance._config.scenario.directory, 'create.yml')
+    x = os.path.join(
+        _instance._config.provisioner.playbooks._get_playbook_directory(),
+        'docker', 'create.yml')
 
     assert x == _instance.playbooks.create
 
@@ -511,7 +523,9 @@ def test_playbooks_converge_property(_instance):
 
 
 def test_playbooks_destroy_property(_instance):
-    x = os.path.join(_instance._config.scenario.directory, 'destroy.yml')
+    x = os.path.join(
+        _instance._config.provisioner.playbooks._get_playbook_directory(),
+        'docker', 'destroy.yml')
 
     assert x == _instance.playbooks.destroy
 

--- a/test/unit/verifier/lint/test_yamllint.py
+++ b/test/unit/verifier/lint/test_yamllint.py
@@ -122,9 +122,17 @@ def test_options_property_handles_cli_args(_instance):
 def test_bake(_instance):
     _instance._tests = ['test1', 'test2', 'test3']
     _instance.bake()
-    x = '{} -s --foo=bar test1 test2 test3'.format(str(sh.yamllint))
+    x = [
+        str(sh.Command('yamllint')),
+        '-s',
+        '--foo=bar',
+        'test1',
+        'test2',
+        'test3',
+    ]
 
-    assert x == _instance._yamllint_command
+    result = str(_instance._yamllint_command).split()
+    assert sorted(x) == sorted(result)
 
 
 def test_execute(patched_logger_info, patched_logger_success,


### PR DESCRIPTION
Bundled the docker and vagrant provisioning playbooks.  These are
the most commonly used playbooks, and contain the most functionality.
Additional playbooks may be bundled in the future, but as of now are
lacking a clean `molecule.yml` API.

The playbook loading order is now:

  1. provisioner.playbooks.$driver_name.$action
  2. provisioner.playbooks.$action
  3. bundled_playbook.$driver_name.$action