### PR TITLE
Made prepare optional

### DIFF
--- a/molecule/command/prepare.py
+++ b/molecule/command/prepare.py
@@ -66,18 +66,13 @@ class Prepare(base.Base):
             LOG.warn(msg)
             return
 
-        if self._has_prepare_playbook():
-            self._config.provisioner.prepare()
-        else:
-            msg = ('[DEPRECATION WARNING]:\n  The prepare playbook not found '
-                   'at {}/prepare.yml.  Please add one to the scenarios '
-                   'directory.').format(self._config.scenario.directory)
+        if not self._config.provisioner.playbooks.prepare:
+            msg = 'Skipping, prepare playbook not configured.'
             LOG.warn(msg)
+            return
 
+        self._config.provisioner.prepare()
         self._config.state.change_state('prepared', True)
-
-    def _has_prepare_playbook(self):
-        return self._config.provisioner.playbooks.prepare is not None
 
 
 @click.command()

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -313,7 +313,7 @@ class Config(object):
                     'converge': 'playbook.yml',
                     'destroy': 'destroy.yml',
                     'prepare': 'prepare.yml',
-                    'side_effect': None,
+                    'side_effect': 'side_effect.yml',
                     'verify': 'verify.yml',
                 },
                 'lint': {

--- a/molecule/cookiecutter/scenario/driver/azure/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/prepare.yml
+++ b/molecule/cookiecutter/scenario/driver/azure/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/prepare.yml
@@ -1,7 +1,0 @@
----
-{% raw -%}
-- name: Prepare
-  hosts: all
-  gather_facts: false
-  tasks: []
-{%- endraw %}

--- a/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/prepare.yml
+++ b/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/prepare.yml
@@ -1,7 +1,0 @@
----
-{% raw -%}
-- name: Prepare
-  hosts: all
-  gather_facts: false
-  tasks: []
-{%- endraw %}

--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/prepare.yml
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/prepare.yml
@@ -1,7 +1,0 @@
----
-{% raw -%}
-- name: Prepare
-  hosts: all
-  gather_facts: false
-  tasks: []
-{%- endraw %}

--- a/molecule/cookiecutter/scenario/driver/lxc/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/prepare.yml
+++ b/molecule/cookiecutter/scenario/driver/lxc/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/prepare.yml
@@ -1,7 +1,0 @@
----
-{% raw -%}
-- name: Prepare
-  hosts: all
-  gather_facts: false
-  tasks: []
-{%- endraw %}

--- a/molecule/model/schema_v2.py
+++ b/molecule/model/schema_v2.py
@@ -228,7 +228,6 @@ base_schema = {
                     },
                     'side_effect': {
                         'type': 'string',
-                        'nullable': True,
                     },
                     'verify': {
                         'type': 'string',

--- a/test/scenarios/dependency/molecule/ansible-galaxy/prepare.yml
+++ b/test/scenarios/dependency/molecule/ansible-galaxy/prepare.yml
@@ -1,5 +1,0 @@
----
-- name: Prepare
-  hosts: all
-  gather_facts: false
-  tasks: []

--- a/test/scenarios/dependency/molecule/gilt/prepare.yml
+++ b/test/scenarios/dependency/molecule/gilt/prepare.yml
@@ -1,5 +1,0 @@
----
-- name: Prepare
-  hosts: all
-  gather_facts: false
-  tasks: []

--- a/test/scenarios/dependency/molecule/shell/prepare.yml
+++ b/test/scenarios/dependency/molecule/shell/prepare.yml
@@ -1,5 +1,0 @@
----
-- name: Prepare
-  hosts: all
-  gather_facts: false
-  tasks: []

--- a/test/scenarios/driver/azure/molecule/default/prepare.yml
+++ b/test/scenarios/driver/azure/molecule/default/prepare.yml
@@ -1,5 +1,0 @@
----
-- name: Prepare
-  hosts: all
-  gather_facts: false
-  tasks: []

--- a/test/scenarios/driver/delegated/molecule/docker/prepare.yml
+++ b/test/scenarios/driver/delegated/molecule/docker/prepare.yml
@@ -1,5 +1,0 @@
----
-- name: Prepare
-  hosts: all
-  gather_facts: false
-  tasks: []

--- a/test/scenarios/driver/delegated/molecule/gce/prepare.yml
+++ b/test/scenarios/driver/delegated/molecule/gce/prepare.yml
@@ -1,5 +1,0 @@
----
-- name: Prepare
-  hosts: all
-  gather_facts: false
-  tasks: []

--- a/test/scenarios/driver/delegated/molecule/vagrant/prepare.yml
+++ b/test/scenarios/driver/delegated/molecule/vagrant/prepare.yml
@@ -1,5 +1,0 @@
----
-- name: Prepare
-  hosts: all
-  gather_facts: false
-  tasks: []

--- a/test/scenarios/driver/docker/molecule/default/prepare.yml
+++ b/test/scenarios/driver/docker/molecule/default/prepare.yml
@@ -1,5 +1,0 @@
----
-- name: Prepare
-  hosts: all
-  gather_facts: false
-  tasks: []

--- a/test/scenarios/driver/docker/molecule/multi-node/prepare.yml
+++ b/test/scenarios/driver/docker/molecule/multi-node/prepare.yml
@@ -1,5 +1,0 @@
----
-- name: Prepare
-  hosts: all
-  gather_facts: false
-  tasks: []

--- a/test/scenarios/driver/lxc/molecule/default/prepare.yml
+++ b/test/scenarios/driver/lxc/molecule/default/prepare.yml
@@ -1,5 +1,0 @@
----
-- name: Prepare
-  hosts: all
-  gather_facts: false
-  tasks: []

--- a/test/scenarios/driver/lxc/molecule/multi-node/prepare.yml
+++ b/test/scenarios/driver/lxc/molecule/multi-node/prepare.yml
@@ -1,5 +1,0 @@
----
-- name: Prepare
-  hosts: all
-  gather_facts: false
-  tasks: []

--- a/test/scenarios/driver/vagrant/molecule/default/prepare.yml
+++ b/test/scenarios/driver/vagrant/molecule/default/prepare.yml
@@ -1,5 +1,0 @@
----
-- name: Prepare
-  hosts: all
-  gather_facts: false
-  tasks: []

--- a/test/scenarios/host_group_vars/molecule/default/prepare.yml
+++ b/test/scenarios/host_group_vars/molecule/default/prepare.yml
@@ -1,5 +1,0 @@
----
-- name: Prepare
-  hosts: all
-  gather_facts: false
-  tasks: []

--- a/test/scenarios/host_group_vars/molecule/links/prepare.yml
+++ b/test/scenarios/host_group_vars/molecule/links/prepare.yml
@@ -1,5 +1,0 @@
----
-- name: Prepare
-  hosts: all
-  gather_facts: false
-  tasks: []

--- a/test/scenarios/idempotence/molecule/raises/prepare.yml
+++ b/test/scenarios/idempotence/molecule/raises/prepare.yml
@@ -1,5 +1,0 @@
----
-- name: Prepare
-  hosts: all
-  gather_facts: false
-  tasks: []

--- a/test/scenarios/interpolation/molecule/default/prepare.yml
+++ b/test/scenarios/interpolation/molecule/default/prepare.yml
@@ -1,5 +1,0 @@
----
-- name: Prepare
-  hosts: all
-  gather_facts: false
-  tasks: []

--- a/test/scenarios/overrride_driver/molecule/default/prepare.yml
+++ b/test/scenarios/overrride_driver/molecule/default/prepare.yml
@@ -1,5 +1,0 @@
----
-- name: Prepare
-  hosts: all
-  gather_facts: false
-  tasks: []

--- a/test/scenarios/plugins/molecule/default/prepare.yml
+++ b/test/scenarios/plugins/molecule/default/prepare.yml
@@ -1,5 +1,0 @@
----
-- name: Prepare
-  hosts: all
-  gather_facts: false
-  tasks: []

--- a/test/scenarios/side_effect/molecule/default/prepare.yml
+++ b/test/scenarios/side_effect/molecule/default/prepare.yml
@@ -1,5 +1,0 @@
----
-- name: Prepare
-  hosts: all
-  gather_facts: false
-  tasks: []

--- a/test/scenarios/test_destroy_strategy/molecule/default/prepare.yml
+++ b/test/scenarios/test_destroy_strategy/molecule/default/prepare.yml
@@ -1,5 +1,0 @@
----
-- name: Prepare
-  hosts: all
-  gather_facts: false
-  tasks: []

--- a/test/scenarios/verifier/molecule/goss/prepare.yml
+++ b/test/scenarios/verifier/molecule/goss/prepare.yml
@@ -1,5 +1,0 @@
----
-- name: Prepare
-  hosts: all
-  gather_facts: false
-  tasks: []

--- a/test/scenarios/verifier/molecule/inspec/prepare.yml
+++ b/test/scenarios/verifier/molecule/inspec/prepare.yml
@@ -1,5 +1,0 @@
----
-- name: Prepare
-  hosts: all
-  gather_facts: false
-  tasks: []

--- a/test/scenarios/verifier/molecule/testinfra/prepare.yml
+++ b/test/scenarios/verifier/molecule/testinfra/prepare.yml
@@ -1,5 +1,0 @@
----
-- name: Prepare
-  hosts: all
-  gather_facts: false
-  tasks: []

--- a/test/unit/model/v2/test_provisioner_section.py
+++ b/test/unit/model/v2/test_provisioner_section.py
@@ -171,25 +171,6 @@ def test_provisioner_has_errors(_config):
 
 
 @pytest.fixture
-def _model_provisioner_playbooks_side_effect_nullable_section_data():
-    return {
-        'provisioner': {
-            'playbooks': {
-                'side_effect': None,
-            },
-        }
-    }
-
-
-@pytest.mark.parametrize(
-    '_config',
-    ['_model_provisioner_playbooks_side_effect_nullable_section_data'],
-    indirect=True)
-def test_provisioner_playbooks_side_effect_nullable(_config):
-    assert {} == schema_v2.validate(_config)
-
-
-@pytest.fixture
 def _model_provisioner_config_options_disallowed_section_data():
     return {
         'provisioner': {


### PR DESCRIPTION
No reason to provide the prepare playbook, when most of the time
it is not used.  The prepare and side_effect playbooks are leveraged
in a similar way.

* Removed the deprecated warning.
* Removed the prepare.yml files.