### PR TITLE
Docker create playbooks: add tmpfs & security_opts docker_container parameters

### DIFF
--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -54,8 +54,13 @@ class Docker(base.Base):
                 email: user@example.com
             command: sleep infinity
             privileged: True|False
+            security_opts:
+              - seccomp=unconfined
             volumes:
               - /sys/fs/cgroup:/sys/fs/cgroup:ro
+            tmpfs:
+              - /tmp
+              - /run
             capabilities:
               - SYS_ADMIN
             exposed_ports:

--- a/molecule/model/schema_v2.py
+++ b/molecule/model/schema_v2.py
@@ -617,7 +617,19 @@ platforms_docker_schema = {
                 'privileged': {
                     'type': 'boolean',
                 },
+                'security_opts': {
+                    'type': 'list',
+                    'schema': {
+                        'type': 'string',
+                    }
+                },
                 'volumes': {
+                    'type': 'list',
+                    'schema': {
+                        'type': 'string',
+                    }
+                },
+                'tmpfs': {
                     'type': 'list',
                     'schema': {
                         'type': 'string',

--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -60,7 +60,9 @@
         log_driver: json-file
         command: "{{ item.command | default('bash -c \"while true; do sleep 10000; done\"') }}"
         privileged: "{{ item.privileged | default(omit) }}"
+        security_opts: "{{ item.security_opts | default(omit) }}"
         volumes: "{{ item.volumes | default(omit) }}"
+        tmpfs: "{{ item.tmpfs | default(omit) }}"
         capabilities: "{{ item.capabilities | default(omit) }}"
         exposed_ports: "{{ item.exposed_ports | default(omit) }}"
         published_ports: "{{ item.published_ports | default(omit) }}"

--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -55,7 +55,9 @@
         log_driver: json-file
         command: "{{ item.command | default('bash -c \"while true; do sleep 10000; done\"') }}"
         privileged: "{{ item.privileged | default(omit) }}"
+        security_opts: "{{ item.security_opts | default(omit) }}"
         volumes: "{{ item.volumes | default(omit) }}"
+        tmpfs: "{{ item.tmpfs | default(omit) }}"
         capabilities: "{{ item.capabilities | default(omit) }}"
         exposed_ports: "{{ item.exposed_ports | default(omit) }}"
         published_ports: "{{ item.published_ports | default(omit) }}"


### PR DESCRIPTION
Docker create playbooks: add `tmpfs` & `security_opts` [docker_container module](http://docs.ansible.com/ansible/2.5/modules/docker_container_module.html) parameters.