### PR TITLE
Correct .env file interpolation

### DIFF
--- a/molecule/provisioner/ansible/plugins/filters/molecule_core.py
+++ b/molecule/provisioner/ansible/plugins/filters/molecule_core.py
@@ -20,6 +20,7 @@
 
 import os
 
+from molecule import config
 from molecule import interpolation
 from molecule import util
 
@@ -34,8 +35,12 @@ def from_yaml(data):
 
     :return: dict
     """
-    i = interpolation.Interpolator(interpolation.TemplateWithDefaults,
-                                   os.environ)
+    molecule_env_file = os.environ['MOLECULE_ENV_FILE']
+
+    env = os.environ.copy()
+    env = config.set_env_from_file(env, molecule_env_file)
+
+    i = interpolation.Interpolator(interpolation.TemplateWithDefaults, env)
     interpolated_data = i.interpolate(data)
 
     return util.safe_load(interpolated_data)

--- a/molecule/util.py
+++ b/molecule/util.py
@@ -243,7 +243,8 @@ def title(word):
 
 
 def abs_path(path):
-    return os.path.abspath(path)
+    if path:
+        return os.path.abspath(path)
 
 
 def camelize(string):

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -350,6 +350,10 @@ def test_abs_path(temp_dir):
     assert x == util.abs_path(os.path.join(os.path.pardir, 'foo', 'bar'))
 
 
+def test_abs_path_with_none_path():
+    assert util.abs_path(None) is None
+
+
 def test_camelize():
     assert 'Foo' == util.camelize('foo')
     assert 'FooBar' == util.camelize('foo_bar')


### PR DESCRIPTION
Molecule was not handling env file interpolation due to Molecule's
filter plugin not being updated when .env file support was added.

Fixes: #1358