### PR TITLE
Create unique keypair to allow parallel executions

### DIFF
--- a/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -25,7 +25,7 @@
 
     neutron_network_name: molecule
 
-    keypair_name: molecule_key
+    keypair_name: "keypair-{{ molecule_yml['platforms'][0]['name'] }}"
     keypair_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
 
     nova_image: Ubuntu-16.04


### PR DESCRIPTION
This change was very useful for me, in order to avoid collisions while executing ( in Jenkins builds ) several ansible roles testing. When we create a keypair, the next job will overwrite it, causing SSH connection errors in the first job.