### PR TITLE
Support passing arbitrary keys to vm.network 

### DIFF
--- a/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
+++ b/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
@@ -334,7 +334,7 @@ Vagrant.configure('2') do |config|
       if instance['interfaces']
         instance['interfaces'].each { |interface|
           c.vm.network "#{interface['network_name']}",
-                       interface.select{|k| k != 'network_name'}.transform_keys{|k| k.to_sym}
+                       Hash[interface.select{|k| k != 'network_name'}.map{|k,v| [k.to_sym, v]}]
         }
       end
 

--- a/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
+++ b/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
@@ -333,11 +333,8 @@ Vagrant.configure('2') do |config|
 
       if instance['interfaces']
         instance['interfaces'].each { |interface|
-          if interface['type'] == 'static'
-            c.vm.network "#{interface['network_name']}", type: "#{interface['type']}", auto_config: "#{interface['auto_config']}", ip: "#{interface['ip']}"
-          else
-            c.vm.network "#{interface['network_name']}", type: "#{interface['type']}", auto_config: "#{interface['auto_config']}"
-          end
+          c.vm.network "#{interface['network_name']}",
+                       interface.select{|k| k != 'network_name'}.transform_keys{|k| k.to_sym}
         }
       end
 

--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -147,7 +147,8 @@ def list(x):
     out = out.stdout.decode('utf-8')
     out = util.strip_ansi_color(out)
 
-    assert x in out
+    for l in x.splitlines():
+        assert l in out
 
 
 @pytest.helpers.register
@@ -157,7 +158,8 @@ def list_with_format_plain(x):
     out = out.stdout.decode('utf-8')
     out = util.strip_ansi_color(out)
 
-    assert x in out
+    for l in x.splitlines():
+        assert l in out
 
 
 @pytest.helpers.register

--- a/test/scenarios/driver/vagrant/molecule/default/molecule.yml
+++ b/test/scenarios/driver/vagrant/molecule/default/molecule.yml
@@ -16,6 +16,9 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: dhcp
+      - virtualbox__intnet: test_network
+        network_name: private_network
+        ip: 192.168.0.1
     provision: false
 provisioner:
   name: ansible

--- a/test/scenarios/driver/vagrant/molecule/default/tests/test_default.py
+++ b/test/scenarios/driver/vagrant/molecule/default/tests/test_default.py
@@ -28,8 +28,12 @@ def test_etc_molecule_ansible_hostname_file(host):
     assert f.mode == 0o644
 
 
-def test_interface(host):
+def test_hostonly_interface(host):
     i = host.interface('eth1').addresses
 
     # NOTE(retr0h): Contains ipv4 and ipv6 addresses.
     assert len(i) == 2
+
+
+def test_internal_interface(host):
+    assert '192.168.0.1' in host.interface('eth2').addresses

--- a/test/scenarios/driver/vagrant/molecule/multi-node/molecule.yml
+++ b/test/scenarios/driver/vagrant/molecule/multi-node/molecule.yml
@@ -16,6 +16,9 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: dhcp
+      - virtualbox__intnet: test_network
+        network_name: private_network
+        ip: 192.168.0.1
     groups:
       - foo
       - bar
@@ -29,6 +32,9 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: dhcp
+      - virtualbox__intnet: test_network
+        network_name: private_network
+        ip: 192.168.0.2
     groups:
       - foo
       - baz

--- a/test/scenarios/driver/vagrant/molecule/multi-node/tests/test_default.py
+++ b/test/scenarios/driver/vagrant/molecule/multi-node/tests/test_default.py
@@ -30,7 +30,7 @@ def test_etc_molecule_ansible_hostname_file(host):
     assert f.mode == 0o644
 
 
-def test_interface(host):
+def test_hostonly_interface(host):
     i = host.interface('eth1').addresses
 
     # NOTE(retr0h): Contains ipv4 and ipv6 addresses.

--- a/test/scenarios/driver/vagrant/molecule/multi-node/tests/test_instance-1.py
+++ b/test/scenarios/driver/vagrant/molecule/multi-node/tests/test_instance-1.py
@@ -29,3 +29,7 @@ def test_has_shared_directory(host):
     f = host.file('/vagrant')
 
     assert f.is_directory
+
+
+def test_internal_interface(host):
+    assert '192.168.0.1' in host.interface('eth2').addresses

--- a/test/scenarios/driver/vagrant/molecule/multi-node/tests/test_instance-2.py
+++ b/test/scenarios/driver/vagrant/molecule/multi-node/tests/test_instance-2.py
@@ -29,3 +29,7 @@ def test_does_not_have_shared_directory(host):
     f = host.file('/vagrant')
 
     assert not f.is_directory
+
+
+def test_internal_interface(host):
+    assert '192.168.0.2' in host.interface('eth2').addresses


### PR DESCRIPTION
I wanted to be sure that `virtualbox__intnet` is really passed to Vagrant, so I added additional network to vagrant driver scenario and updated tests (and checked that they actually pass after implementing feature). Also I think that having an example of how to add VirtualBox internal network might be useful. Still, if you think these changes are too VirtualBox-specific and not appropriate I can just remove related commit.

Another way to test this might be just removing `auto_config: true` from test scenario since it's default in Vagrant and with generic key passing it's no longer necessary to pass it explicitly. I can add these modifications if you think it's appropriate.

Also when I started working with clean codebase I still got some functional tests failing, so I fixed them in my first commit. The problem was with output lines ordering, sometimes it was different from test expectations.
