### PR TITLE
Updates to the Ansible provisioning playbook for docker and vagrant for missing options

### DIFF
--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -53,7 +53,7 @@
       docker_container:
         name: "{{ item.name }}"
         docker_host: "{{ item.docker_host | default('unix://var/run/docker.sock') }}"
-        hostname: "{{ item.name }}"
+        hostname: "{{ item.hostname | default(item.name) }}"
         image: "molecule_local/{{ item.image }}"
         state: started
         recreate: false

--- a/molecule/provisioner/ansible/playbooks/vagrant/destroy.yml
+++ b/molecule/provisioner/ansible/playbooks/vagrant/destroy.yml
@@ -10,6 +10,7 @@
         instance_name: "{{ item.name }}"
         platform_box: "{{ item.box }}"
         provider_name: "{{ molecule_yml.driver.provider.name }}"
+        provider_options: "{{ item.provider_options | default(omit) }}"
         provider_raw_config_args: "{{ item.provider_raw_config_args | default(omit) }}"
         force_stop: "{{ item.force_stop | default(true) }}"
 

--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -53,7 +53,7 @@
       docker_container:
         name: "{{ item.name }}"
         docker_host: "{{ item.docker_host | default('unix://var/run/docker.sock') }}"
-        hostname: "{{ item.name }}"
+        hostname: "{{ item.hostname | default(item.name) }}"
         image: "molecule_local/{{ item.image }}"
         state: started
         recreate: false

--- a/test/resources/playbooks/vagrant/destroy.yml
+++ b/test/resources/playbooks/vagrant/destroy.yml
@@ -10,6 +10,7 @@
         instance_name: "{{ item.name }}"
         platform_box: "{{ item.box }}"
         provider_name: "{{ molecule_yml.driver.provider.name }}"
+        provider_options: "{{ item.provider_options | default(omit) }}"
         provider_raw_config_args: "{{ item.provider_raw_config_args | default(omit) }}"
         force_stop: "{{ item.force_stop | default(true) }}"
 


### PR DESCRIPTION
allow provider_options in the vagrant destroy playbook and setting a unique hostname hostname in the docker create playbook