### PR TITLE
Fixes docs build, appends #egg to tox-tags url

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -18,4 +18,4 @@ shade==1.22.2
 twine
 wheel==0.30.0
 yapf==0.21.0
-https://github.com/AndreLouisCaron/tox-tags/archive/master.zip
+https://github.com/AndreLouisCaron/tox-tags/archive/master.zip#egg=tox-tags


### PR DESCRIPTION
As the title states, the [docs build](https://readthedocs.org/projects/molecule/builds/?page=1) is failing since #1467 or #1435 was merged.
Appending `#egg` should fix the build.
Tested it locally in the `python:3.7-stretch` Docker image by simulating the build steps:

```bash
pip install pip==9.0.1 #to match version with docs builder
pip install "Pygments==2.2.0" "setuptools<40" "docutils==0.13.1" "mock==1.0.1" "pillow==2.6.1" "alabaster>=0.7,<0.8,!=0.7.5" "commonmark==0.5.4"
pip install --exists-action=w -r doc-requirements.txt
pip install -r test-requirements.txt #to verify if this still works
```

This all completes without error, where as soon as I remove `#egg=tox-tags` it errors again :)

Related:
https://github.com/pypa/setuptools/issues/1052