### PR TITLE
Bump Goss to v0.3.6

### DIFF
--- a/molecule/cookiecutter/scenario/verifier/goss/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
+++ b/molecule/cookiecutter/scenario/verifier/goss/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
@@ -8,7 +8,7 @@
   hosts: all
   become: true
   vars:
-    goss_version: v0.3.2
+    goss_version: v0.3.6
     goss_arch: amd64
     goss_dst: /usr/local/bin/goss
     goss_sha256sum: 2f6727375db2ea0f81bee36e2c5be78ab5ab8d5981f632f761b25e4003e190ec


### PR DESCRIPTION
Bumps Goss version to v0.3.6 in the cookiecutter template. 