### PR TITLE
Bumped testinfra to 1.16.0 due to testinfra bug.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 History
 *******
 
+Unreleased
+==========
+
+* Bumped testinfra to 1.16.0 due to testinfra bug.
+
 2.18.1
 ======
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,6 @@ PyYAML==3.13
 sh==1.12.14
 six==1.11.0
 tabulate==0.8.2
-testinfra==1.14.1
+testinfra==1.16.0
 tree-format==0.1.2
 yamllint==1.11.1


### PR DESCRIPTION
This is a request to bump testinfra to 1.16.0 because they've fixed PATH issue that prevent using some modules (like sysctl) on Red Hat-type systems.

This change has passed all Tox tests (except some rubocop because I didn't installed it)

