### PR TITLE
utf-8 issue in idempotence

### DIFF
--- a/molecule/command/idempotence.py
+++ b/molecule/command/idempotence.py
@@ -68,7 +68,7 @@ class Idempotence(base.Base):
             LOG.success(msg)
         else:
             msg = ('Idempotence test failed because of the following tasks:\n'
-                   '{}').format('\n'.join(self._non_idempotent_tasks(output)))
+                   u'{}').format('\n'.join(self._non_idempotent_tasks(output)))
             util.sysexit_with_message(msg)
 
     def _is_idempotent(self, output):
@@ -114,7 +114,7 @@ class Idempotence(base.Base):
             elif line.startswith('changed'):
                 host_name = re.search(r'\[(.*)\]', line).groups()[0]
                 task_name = re.search(r'\[(.*)\]', task_line).groups()[0]
-                res.append('* [{}] => {}'.format(host_name, task_name))
+                res.append(u'* [{}] => {}'.format(host_name, task_name))
 
         return res
 


### PR DESCRIPTION
if a task result contains non ascii character and is non idempotente, molecule fails whith the following errors : 

```
molecule/command/idempotence.py", line 114, in _non_idempotent_tasks
    res.append('* [{}] => {}'.format(host_name, task_name))
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2018' in position 301: ordinal not in range(128)

molecule/command/idempotence.py", line 68, in execute
    '{}').format('\n'.join(self._non_idempotent_tasks(output)))
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2018' in position 367: ordinal not in range(128)
```