### PR TITLE
added pull: yes|no param to Docker executor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .eggs/
 .tox/
 .vagrant/
+.pytest_cache/
 doc/build/
 htmlcov/
 pytestdebug.log

--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -46,7 +46,7 @@ class Docker(base.Base):
           - name: instance
             hostname: instance
             image: image_name:tag
-            pull: no
+            pull: True|False
             registry:
               url: registry.example.com
               credentials:

--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -46,6 +46,7 @@ class Docker(base.Base):
           - name: instance
             hostname: instance
             image: image_name:tag
+            pull: no
             registry:
               url: registry.example.com
               credentials:

--- a/molecule/model/schema_v2.py
+++ b/molecule/model/schema_v2.py
@@ -589,6 +589,9 @@ platforms_docker_schema = {
                 'image': {
                     'type': 'string',
                 },
+                'pull': {
+                    'type': 'boolean',
+                },
                 'registry': {
                     'type': 'dict',
                     'schema': {

--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -39,6 +39,7 @@
         docker_host: "{{ item.item.docker_host | default('unix://var/run/docker.sock') }}"
         dockerfile: "{{ item.item.dockerfile | default(item.invocation.module_args.dest) }}"
         force: "{{ item.item.force | default(true) }}"
+        pull: "{{ item.item.pull | default(true) }}"
       with_items: "{{ platforms.results }}"
       when: platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
 

--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -39,7 +39,7 @@
         docker_host: "{{ item.item.docker_host | default('unix://var/run/docker.sock') }}"
         dockerfile: "{{ item.item.dockerfile | default(item.invocation.module_args.dest) }}"
         force: "{{ item.item.force | default(true) }}"
-        pull: "{{ item.item.pull | default(true) }}"
+        pull: "{{ item.item.pull | default(omit) }}"
       with_items: "{{ platforms.results }}"
       when: platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
 

--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -39,6 +39,7 @@
         docker_host: "{{ item.item.docker_host | default('unix://var/run/docker.sock') }}"
         dockerfile: "{{ item.item.dockerfile | default(item.invocation.module_args.dest) }}"
         force: "{{ item.item.force | default(true) }}"
+        pull: "{{ item.item.pull | default(true) }}"
       with_items: "{{ platforms.results }}"
       when: platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
 

--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -39,7 +39,7 @@
         docker_host: "{{ item.item.docker_host | default('unix://var/run/docker.sock') }}"
         dockerfile: "{{ item.item.dockerfile | default(item.invocation.module_args.dest) }}"
         force: "{{ item.item.force | default(true) }}"
-        pull: "{{ item.item.pull | default(true) }}"
+        pull: "{{ item.item.pull | default(omit }}"
       with_items: "{{ platforms.results }}"
       when: platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
 

--- a/test/unit/model/v2/test_platforms_section.py
+++ b/test/unit/model/v2/test_platforms_section.py
@@ -35,6 +35,8 @@ def _model_platforms_docker_section_data():
             'hostname':
             'instance',
             'image':
+						'pull':
+						True,
             'image_name:tag',
             'registry': {
                 'url': 'registry.example.com',
@@ -105,6 +107,7 @@ def _model_platforms_docker_errors_section_data():
             'name': int(),
             'hostname': int(),
             'image': int(),
+						'pull': str(),
             'registry': {
                 'url': int(),
                 'credentials': {

--- a/test/unit/model/v2/test_platforms_section.py
+++ b/test/unit/model/v2/test_platforms_section.py
@@ -107,7 +107,7 @@ def _model_platforms_docker_errors_section_data():
             'name': int(),
             'hostname': int(),
             'image': int(),
-             'pull': int(),
+            'pull': int(),
             'registry': {
                 'url': int(),
                 'credentials': {

--- a/test/unit/model/v2/test_platforms_section.py
+++ b/test/unit/model/v2/test_platforms_section.py
@@ -35,9 +35,9 @@ def _model_platforms_docker_section_data():
             'hostname':
             'instance',
             'image':
+            'image_name:tag',
 						'pull':
 						True,
-            'image_name:tag',
             'registry': {
                 'url': 'registry.example.com',
                 'credentials': {
@@ -168,6 +168,7 @@ def test_platforms_docker_has_errors(_config):
                     0: ['must be of string type']
                 }],
                 'image': ['must be of string type'],
+                'pull': ['must be of boolean type'],
                 'hostname': ['must be of string type'],
                 'security_opts': [{
                     0: ['must be of string type']

--- a/test/unit/model/v2/test_platforms_section.py
+++ b/test/unit/model/v2/test_platforms_section.py
@@ -107,7 +107,7 @@ def _model_platforms_docker_errors_section_data():
             'name': int(),
             'hostname': int(),
             'image': int(),
-						'pull': str(),
+						'pull': int(),
             'registry': {
                 'url': int(),
                 'credentials': {

--- a/test/unit/model/v2/test_platforms_section.py
+++ b/test/unit/model/v2/test_platforms_section.py
@@ -36,8 +36,8 @@ def _model_platforms_docker_section_data():
             'instance',
             'image':
             'image_name:tag',
-						'pull':
-						True,
+            'pull':
+            True,
             'registry': {
                 'url': 'registry.example.com',
                 'credentials': {
@@ -107,7 +107,7 @@ def _model_platforms_docker_errors_section_data():
             'name': int(),
             'hostname': int(),
             'image': int(),
-						'pull': int(),
+             'pull': int(),
             'registry': {
                 'url': int(),
                 'credentials': {


### PR DESCRIPTION
I've made a `pull: yes|no` parameter for the Docker driver. Provides a neat solution for issue #1234.

Note: I wasn't sure how to test, could you [fix those broken refs](https://github.com/metacloud/molecule/blob/master/CONTRIBUTING.rst)?

Looking forward hearing from you.