### PR TITLE
pre-validate Molecule special variables

### DIFF
--- a/molecule/command/init/scenario.py
+++ b/molecule/command/init/scenario.py
@@ -38,12 +38,12 @@ class Scenario(base.Base):
 
         Initialize a new scenario.
 
-    .. program:: cd foo; molecule init scenario --scenario-name bar --role-name foo  # noqa
+    .. program:: cd foo; molecule init scenario --scenario-name bar --role-name foo
 
-    .. option:: cd foo; molecule init scenario --scenario-name bar --role-name foo  # noqa
+    .. option:: cd foo; molecule init scenario --scenario-name bar --role-name foo
 
         Initialize an existing role with Molecule:
-    """
+    """  # noqa
 
     def __init__(self, command_args):
         self._command_args = command_args

--- a/molecule/command/init/template.py
+++ b/molecule/command/init/template.py
@@ -33,12 +33,12 @@ LOG = logger.get_logger(__name__)
 
 class Template(base.Base):
     """
-    .. program:: molecule init template --url https://example.com/user/cookiecutter-repo  # noqa
+    .. program:: molecule init template --url https://example.com/user/cookiecutter-repo
 
-    .. option:: molecule init init template --url https://example.com/user/cookiecutter-repo  # noqa
+    .. option:: molecule init init template --url https://example.com/user/cookiecutter-repo
 
         Initialize a new role from a Cookiecutter URL.
-    """
+    """  # noqa
 
     def __init__(self, command_args):
         self._command_args = command_args

--- a/molecule/config.py
+++ b/molecule/config.py
@@ -188,8 +188,10 @@ class Config(object):
             'MOLECULE_DRIVER_NAME': self.driver.name,
             'MOLECULE_LINT_NAME': self.lint.name,
             'MOLECULE_PROVISIONER_NAME': self.provisioner.name,
+            'MOLECULE_PROVISIONER_LINT_NAME': self.provisioner.lint.name,
             'MOLECULE_SCENARIO_NAME': self.scenario.name,
             'MOLECULE_VERIFIER_NAME': self.verifier.name,
+            'MOLECULE_VERIFIER_LINT_NAME': self.verifier.lint.name,
             'MOLECULE_VERIFIER_TEST_DIRECTORY': self.verifier.directory,
         }
 

--- a/molecule/interpolation.py
+++ b/molecule/interpolation.py
@@ -79,6 +79,7 @@ class TemplateWithDefaults(string.Template):
             # Check the most common path first.
             named = mo.group('named') or mo.group('braced')
             if named is not None:
+                # TODO(retr0h): This needs to be better handled.
                 if keep_string and named.startswith(keep_string):
                     return '$%s' % named
                 if ':-' in named:

--- a/test/unit/model/v2/test_platforms_section.py
+++ b/test/unit/model/v2/test_platforms_section.py
@@ -203,7 +203,7 @@ def test_platforms_docker_registry_credentials_are_interpolated(_config):
                 'registry': [{
                     'credentials': [{
                         'password': [
-                            "value does not match regex '^[{$]+[a-z0-9A-z]+[}]*$'",  # noqa
+                            "value does not match regex '^[{$]+[a-z0-9A-Z]+[}]*$'",  # noqa
                         ]
                     }]
                 }]

--- a/test/unit/model/v2/test_pre_validate.py
+++ b/test/unit/model/v2/test_pre_validate.py
@@ -62,12 +62,85 @@ def test_platforms_docker_has_errors(_stream):
                     'credentials': [{
                         'password': [
                             ('value does not match regex '
-                             "'^[{$]+[a-z0-9A-z]+[}]*$'"),
+                             "'^[{$]+[a-z0-9A-Z]+[}]*$'"),
                         ]
                     }]
                 }]
             }]
         }]
+    }
+
+    assert x == schema_v2.pre_validate(_stream())
+
+
+@pytest.fixture
+def _model_molecule_env_errors_section_data():
+    return """
+---
+dependency:
+  name: $MOLECULE_DEPENDENCY_NAME
+driver:
+  name: $MOLECULE_DRIVER_NAME
+lint:
+  name: $MOLECULE_LINT_NAME
+platforms:
+  - name: instance
+    image: centos:latest
+    networks:
+      - name: foo
+      - name: bar
+provisioner:
+  name: $MOLECULE_PROVISIONER_NAME
+  lint:
+    name: $MOLECULE_PROVISIONER_LINT_NAME
+scenario:
+  name: $MOLECULE_SCENARIO_NAME
+verifier:
+  name: $MOLECULE_VERIFIER_NAME
+  lint:
+    name: $MOLECULE_VERIFIER_LINT_NAME
+""".strip()
+
+
+@pytest.mark.parametrize('_stream',
+                         [(_model_molecule_env_errors_section_data)])
+def test_has_errors_when_molecule_env_var_referenced_in_unallowed_sections(
+        _stream):
+    x = {
+        'scenario': [{
+            'name':
+            ['cannot reference $MOLECULE special variables in this section']
+        }],
+        'lint': [{
+            'name':
+            ['cannot reference $MOLECULE special variables in this section']
+        }],
+        'driver': [{
+            'name':
+            ['cannot reference $MOLECULE special variables in this section']
+        }],
+        'dependency': [{
+            'name':
+            ['cannot reference $MOLECULE special variables in this section']
+        }],
+        'verifier': [{
+            'lint': [{
+                'name':
+                [('cannot reference $MOLECULE special variables in this '
+                  'section')]
+            }],
+            'name':
+            ['cannot reference $MOLECULE special variables in this section']
+        }],
+        'provisioner': [{
+            'lint': [{
+                'name':
+                [('cannot reference $MOLECULE special variables in this '
+                  'section')]
+            }],
+            'name':
+            ['cannot reference $MOLECULE special variables in this section']
+        }],
     }
 
     assert x == schema_v2.pre_validate(_stream())

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -298,10 +298,14 @@ def test_env(config_instance):
         'yamllint',
         'MOLECULE_PROVISIONER_NAME':
         'ansible',
+        'MOLECULE_PROVISIONER_LINT_NAME':
+        'ansible-lint',
         'MOLECULE_SCENARIO_NAME':
         'default',
         'MOLECULE_VERIFIER_NAME':
         'testinfra',
+        'MOLECULE_VERIFIER_LINT_NAME':
+        'flake8',
         'MOLECULE_VERIFIER_TEST_DIRECTORY':
         config_instance.verifier.directory,
     }


### PR DESCRIPTION
Molecule special variables are exactly that, special.  They should
only be used in safe sections of molecule.yml.  Updated Molecule's
pre-validator to ensure these special variables are not used.

Fixes: #1310