### PR TITLE
Add git to docker DIND container

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -23,6 +23,7 @@ ENV PACKAGES="\
     ruby-dev \
     ruby-rdoc \
     ruby-irb \
+    git \
 "
 
 ENV PIP_PACKAGES="\


### PR DESCRIPTION
Ansible-galaxy can require git to be installed to pull down certain dependencies