### PR TITLE
fix(lxd): Removes local mode from documentation

### DIFF
--- a/molecule/driver/lxd.py
+++ b/molecule/driver/lxd.py
@@ -31,8 +31,11 @@ class LXD(base.Base):
 
     Molecule leverages Ansible's `lxd_container`_ module, by mapping variables
     from `molecule.yml` into `create.yml` and `destroy.yml`.
+    The `lxd_container`_ module leverages the LXD API. Usefull information
+    about, for example the source variable can be found in the `LXD API documentation`.
 
     .. _`lxd_container`: http://docs.ansible.com/ansible/latest/lxd_container_module.html
+    .. _`LXD API documentation`: https://github.com/lxc/lxd/blob/master/doc/rest-api.md#post-1
 
     .. code-block:: yaml
 

--- a/molecule/driver/lxd.py
+++ b/molecule/driver/lxd.py
@@ -46,7 +46,7 @@ class LXD(base.Base):
             trust_password: password
             source:
               type: image
-              mode: pull|local
+              mode: pull
               server: https://images.linuxcontainers.org
               protocol: lxd|simplestreams
               alias: ubuntu/xenial/amd64


### PR DESCRIPTION
As discussed in #1490, removes the mode: local option from the documentation. 
Also adds a little elaboration on the lxd_container module and the LXD API. Hopefully this points end-users in the right direction.