### PR TITLE
Update ansible-lint to version 3.4.23

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible-lint==3.4.21
+ansible-lint==3.4.23
 anyconfig==0.9.4
 cerberus==1.1
 click==6.7


### PR DESCRIPTION
Please use the latest available version of ansible-lint, because they finally allow vault encrypted variables in YAML files.