### PR TITLE
Adds pre_build_image option to Docker create playbook

### DIFF
--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -47,6 +47,7 @@ class Docker(base.Base):
             hostname: instance
             image: image_name:tag
             pull: True|False
+            pre_build_image: True|False
             registry:
               url: registry.example.com
               credentials:

--- a/molecule/model/schema_v2.py
+++ b/molecule/model/schema_v2.py
@@ -611,6 +611,9 @@ platforms_docker_schema = {
                 'pull': {
                     'type': 'boolean',
                 },
+                'pre_build_image': {
+                    'type': 'boolean',
+                },
                 'registry': {
                     'type': 'dict',
                     'schema': {

--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: false
   tasks:
     - name: Log into a Docker registry
       docker_login:
@@ -20,9 +20,10 @@
 
     - name: Create Dockerfiles from image names
       template:
-        src: "{{ molecule_scenario_directory }}/Dockerfile.j2"
+        src: Dockerfile.j2
         dest: "{{ molecule_ephemeral_directory }}/Dockerfile_{{ item.image | regex_replace('[^a-zA-Z0-9_]', '_') }}"
       with_items: "{{ molecule_yml.platforms }}"
+      when: not item.pre_build_image | default(false)
       register: platforms
 
     - name: Discover local Docker images
@@ -30,6 +31,7 @@
         name: "molecule_local/{{ item.item.name }}"
         docker_host: "{{ item.item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
       with_items: "{{ platforms.results }}"
+      when: not item.pre_build_image | default(false)
       register: docker_images
 
     - name: Build an Ansible compatible image
@@ -41,7 +43,9 @@
         force: "{{ item.item.force | default(true) }}"
         pull: "{{ item.item.pull | default(omit) }}"
       with_items: "{{ platforms.results }}"
-      when: platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
+      when:
+        - platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
+        - not item.item.pre_build_image | default(false)
 
     - name: Create docker network(s)
       docker_network:
@@ -55,7 +59,7 @@
         name: "{{ item.name }}"
         docker_host: "{{ item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
         hostname: "{{ item.hostname | default(item.name) }}"
-        image: "molecule_local/{{ item.image }}"
+        image: "{{ item.pre_build_image | default(false) | ternary('', 'molecule_local/') }}{{ item.image }}"
         state: started
         recreate: false
         log_driver: json-file

--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: false
+  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
   tasks:
     - name: Log into a Docker registry
       docker_login:
@@ -20,7 +20,7 @@
 
     - name: Create Dockerfiles from image names
       template:
-        src: Dockerfile.j2
+        src: "{{ molecule_scenario_directory }}/Dockerfile.j2"
         dest: "{{ molecule_ephemeral_directory }}/Dockerfile_{{ item.image | regex_replace('[^a-zA-Z0-9_]', '_') }}"
       with_items: "{{ molecule_yml.platforms }}"
       when: not item.pre_build_image | default(false)

--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: false
+  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
   tasks:
     - name: Log into a Docker registry
       docker_login:

--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  no_log: false
   tasks:
     - name: Log into a Docker registry
       docker_login:
@@ -23,6 +23,7 @@
         src: Dockerfile.j2
         dest: "{{ molecule_ephemeral_directory }}/Dockerfile_{{ item.image | regex_replace('[^a-zA-Z0-9_]', '_') }}"
       with_items: "{{ molecule_yml.platforms }}"
+      when: not item.pre_build_image | default(false)
       register: platforms
 
     - name: Discover local Docker images
@@ -30,6 +31,7 @@
         name: "molecule_local/{{ item.item.name }}"
         docker_host: "{{ item.item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
       with_items: "{{ platforms.results }}"
+      when: not item.pre_build_image | default(false)
       register: docker_images
 
     - name: Build an Ansible compatible image
@@ -41,7 +43,9 @@
         force: "{{ item.item.force | default(true) }}"
         pull: "{{ item.item.pull | default(omit) }}"
       with_items: "{{ platforms.results }}"
-      when: platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
+      when:
+        - platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
+        - not item.item.pre_build_image | default(false)
 
     - name: Create docker network(s)
       docker_network:
@@ -55,7 +59,7 @@
         name: "{{ item.name }}"
         docker_host: "{{ item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
         hostname: "{{ item.hostname | default(item.name) }}"
-        image: "molecule_local/{{ item.image }}"
+        image: "{{ item.pre_build_image | default(false) | ternary('', 'molecule_local/') }}{{ item.image }}"
         state: started
         recreate: false
         log_driver: json-file

--- a/test/unit/model/v2/test_platforms_section.py
+++ b/test/unit/model/v2/test_platforms_section.py
@@ -38,6 +38,8 @@ def _model_platforms_docker_section_data():
             'image_name:tag',
             'pull':
             True,
+            'pre_build_image':
+            False,
             'registry': {
                 'url': 'registry.example.com',
                 'credentials': {
@@ -111,6 +113,7 @@ def _model_platforms_docker_errors_section_data():
             'hostname': int(),
             'image': int(),
             'pull': int(),
+            'pre_build_image': int(),
             'registry': {
                 'url': int(),
                 'credentials': {
@@ -173,6 +176,7 @@ def test_platforms_docker_has_errors(_config):
                 }],
                 'image': ['must be of string type'],
                 'pull': ['must be of boolean type'],
+                'pre_build_image': ['must be of boolean type'],
                 'hostname': ['must be of string type'],
                 'security_opts': [{
                     0: ['must be of string type']


### PR DESCRIPTION
As the title states adds a `pre_build_image`option to the Docker API. 
When user want to user their own prebuild images instead of running the default Molecule Dockerfile.j2 build. When set to true the `image:` get passed to docker_container without the `molecule_local` prefix.

In my case I use my own images which use a script to simulate systemd in the container ([repo](https://github.com/LANsible/docker-base-ansible)). This allows me to skip all the build steps.
