### PR TITLE
Allows lowercase environment variables in the Docker scheme

### DIFF
--- a/molecule/model/schema_v2.py
+++ b/molecule/model/schema_v2.py
@@ -694,7 +694,7 @@ platforms_docker_schema = {
                     'type': 'dict',
                     'keyschema': {
                         'type': 'string',
-                        'regex': '^[A-Z0-9_-]+$',
+                        'regex': '^[a-zA-Z0-9_-]+$',
                     }
                 },
                 'restart_policy': {

--- a/test/unit/model/v2/test_platforms_section.py
+++ b/test/unit/model/v2/test_platforms_section.py
@@ -81,6 +81,7 @@ def _model_platforms_docker_section_data():
             ],
             'env': {
                 'FOO': 'bar',
+                'foo': 'bar',
             },
             'restart_policy':
             'on-failure',


### PR DESCRIPTION
Fixes #1476 

Adapts the schema to allow lowercase environment variables, added test with lowercase variables.