### PR TITLE
documentation : dependencies on centos and docker driver clarifications

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -24,7 +24,7 @@ CentOS 7
 .. code-block:: bash
 
     $ sudo yum install -y epel-release
-    $ sudo yum install -y gcc python-pip python-devel openssl-devel
+    $ sudo yum install -y gcc python-pip python-devel openssl-devel libselinux-python
 
 Ubuntu 16.x
 -----------

--- a/molecule/cookiecutter/scenario/driver/azure/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
+++ b/molecule/cookiecutter/scenario/driver/azure/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
@@ -1,5 +1,5 @@
 *******
-Install
+Azure driver installation guide
 *******
 
 Requirements

--- a/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
+++ b/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
@@ -1,5 +1,5 @@
 *******
-Install
+Delegated driver installation guide
 *******
 
 Requirements

--- a/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
+++ b/molecule/cookiecutter/scenario/driver/docker/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
@@ -1,10 +1,11 @@
 *******
-Install
+Docker driver installation guide
 *******
 
 Requirements
 ============
 
+* General molecule dependencies (see https://molecule.readthedocs.io/en/latest/installation.html)
 * Docker Engine
 * docker-py
 * docker

--- a/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
+++ b/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
@@ -1,5 +1,5 @@
 *******
-Install
+Amazon Web Services driver installation guide
 *******
 
 Requirements

--- a/molecule/cookiecutter/scenario/driver/gce/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
+++ b/molecule/cookiecutter/scenario/driver/gce/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
@@ -1,5 +1,5 @@
 *******
-Install
+Google Cloud Engine driver installation guide
 *******
 
 Requirements

--- a/molecule/cookiecutter/scenario/driver/lxc/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
+++ b/molecule/cookiecutter/scenario/driver/lxc/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
@@ -1,5 +1,5 @@
 *******
-Install
+LXC driver installation guide
 *******
 
 Requirements

--- a/molecule/cookiecutter/scenario/driver/lxd/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
+++ b/molecule/cookiecutter/scenario/driver/lxd/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
@@ -1,5 +1,5 @@
 *******
-Install
+LXD driver installation guide
 *******
 
 Requirements

--- a/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
+++ b/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
@@ -1,5 +1,5 @@
 *******
-Install
+Openstack driver installation guide
 *******
 
 Requirements

--- a/molecule/cookiecutter/scenario/driver/vagrant/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
+++ b/molecule/cookiecutter/scenario/driver/vagrant/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
@@ -1,5 +1,5 @@
 *******
-Install
+Vagrant driver installation guide
 *******
 
 Requirements


### PR DESCRIPTION
Fix for #1363.
- added dependency for Centos 7 (includes Fedora and Redhat installation types)
- improved docker driver readme