### PR TITLE
Corrected schema due to #1344

### DIFF
--- a/molecule/config.py
+++ b/molecule/config.py
@@ -52,6 +52,7 @@ LOG = logger.get_logger(__name__)
 MOLECULE_DIRECTORY = 'molecule'
 MOLECULE_FILE = 'molecule.yml'
 MERGE_STRATEGY = anyconfig.MS_DICTS
+MOLECULE_KEEP_STRING = 'MOLECULE_'
 
 
 # https://stackoverflow.com/questions/16017397/injecting-function-call-after-init-with-decorator  # noqa
@@ -267,7 +268,7 @@ class Config(object):
 
         :return: dict
         """
-        return self._combine(keep_string='MOLECULE_')
+        return self._combine(keep_string=MOLECULE_KEEP_STRING)
 
     def _reget_config(self):
         """
@@ -447,7 +448,10 @@ class Config(object):
         }
 
     def _preflight(self, data):
-        errors = schema_v2.pre_validate(data)
+        env = os.environ.copy()
+        env = self._set_env(env)
+        errors = schema_v2.pre_validate(data, env, MOLECULE_KEEP_STRING)
+
         if errors:
             msg = "Failed to validate.\n\n{}".format(errors)
             util.sysexit_with_message(msg)

--- a/test/unit/model/v2/test_pre_validate.py
+++ b/test/unit/model/v2/test_pre_validate.py
@@ -35,9 +35,19 @@ platforms:
 """.strip()
 
 
+@pytest.fixture
+def _env():
+    return {}
+
+
+@pytest.fixture
+def _keep_string():
+    return 'MOLECULE_'
+
+
 @pytest.mark.parametrize('_stream', [(_model_platforms_docker_section_data)])
-def test_platforms_docker(_stream):
-    assert {} == schema_v2.pre_validate(_stream())
+def test_platforms_docker(_stream, _env, _keep_string):
+    assert {} == schema_v2.pre_validate(_stream(), _env, _keep_string)
 
 
 @pytest.fixture
@@ -54,7 +64,7 @@ platforms:
 
 @pytest.mark.parametrize('_stream',
                          [_model_platforms_docker_errors_section_data])
-def test_platforms_docker_has_errors(_stream):
+def test_platforms_docker_has_errors(_stream, _env, _keep_string):
     x = {
         'platforms': [{
             0: [{
@@ -70,7 +80,7 @@ def test_platforms_docker_has_errors(_stream):
         }]
     }
 
-    assert x == schema_v2.pre_validate(_stream())
+    assert x == schema_v2.pre_validate(_stream(), _env, _keep_string)
 
 
 @pytest.fixture
@@ -105,7 +115,7 @@ verifier:
 @pytest.mark.parametrize('_stream',
                          [(_model_molecule_env_errors_section_data)])
 def test_has_errors_when_molecule_env_var_referenced_in_unallowed_sections(
-        _stream):
+        _stream, _env, _keep_string):
     x = {
         'scenario': [{
             'name':
@@ -154,4 +164,4 @@ def test_has_errors_when_molecule_env_var_referenced_in_unallowed_sections(
         }]
     }
 
-    assert x == schema_v2.pre_validate(_stream())
+    assert x == schema_v2.pre_validate(_stream(), _env, _keep_string)

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -474,7 +474,7 @@ def test_preflight(mocker, config_instance, patched_logger_info):
 
     config_instance._preflight('foo')
 
-    m.assert_called_once_with('foo')
+    m.assert_called_once_with('foo', os.environ, config.MOLECULE_KEEP_STRING)
 
 
 def test_preflight_exists_when_validation_fails(


### PR DESCRIPTION
Users are allowed to have their own variables in molecule.yml.
A specific use case I have seen is variables in the driver section.
This patch coerces the var prior to validation.