### PR TITLE
Removed docker credential regexp validation

### DIFF
--- a/molecule/model/schema_v2.py
+++ b/molecule/model/schema_v2.py
@@ -602,7 +602,6 @@ platforms_docker_schema = {
                                 },
                                 'password': {
                                     'type': 'string',
-                                    'regex': '^[{$]+[a-z0-9A-Z]+[}]*$',
                                 },
                                 'email': {
                                     'type': 'string',

--- a/test/unit/model/v2/test_platforms_section.py
+++ b/test/unit/model/v2/test_platforms_section.py
@@ -204,42 +204,6 @@ def test_platforms_docker_has_errors(_config):
 
 
 @pytest.fixture
-def _model_platforms_docker_registry_credentials_section_data():
-    return {
-        'platforms': [{
-            'name': str(),
-            'registry': {
-                'credentials': {
-                    'username': 'foo',
-                    'password': 'bar',
-                },
-            },
-        }]
-    }
-
-
-@pytest.mark.parametrize(
-    '_config', ['_model_platforms_docker_registry_credentials_section_data'],
-    indirect=True)
-def test_platforms_docker_registry_credentials_are_interpolated(_config):
-    x = {
-        'platforms': [{
-            0: [{
-                'registry': [{
-                    'credentials': [{
-                        'password': [
-                            "value does not match regex '^[{$]+[a-z0-9A-Z]+[}]*$'",  # noqa
-                        ]
-                    }]
-                }]
-            }]
-        }]
-    }
-
-    assert x == schema_v2.validate(_config)
-
-
-@pytest.fixture
 def _model_platforms_vagrant_section_data():
     return {
         'driver': {


### PR DESCRIPTION
We perform validation pre-interpolation, we no longer
need to validate the regexp post interpolation.  This
was somehow missed in #1315.

Fixes: #1330,#1331