### PR TITLE
Deprecated ansible 2.2 and 2.3 tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ Forums
 Ansible Support
 ===============
 
-Molecule requires Ansible version 2.2 or later.
+Molecule requires Ansible version 2.4 or later.
 
 .. _`Ansible`: https://docs.ansible.com
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -14,7 +14,7 @@ Requirements
 Depending on the driver chosen, you may need to install additional OS packages.
 See `INSTALL.rst`, which is created when initializing a new scenario.
 
-* Ansible >= 2.2
+* Ansible >= 2.4
 * Python 2.7
 * Python >= 3.6 with Ansible >= 2.4
 

--- a/molecule/cookiecutter/scenario/driver/azure/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/azure/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -90,8 +90,6 @@
 
     - name: Dump instance config
       copy:
-        # NOTE(retr0h): Workaround for Ansible 2.2.
-        #               https://github.com/ansible/ansible/issues/20885
         content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
         dest: "{{ molecule_instance_config }}"
       when: server.changed | bool

--- a/molecule/cookiecutter/scenario/driver/azure/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/azure/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -39,8 +39,6 @@
 
     - name: Dump instance config
       copy:
-        # NOTE(retr0h): Workaround for Ansible 2.2.
-        #               https://github.com/ansible/ansible/issues/20885
         content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
         dest: "{{ molecule_instance_config }}"
       when: server.changed | bool

--- a/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -30,8 +30,6 @@
 
     - name: Dump instance config
       copy:
-        # NOTE(retr0h): Workaround for Ansible 2.2.
-        #               https://github.com/ansible/ansible/issues/20885
         content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
         dest: "{{ molecule_instance_config }}"
       when: server.changed | bool

--- a/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/delegated/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -16,8 +16,6 @@
 
     - name: Dump instance config
       copy:
-        # NOTE(retr0h): Workaround for Ansible 2.2.
-        #               https://github.com/ansible/ansible/issues/20885
         content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
         dest: "{{ molecule_instance_config }}"
       when: server.changed | bool

--- a/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -108,8 +108,6 @@
 
     - name: Dump instance config
       copy:
-        # NOTE(retr0h): Workaround for Ansible 2.2.
-        #               https://github.com/ansible/ansible/issues/20885
         content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
         dest: "{{ molecule_instance_config }}"
       when: server.changed | bool

--- a/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/ec2/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -43,8 +43,6 @@
 
     - name: Dump instance config
       copy:
-        # NOTE(retr0h): Workaround for Ansible 2.2.
-        #               https://github.com/ansible/ansible/issues/20885
         content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
         dest: "{{ molecule_instance_config }}"
       when: server.changed | bool

--- a/molecule/cookiecutter/scenario/driver/gce/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/gce/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -53,8 +53,6 @@
 
     - name: Dump instance config
       copy:
-        # NOTE(retr0h): Workaround for Ansible 2.2.
-        #               https://github.com/ansible/ansible/issues/20885
         content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
         dest: "{{ molecule_instance_config }}"
       when: server.changed | bool

--- a/molecule/cookiecutter/scenario/driver/gce/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/gce/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -35,8 +35,6 @@
 
     - name: Dump instance config
       copy:
-        # NOTE(retr0h): Workaround for Ansible 2.2.
-        #               https://github.com/ansible/ansible/issues/20885
         content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
         dest: "{{ molecule_instance_config }}"
       when: server.changed | bool

--- a/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -119,8 +119,6 @@
 
     - name: Dump instance config
       copy:
-        # NOTE(retr0h): Workaround for Ansible 2.2.
-        #               https://github.com/ansible/ansible/issues/20885
         content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
         dest: "{{ molecule_instance_config }}"
       when: server.changed | bool

--- a/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule/cookiecutter/scenario/driver/openstack/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -31,8 +31,6 @@
 
     - name: Dump instance config
       copy:
-        # NOTE(retr0h): Workaround for Ansible 2.2.
-        #               https://github.com/ansible/ansible/issues/20885
         content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
         dest: "{{ molecule_instance_config }}"
       when: server.changed | bool

--- a/molecule/provisioner/ansible/playbooks/vagrant/create.yml
+++ b/molecule/provisioner/ansible/playbooks/vagrant/create.yml
@@ -54,8 +54,6 @@
 
     - name: Dump instance config
       copy:
-        # NOTE(retr0h): Workaround for Ansible 2.2.
-        #               https://github.com/ansible/ansible/issues/20885
         content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
         dest: "{{ molecule_instance_config }}"
       when: server.changed | bool

--- a/molecule/provisioner/ansible/playbooks/vagrant/destroy.yml
+++ b/molecule/provisioner/ansible/playbooks/vagrant/destroy.yml
@@ -29,8 +29,6 @@
 
     - name: Dump instance config
       copy:
-        # NOTE(retr0h): Workaround for Ansible 2.2.
-        #               https://github.com/ansible/ansible/issues/20885
         content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
         dest: "{{ molecule_instance_config }}"
       when: server.changed | bool

--- a/molecule/shell.py
+++ b/molecule/shell.py
@@ -55,10 +55,10 @@ def _supported_python3_version():  # pragma: no cover
 
 def _supported_ansible_version():  # pragma: no cover
     if (distutils.version.LooseVersion(_get_ansible_version()) <=
-            distutils.version.LooseVersion('2.2')):
+            distutils.version.LooseVersion('2.4')):
         msg = ("Ansible version '{}' not supported.  "
                'Molecule only supports Ansible versions '
-               "'>= 2.2'.").format(_get_ansible_version())
+               "'>= 2.4'.").format(_get_ansible_version())
         util.sysexit_with_message(msg)
 
     if _supported_python2_version():

--- a/test/resources/playbooks/azure/create.yml
+++ b/test/resources/playbooks/azure/create.yml
@@ -89,8 +89,6 @@
 
     - name: Dump instance config
       copy:
-        # NOTE(retr0h): Workaround for Ansible 2.2.
-        #               https://github.com/ansible/ansible/issues/20885
         content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
         dest: "{{ molecule_instance_config }}"
       when: server.changed | bool

--- a/test/resources/playbooks/azure/destroy.yml
+++ b/test/resources/playbooks/azure/destroy.yml
@@ -37,8 +37,6 @@
 
     - name: Dump instance config
       copy:
-        # NOTE(retr0h): Workaround for Ansible 2.2.
-        #               https://github.com/ansible/ansible/issues/20885
         content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
         dest: "{{ molecule_instance_config }}"
       when: server.changed | bool

--- a/test/resources/playbooks/ec2/create.yml
+++ b/test/resources/playbooks/ec2/create.yml
@@ -107,8 +107,6 @@
 
     - name: Dump instance config
       copy:
-        # NOTE(retr0h): Workaround for Ansible 2.2.
-        #               https://github.com/ansible/ansible/issues/20885
         content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
         dest: "{{ molecule_instance_config }}"
       when: server.changed | bool

--- a/test/resources/playbooks/ec2/destroy.yml
+++ b/test/resources/playbooks/ec2/destroy.yml
@@ -44,8 +44,6 @@
 
     - name: Dump instance config
       copy:
-        # NOTE(retr0h): Workaround for Ansible 2.2.
-        #               https://github.com/ansible/ansible/issues/20885
         content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
         dest: "{{ molecule_instance_config }}"
       when: server.changed | bool

--- a/test/resources/playbooks/gce/create.yml
+++ b/test/resources/playbooks/gce/create.yml
@@ -52,8 +52,6 @@
 
     - name: Dump instance config
       copy:
-        # NOTE(retr0h): Workaround for Ansible 2.2.
-        #               https://github.com/ansible/ansible/issues/20885
         content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
         dest: "{{ molecule_instance_config }}"
       when: server.changed | bool

--- a/test/resources/playbooks/gce/destroy.yml
+++ b/test/resources/playbooks/gce/destroy.yml
@@ -34,8 +34,6 @@
 
     - name: Dump instance config
       copy:
-        # NOTE(retr0h): Workaround for Ansible 2.2.
-        #               https://github.com/ansible/ansible/issues/20885
         content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
         dest: "{{ molecule_instance_config }}"
       when: server.changed | bool

--- a/test/resources/playbooks/openstack/create.yml
+++ b/test/resources/playbooks/openstack/create.yml
@@ -118,8 +118,6 @@
 
     - name: Dump instance config
       copy:
-        # NOTE(retr0h): Workaround for Ansible 2.2.
-        #               https://github.com/ansible/ansible/issues/20885
         content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
         dest: "{{ molecule_instance_config }}"
       when: server.changed | bool

--- a/test/resources/playbooks/openstack/destroy.yml
+++ b/test/resources/playbooks/openstack/destroy.yml
@@ -30,8 +30,6 @@
 
     - name: Dump instance config
       copy:
-        # NOTE(retr0h): Workaround for Ansible 2.2.
-        #               https://github.com/ansible/ansible/issues/20885
         content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
         dest: "{{ molecule_instance_config }}"
       when: server.changed | bool

--- a/test/resources/playbooks/vagrant/create.yml
+++ b/test/resources/playbooks/vagrant/create.yml
@@ -54,8 +54,6 @@
 
     - name: Dump instance config
       copy:
-        # NOTE(retr0h): Workaround for Ansible 2.2.
-        #               https://github.com/ansible/ansible/issues/20885
         content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
         dest: "{{ molecule_instance_config }}"
       when: server.changed | bool

--- a/test/resources/playbooks/vagrant/destroy.yml
+++ b/test/resources/playbooks/vagrant/destroy.yml
@@ -29,8 +29,6 @@
 
     - name: Dump instance config
       copy:
-        # NOTE(retr0h): Workaround for Ansible 2.2.
-        #               https://github.com/ansible/ansible/issues/20885
         content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
         dest: "{{ molecule_instance_config }}"
       when: server.changed | bool

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 [tox]
 minversion = 1.8
 envlist =
-    py{27}-ansible{22,23,24,25,26}-functional
-    py{27,36,37}-ansible{22,23,24,25,26}-unit
+    py{27}-ansible{24,25,26}-functional
+    py{27,36,37}-ansible{24,25,26}-unit
     py{36,37}-ansible{24,25,26}-functional
     py{27,36,37}-lint
     format-check
@@ -19,8 +19,6 @@ setenv =
 deps =
     -rrequirements.txt
     -rtest-requirements.txt
-    ansible22: ansible==2.2.3.0
-    ansible23: ansible==2.3.3.0
     ansible24: ansible==2.4.6.0
     ansible25: ansible==2.5.9
     ansible26: ansible==2.6.4
@@ -48,30 +46,6 @@ commands=
 [testenv:pur]
 commands=
     pur -r requirements.txt
-
-[testenv:py27-ansible22-unit]
-tags =
-    unit
-
-[testenv:py36-ansible22-unit]
-tags =
-    unit
-
-[testenv:py37-ansible22-unit]
-tags =
-    unit
-
-[testenv:py27-ansible23-unit]
-tags =
-    unit
-
-[testenv:py36-ansible23-unit]
-tags =
-    unit
-
-[testenv:py37-ansible23-unit]
-tags =
-    unit
 
 [testenv:py27-ansible24-unit]
 tags =
@@ -120,14 +94,6 @@ tags =
 [testenv:py37-lint]
 tags =
     unit
-
-[testenv:py27-ansible22-functional]
-tags =
-    functional
-
-[testenv:py27-ansible23-functional]
-tags =
-    functional
 
 [testenv:py27-ansible24-functional]
 tags =


### PR DESCRIPTION
Ansible 2.2 and 2.3 are not supported by RH [1].
Removed 2.2 and 2.3 from unit/functional tests.

[1] https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html