### PR TITLE
Adds tox-tags to test-requirements.txt

### DIFF
--- a/doc/source/testing.rst
+++ b/doc/source/testing.rst
@@ -18,10 +18,6 @@ Install the test framework `Tox`_.
 
     $ pip install tox
 
-Install `tox-tags`_.
-
-.. _`tox-tags`: https://github.com/AndreLouisCaron/tox-tags
-
 Install the remaining requirements in a venv (optional).
 
 .. code-block:: bash

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -17,3 +17,4 @@ shade==1.22.2
 twine
 wheel==0.30.0
 yapf==0.21.0
+-e git://github.com/AndreLouisCaron/tox-tags@master#egg=tox-tags


### PR DESCRIPTION
As the title states, adds tox-tags to test-requirements.txt. Uses the "editable" form ([pip docs](https://pip.readthedocs.io/en/1.1/requirements.html#requirements-file-format)) in the test-requirements.txt and my source on [SO](https://stackoverflow.com/questions/16584552/how-to-state-in-requirements-txt-a-direct-github-source).

I could pin the latest commit of tox-tags in the requirements to prevent breakage if tox-tags gets updated?