### PR TITLE
feat(docker-build): add feature for auto bumping docker image tag

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -1,6 +1,7 @@
 USER := retr0h
-TAG := latest
-IMAGE := $(USER)/molecule:$(TAG)
+TAG := $(shell git describe --tags `git rev-list --tags --max-count=1`)
+LATEST_IMAGE := $(USER)/molecule:latest
+TAG_IMAGE := $(USER)/molecule:$(TAG)
 
 clean:
 	@echo "+ $@"
@@ -18,13 +19,14 @@ docker-build:
 	cd build && sudo docker build \
 		--rm=true \
 		--no-cache \
-		-t $(IMAGE) .
+		-t $(LATEST_IMAGE) -t $(TAG_IMAGE) .
 
 push:
 	./.tox/py27-ansible25-unit/bin/twine upload dist/* -r pypi
 
 docker-push:
 	@echo "+ $@"
-	sudo docker push $(IMAGE)
+	sudo docker push $(LATEST_IMAGE)
+	sudo docker push $(TAG_IMAGE)
 
 .PHONY: build


### PR DESCRIPTION
Hi, I found there is only `latest` tag for molecule images in docker hub. https://hub.docker.com/r/retr0h/molecule/.

It is a little confused to refer the image without the versioning number, so I add a simple update to grab the latest `git tag` as the image tag. Use git command from [https://gist.github.com/rponte/fdc0724dd984088606b0](https://gist.github.com/rponte/fdc0724dd984088606b0). And also keep the `latest` tag for the image.

So the release flow will be like:

1. firstly to bump git tag, push tags to remote
2. Then to get tags to local, build, push docker image

Please check, Thank you for your time.