### PR TITLE
Expose config.project_directory as env var

### DIFF
--- a/molecule/config.py
+++ b/molecule/config.py
@@ -184,6 +184,7 @@ class Config(object):
             'MOLECULE_INVENTORY_FILE': self.provisioner.inventory_file,
             'MOLECULE_EPHEMERAL_DIRECTORY': self.scenario.ephemeral_directory,
             'MOLECULE_SCENARIO_DIRECTORY': self.scenario.directory,
+            'MOLECULE_PROJECT_DIRECTORY': self.project_directory,
             'MOLECULE_INSTANCE_CONFIG': self.driver.instance_config,
             'MOLECULE_DEPENDENCY_NAME': self.dependency.name,
             'MOLECULE_DRIVER_NAME': self.driver.name,

--- a/molecule/provisioner/ansible.py
+++ b/molecule/provisioner/ansible.py
@@ -174,11 +174,11 @@ class Ansible(base.Base):
     ::
 
         ANSIBLE_ROLES_PATH:
-          $ephemeral_directory/roles/:$project_root/../
+          $ephemeral_directory/roles/:$project_directory/../
         ANSIBLE_LIBRARY:
-          $ephemeral_directory/library/:$project_root/library/
+          $ephemeral_directory/library/:$project_directory/library/
         ANSIBLE_FILTER_PLUGINS:
-          $ephemeral_directory/plugins/filters/:$project_root/filter/plugins/
+          $ephemeral_directory/plugins/filters/:$project_directory/filter/plugins/
 
     Environment variables can be passed to the provisioner.  Variables in this
     section which match the names above will be appened to the above defaults,

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -288,6 +288,8 @@ def test_env(config_instance):
         config_instance.scenario.ephemeral_directory,
         'MOLECULE_SCENARIO_DIRECTORY':
         config_instance.scenario.directory,
+        'MOLECULE_PROJECT_DIRECTORY':
+        config_instance.project_directory,
         'MOLECULE_INSTANCE_CONFIG':
         config_instance.driver.instance_config,
         'MOLECULE_DEPENDENCY_NAME':


### PR DESCRIPTION
MOLECULE_PROJECT_DIRECTORY is now exposed as an env var.

Fixes: #1433