### PR TITLE
Update InSpec to version 2.2.20

### DIFF
--- a/molecule/cookiecutter/scenario/verifier/inspec/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
+++ b/molecule/cookiecutter/scenario/verifier/inspec/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
@@ -8,9 +8,9 @@
   hosts: all
   become: true
   vars:
-    inspec_download_url: "https://packages.chef.io/files/stable/inspec/2.1.43/el/7/inspec-2.1.43-1.el7.x86_64.rpm"
+    inspec_download_url: "https://packages.chef.io/files/stable/inspec/2.2.20/el/7/inspec-2.2.20-1.el7.x86_64.rpm"
     inspec_download_source_dir: /usr/local/src
-    inspec_download_sha256sum: bf36072724322fcca708467e5fc1973e838f605d655d72a2ba17f3365b39cd08
+    inspec_download_sha256sum: 081b86dd6ca785e287fd53337f6308544393ce1d336192dbe799089d9f7a6ff7
 
     inspec_package_name: "{{ inspec_download_url.split('/')[-1] }}"
     inspec_bin: /opt/inspec/bin/inspec

--- a/test/scenarios/verifier/molecule/inspec/verify.yml
+++ b/test/scenarios/verifier/molecule/inspec/verify.yml
@@ -3,9 +3,9 @@
   hosts: all
   become: true
   vars:
-    inspec_download_url: "https://packages.chef.io/files/stable/inspec/2.1.43/el/7/inspec-2.1.43-1.el7.x86_64.rpm"
+    inspec_download_url: "https://packages.chef.io/files/stable/inspec/2.2.20/el/7/inspec-2.2.20-1.el7.x86_64.rpm"
     inspec_download_source_dir: /usr/local/src
-    inspec_download_sha256sum: bf36072724322fcca708467e5fc1973e838f605d655d72a2ba17f3365b39cd08
+    inspec_download_sha256sum: 081b86dd6ca785e287fd53337f6308544393ce1d336192dbe799089d9f7a6ff7
 
     inspec_package_name: "{{ inspec_download_url.split('/')[-1] }}"
     inspec_bin: /opt/inspec/bin/inspec


### PR DESCRIPTION
Starting with version 2.1.68, InSpec also supports Ubuntu 18.04.