### PR TITLE
Reintroduce base config merging

### DIFF
--- a/molecule/command/check.py
+++ b/molecule/command/check.py
@@ -40,6 +40,10 @@ class Check(base.Base):
     Executing with `debug`:
 
     $ molecule --debug check
+
+    Executing with a `base-config`:
+
+    $ molecule --base-config base.yml check
     """
 
     def execute(self):

--- a/molecule/command/converge.py
+++ b/molecule/command/converge.py
@@ -47,6 +47,10 @@ class Converge(base.Base):
     Executing with `debug`:
 
     $ molecule --debug converge
+
+    Executing with a `base-config`:
+
+    $ molecule --base-config base.yml converge
     """
 
     def execute(self):

--- a/molecule/command/create.py
+++ b/molecule/command/create.py
@@ -45,6 +45,10 @@ class Create(base.Base):
     Executing with `debug`:
 
     $ molecule --debug create
+
+    Executing with a `base-config`:
+
+    $ molecule --base-config base.yml create
     """
 
     def execute(self):

--- a/molecule/command/dependency.py
+++ b/molecule/command/dependency.py
@@ -40,6 +40,10 @@ class Dependency(base.Base):
     Executing with `debug`:
 
     $ molecule --debug dependency
+
+    Executing with a `base-config`:
+
+    $ molecule --base-config base.yml dependency
     """
 
     def execute(self):

--- a/molecule/command/destroy.py
+++ b/molecule/command/destroy.py
@@ -49,6 +49,10 @@ class Destroy(base.Base):
     Executing with `debug`:
 
     $ molecule --debug destroy
+
+    Executing with a `base-config`:
+
+    $ molecule --base-config base.yml destroy
     """
 
     def execute(self):

--- a/molecule/command/idempotence.py
+++ b/molecule/command/idempotence.py
@@ -46,6 +46,10 @@ class Idempotence(base.Base):
     Executing with `debug`:
 
     $ molecule --debug idempotence
+
+    Executing with a `base-config`:
+
+    $ molecule --base-config base.yml idempotence
     """
 
     def execute(self):

--- a/molecule/command/lint.py
+++ b/molecule/command/lint.py
@@ -40,6 +40,10 @@ class Lint(base.Base):
     Executing with `debug`:
 
     $ molecule --debug lint
+
+    Executing with a `base-config`:
+
+    $ molecule --base-config base.yml lint
     """
 
     def execute(self):

--- a/molecule/command/list.py
+++ b/molecule/command/list.py
@@ -50,6 +50,10 @@ class List(base.Base):
     Executing with `debug`:
 
     $ molecule --debug list
+
+    Executing with a `base-config`:
+
+    $ molecule --base-config base.yml list
     """
 
     def execute(self):

--- a/molecule/command/login.py
+++ b/molecule/command/login.py
@@ -53,6 +53,10 @@ class Login(base.Base):
     Executing with `debug`:
 
     $ molecule --debug login
+
+    Executing with a `base-config`:
+
+    $ molecule --base-config base.yml login
     """
 
     def __init__(self, c):

--- a/molecule/command/prepare.py
+++ b/molecule/command/prepare.py
@@ -49,6 +49,10 @@ class Prepare(base.Base):
     Executing with `debug`:
 
     $ molecule --debug prepare
+
+    Executing with a `base-config`:
+
+    $ molecule --base-config base.yml prepare
     """
 
     def execute(self):

--- a/molecule/command/side_effect.py
+++ b/molecule/command/side_effect.py
@@ -43,6 +43,10 @@ class SideEffect(base.Base):
     Executing with `debug`:
 
     $ molecule --debug side-effect
+
+    Executing with a `base-config`:
+
+    $ molecule --base-config base.yml side-effect
     """
 
     def execute(self):

--- a/molecule/command/syntax.py
+++ b/molecule/command/syntax.py
@@ -40,6 +40,10 @@ class Syntax(base.Base):
     Executing with `debug`:
 
     $ molecule --debug syntax
+
+    Executing with a `base-config`:
+
+    $ molecule --base-config base.yml syntax
     """
 
     def execute(self):

--- a/molecule/command/test.py
+++ b/molecule/command/test.py
@@ -54,6 +54,10 @@ class Test(base.Base):
     Executing with `debug`:
 
     $ molecule --debug test
+
+    Executing with a `base-config`:
+
+    $ molecule --base-config base.yml test
     """
 
     def execute(self):

--- a/molecule/command/verify.py
+++ b/molecule/command/verify.py
@@ -40,6 +40,10 @@ class Verify(base.Base):
     Executing with `debug`:
 
     $ molecule --debug verify
+
+    Executing with a `base-config`:
+
+    $ molecule --base-config base.yml verify
     """
 
     def execute(self):

--- a/molecule/shell.py
+++ b/molecule/shell.py
@@ -20,6 +20,7 @@
 
 import distutils
 import distutils.version
+import os
 import sys
 
 import ansible
@@ -31,6 +32,8 @@ from molecule import command
 from molecule import util
 
 click_completion.init()
+
+LOCAL_CONFIG = os.path.expanduser('~/.config/molecule/config.yml')
 
 
 def _get_python_version():  # pragma: no cover
@@ -86,9 +89,16 @@ def _allowed(ctx, param, value):  # pragma: no cover
     default=False,
     callback=_allowed,
     help='Enable or disable debug mode. Default is disabled.')
+@click.option(
+    '--base-config',
+    '-c',
+    default=LOCAL_CONFIG,
+    help=('Path to a base config.  If provided Molecule will load '
+          "this config first, and deep merge each scenario's "
+          'molecule.yml ontop. ({})').format(LOCAL_CONFIG))
 @click.version_option(version=molecule.__version__)
 @click.pass_context
-def main(ctx, debug):  # pragma: no cover
+def main(ctx, debug, base_config):  # pragma: no cover
     """
     \b
      _____     _             _
@@ -105,6 +115,7 @@ def main(ctx, debug):  # pragma: no cover
     ctx.obj = {}
     ctx.obj['args'] = {}
     ctx.obj['args']['debug'] = debug
+    ctx.obj['args']['base_config'] = base_config
 
 
 main.add_command(command.check.check)


### PR DESCRIPTION
Molecule introduces a new CLI option `--base-config`, which is
loaded prior to each scenario's `molecule.yml`.  This allows
developers to specify a base config, to help reduce repetition
in their molecule.yml files.  The default base config is
~/.config/molecule/config.yml.

Fixes: #1205
Fixes: #1099
Fixes: #1183