### PR TITLE
Updates tox-tags url in test-requirements.txt

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -17,4 +17,4 @@ shade==1.22.2
 twine
 wheel==0.30.0
 yapf==0.21.0
--e git://github.com/AndreLouisCaron/tox-tags@master#egg=tox-tags
+https://github.com/AndreLouisCaron/tox-tags/archive/master.zip


### PR DESCRIPTION
Worked behind a strict firewall today and the previous approach wasn't working. So dug around and found out a https:// approach is also an option. I think a better approach since this is never blocked on a firewall and even faster since the repo does not get cloned ([source](https://stackoverflow.com/a/24811490))

Another option which does clone the repository:
`git+https://github.com/AndreLouisCaron/tox-tags.git@master`