### PR TITLE
Corrected provider_override_args

### DIFF
--- a/molecule/driver/vagrant.py
+++ b/molecule/driver/vagrant.py
@@ -79,6 +79,8 @@ class Vagrant(base.Base):
               gui: True
             provider_raw_config_args:
               - "customize ['modifyvm', :id, '--cpuexecutioncap', '50']"
+            provider_override_args:
+              - "vm.synced_folder './', '/vagrant', disabled: true, type: 'nfs'"
             provision: True
 
     .. code-block:: bash

--- a/molecule/provisioner/ansible/playbooks/vagrant/create.yml
+++ b/molecule/provisioner/ansible/playbooks/vagrant/create.yml
@@ -22,6 +22,7 @@
         provider_cpus: "{{ item.cpus | default(omit) }}"
         provider_options: "{{ item.provider_options | default(omit) }}"
         provider_raw_config_args: "{{ item.provider_raw_config_args | default(omit) }}"
+        provider_override_args: "{{ item.provider_override_args | default(omit) }}"
 
         provision: "{{ item.provision | default(omit) }}"
 

--- a/test/resources/playbooks/vagrant/create.yml
+++ b/test/resources/playbooks/vagrant/create.yml
@@ -22,6 +22,7 @@
         provider_cpus: "{{ item.cpus | default(omit) }}"
         provider_options: "{{ item.provider_options | default(omit) }}"
         provider_raw_config_args: "{{ item.provider_raw_config_args | default(omit) }}"
+        provider_override_args: "{{ item.provider_override_args | default(omit) }}"
 
         provision: "{{ item.provision | default(omit) }}"
 


### PR DESCRIPTION
Pass provider_override_args into vagrant.yml.

Fixes: #1385