### PR TITLE
Added python 3.7 support

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -16,7 +16,7 @@ See `INSTALL.rst`, which is created when initializing a new scenario.
 
 * Ansible >= 2.2
 * Python 2.7
-* Python 3.6 with Ansible >= 2.4
+* Python >= 3.6 with Ansible >= 2.4
 
 CentOS 7
 --------

--- a/molecule/shell.py
+++ b/molecule/shell.py
@@ -38,7 +38,7 @@ ENV_FILE = '.env.yml'
 
 
 def _get_python_version():  # pragma: no cover
-    return sys.version_info[:2]
+    return sys.version_info
 
 
 def _get_ansible_version():  # pragma: no cover
@@ -46,11 +46,11 @@ def _get_ansible_version():  # pragma: no cover
 
 
 def _supported_python2_version():  # pragma: no cover
-    return _get_python_version() == (2, 7)
+    return _get_python_version()[:2] == (2, 7)
 
 
 def _supported_python3_version():  # pragma: no cover
-    return _get_python_version() == (3, 6)
+    return _get_python_version() >= (3, 6)
 
 
 def _supported_ansible_version():  # pragma: no cover
@@ -74,7 +74,7 @@ def _supported_ansible_version():  # pragma: no cover
     else:
         msg = ("Python version '{}' not supported.  "
                'Molecule only supports Python versions '
-               "'2.7' and '3.6'.").format(_get_python_version())
+               "'2.7' and '>= 3.6'.").format(_get_python_version())
         util.sysexit_with_message(msg)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifier =
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
     Topic :: System :: Systems Administration
     Topic :: Utilities
 

--- a/test/functional/docker/test_scenarios.py
+++ b/test/functional/docker/test_scenarios.py
@@ -288,7 +288,8 @@ def test_command_test_destroy_strategy_always(scenario_to_test, with_scenario,
         cmd = sh.molecule.bake('test', **options)
         pytest.helpers.run_command(cmd, log=False)
 
-    msg = "An error occurred during the test sequence action: 'lint'. Cleaning up."
+    msg = ("An error occurred during the test sequence action: 'lint'. "
+           'Cleaning up.')
     assert msg in str(e.value.stdout)
 
     assert 'PLAY [Destroy]' in str(e.value.stdout)
@@ -313,7 +314,8 @@ def test_command_test_destroy_strategy_never(scenario_to_test, with_scenario,
         cmd = sh.molecule.bake('test', **options)
         pytest.helpers.run_command(cmd, log=False)
 
-    msg = "An error occurred during the test sequence action: 'lint'. Cleaning up."
+    msg = ("An error occurred during the test sequence action: 'lint'. "
+           'Cleaning up.')
     assert msg not in str(e.value.stdout)
 
     assert 0 != e.value.exit_code

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,9 @@
 minversion = 1.8
 envlist =
     py{27}-ansible{22,23,24,25,26}-functional
-    py{27,36}-ansible{22,23,24,25,26}-unit
-    py{36}-ansible{24,25,26}-functional
-    py{27,36}-lint
+    py{27,36,37}-ansible{22,23,24,25,26}-unit
+    py{36,37}-ansible{24,25,26}-functional
+    py{27,36,37}-lint
     format-check
     doc
 skipdist = True
@@ -58,11 +58,19 @@ tags =
 tags =
     unit
 
+[testenv:py37-ansible22-unit]
+tags =
+    unit
+
 [testenv:py27-ansible23-unit]
 tags =
     unit
 
 [testenv:py36-ansible23-unit]
+tags =
+    unit
+
+[testenv:py37-ansible23-unit]
 tags =
     unit
 
@@ -74,11 +82,19 @@ tags =
 tags =
     unit
 
+[testenv:py37-ansible24-unit]
+tags =
+    unit
+
 [testenv:py27-ansible25-unit]
 tags =
     unit
 
 [testenv:py36-ansible25-unit]
+tags =
+    unit
+
+[testenv:py37-ansible25-unit]
 tags =
     unit
 
@@ -90,11 +106,19 @@ tags =
 tags =
     unit
 
+[testenv:py37-ansible26-unit]
+tags =
+    unit
+
 [testenv:py27-lint]
 tags =
     unit
 
 [testenv:py36-lint]
+tags =
+    unit
+
+[testenv:py37-lint]
 tags =
     unit
 
@@ -110,6 +134,14 @@ tags =
 tags =
     functional
 
+[testenv:py36-ansible24-functional]
+tags =
+    functional
+
+[testenv:py37-ansible24-functional]
+tags =
+    functional
+
 [testenv:py27-ansible25-functional]
 tags =
     functional
@@ -118,10 +150,18 @@ tags =
 tags =
     functional
 
+[testenv:py37-ansible25-functional]
+tags =
+    functional
+
 [testenv:py27-ansible26-functional]
 tags =
     functional
 
 [testenv:py36-ansible26-functional]
+tags =
+    functional
+
+[testenv:py37-ansible26-functional]
 tags =
     functional


### PR DESCRIPTION
Updated Molecule to support python versions >= 3.6
starting with Ansible 2.4.

Fixes: #1382