### PR TITLE
Added network_mode option to Docker container

### DIFF
--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -78,6 +78,7 @@ class Docker(base.Base):
             networks:
               - name: foo
               - name: bar
+			network_mode: host
             docker_host: tcp://localhost:12376
             env:
               FOO: bar

--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -78,7 +78,7 @@ class Docker(base.Base):
             networks:
               - name: foo
               - name: bar
-			network_mode: host
+            network_mode: host
             docker_host: tcp://localhost:12376
             env:
               FOO: bar

--- a/molecule/model/schema_v2.py
+++ b/molecule/model/schema_v2.py
@@ -708,6 +708,9 @@ platforms_docker_schema = {
                         }
                     }
                 },
+                'network_mode': {
+                    'type': 'string',
+                },
             }
         }
     },

--- a/molecule/provisioner/ansible/playbooks/docker/create.yml
+++ b/molecule/provisioner/ansible/playbooks/docker/create.yml
@@ -73,6 +73,7 @@
         published_ports: "{{ item.published_ports | default(omit) }}"
         ulimits: "{{ item.ulimits | default(omit) }}"
         networks: "{{ item.networks | default(omit) }}"
+        network_mode: "{{ item.network_mode | default(omit) }}"
         dns_servers: "{{ item.dns_servers | default(omit) }}"
         env: "{{ item.env | default(omit) }}"
       register: server

--- a/test/resources/playbooks/docker/create.yml
+++ b/test/resources/playbooks/docker/create.yml
@@ -73,6 +73,7 @@
         published_ports: "{{ item.published_ports | default(omit) }}"
         ulimits: "{{ item.ulimits | default(omit) }}"
         networks: "{{ item.networks | default(omit) }}"
+        network_mode: "{{ item.network_mode | default(omit) }}"
         dns_servers: "{{ item.dns_servers | default(omit) }}"
         env: "{{ item.env | default(omit) }}"
       register: server

--- a/test/unit/model/v2/test_platforms_section.py
+++ b/test/unit/model/v2/test_platforms_section.py
@@ -90,6 +90,8 @@ def _model_platforms_docker_section_data():
                     'name': 'bar',
                 },
             ],
+            'network_mode':
+            'mode',
             'foo':
             'bar'
         }]
@@ -154,6 +156,7 @@ def _model_platforms_docker_errors_section_data():
                     'name': int(),
                 },
             ],
+            'network_mode': int(),
         }]
     }
 
@@ -205,6 +208,7 @@ def test_platforms_docker_has_errors(_config):
                         'name': ['must be of string type']
                     }]
                 }],
+                'network_mode': ['must bt of string type'],
                 'ulimits': [{
                     0: ['must be of string type']
                 }],


### PR DESCRIPTION
Hi,

First, sorry for my english...

I was _fighting_ some time with an issue in one of my roles, and finally it was related with the network of the Docker container created by Molecule.

I just added the `network_mode` parameter to the `create.yml` file, similar to `--net=host` in the `docker run` command.

According to the official documentation of the [Ansible Docker module](https://docs.ansible.com/ansible/latest/modules/docker_container_module.html), you can choose "_bridge_", "_host_", "_none_" or "_container:<name|id>_"

So now, you can set this value in the `platforms` node of the `molecule.yml` config file.

Thank you,