### PR TITLE
better handling for quoted or escaped values in vagrant.yml

### DIFF
--- a/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
+++ b/molecule/provisioner/ansible/plugins/libraries/molecule_vagrant.py
@@ -155,7 +155,7 @@ Vagrant.configure('2') do |config|
   c['options'].delete('synced_folder')
 
   c['options'].each { |key, value|
-    eval("config.#{key} = #{value}")
+    value.is_a?(String) ? eval("config.#{key} = \"#{value}\"") : eval("config.#{key} = #{value}")
   }
 
   ##


### PR DESCRIPTION
While testing molecule I ran into a problem where if I needed to do this in molecule.yml
```
platforms:
  - name: instance
    box: SierraX/openbsd-6.2
    config_options:
      ssh.sudo_command: "doas env %c"
```
The **%c** would generate an error in the Vagrantfile

So checking if it's a String and escaping properly seemed like a good option.