### PR TITLE
refactoring: driver.base.Base -> api.Driver

### DIFF
--- a/molecule/api.py
+++ b/molecule/api.py
@@ -2,6 +2,7 @@ import pluggy
 from importlib import import_module
 from molecule import logger
 from molecule.util import lru_cache
+from molecule.driver.base import Driver  # noqa
 import traceback
 
 LOG = logger.get_logger(__name__)

--- a/molecule/driver/base.py
+++ b/molecule/driver/base.py
@@ -26,7 +26,7 @@ from molecule import status
 Status = status.get_status()
 
 
-class Base(object):
+class Driver(object):
     __metaclass__ = abc.ABCMeta
 
     def __init__(self, config):

--- a/molecule/driver/delegated.py
+++ b/molecule/driver/delegated.py
@@ -20,12 +20,12 @@
 
 from molecule import logger
 from molecule import util
-from molecule.driver import base
+from molecule.api import Driver
 
 LOG = logger.get_logger(__name__)
 
 
-class Delegated(base.Base):
+class Delegated(Driver):
     """
     The class responsible for managing delegated instances.  Delegated is `not`
     the default driver used in Molecule.

--- a/molecule/driver/digitalocean.py
+++ b/molecule/driver/digitalocean.py
@@ -19,14 +19,13 @@
 #  DEALINGS IN THE SOFTWARE.
 
 from molecule import logger
-from molecule.driver import base
-
+from molecule.api import Driver
 from molecule import util
 
 log = logger.get_logger(__name__)
 
 
-class DigitalOcean(base.Base):
+class DigitalOcean(Driver):
     """
     This class is responsible for managing `DigitalOcean`_ instances.
     `DigitalOcean`_ is **not** the default driver used in Molecule.

--- a/molecule/driver/docker.py
+++ b/molecule/driver/docker.py
@@ -23,14 +23,14 @@ from __future__ import absolute_import
 import os
 
 from molecule import logger
-from molecule.driver import base
+from molecule.api import Driver
 from molecule.util import lru_cache
 from molecule.util import sysexit_with_message
 
 log = logger.get_logger(__name__)
 
 
-class Docker(base.Base):
+class Docker(Driver):
     """
     The class responsible for managing `Docker`_ containers.  `Docker`_ is
     the default driver used in Molecule.

--- a/molecule/driver/ec2.py
+++ b/molecule/driver/ec2.py
@@ -38,14 +38,14 @@ except ImportError:
     HAS_BOTO3 = False
 
 from molecule import logger
-from molecule.driver import base
+from molecule.api import Driver
 
 from molecule import util
 
 LOG = logger.get_logger(__name__)
 
 
-class EC2(base.Base):
+class EC2(Driver):
     """
     The class responsible for managing `EC2`_ instances.  `EC2`_
     is ``not`` the default driver used in Molecule.

--- a/molecule/driver/gce.py
+++ b/molecule/driver/gce.py
@@ -19,14 +19,14 @@
 #  DEALINGS IN THE SOFTWARE.
 
 from molecule import logger
-from molecule.driver import base
+from molecule.api import Driver
 
 from molecule import util
 
 LOG = logger.get_logger(__name__)
 
 
-class GCE(base.Base):
+class GCE(Driver):
     """
     The class responsible for managing `GCE`_ instances.  `GCE`_
     is `not` the default driver used in Molecule.

--- a/molecule/driver/hetznercloud.py
+++ b/molecule/driver/hetznercloud.py
@@ -21,14 +21,14 @@
 import os
 
 from molecule import logger, util
-from molecule.driver import base
+from molecule.api import Driver
 from molecule.util import lru_cache
 from molecule.util import sysexit_with_message
 
 log = logger.get_logger(__name__)
 
 
-class HetznerCloud(base.Base):
+class HetznerCloud(Driver):
     """
     The class responsible for managing `Hetzner Cloud`_ instances.
     `Hetzner Cloud`_ is **not** the default driver used in Molecule.

--- a/molecule/driver/linode.py
+++ b/molecule/driver/linode.py
@@ -18,12 +18,12 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 
-from molecule.driver import base
+from molecule.api import Driver
 
 from molecule import util
 
 
-class Linode(base.Base):
+class Linode(Driver):
     """
     The class responsible for managing `Linode`_ instances.  `Linode`_
     is `not` the default driver used in Molecule.

--- a/molecule/driver/lxc.py
+++ b/molecule/driver/lxc.py
@@ -19,12 +19,12 @@
 #  DEALINGS IN THE SOFTWARE.
 
 from molecule import logger
-from molecule.driver import base
+from molecule.api import Driver
 
 LOG = logger.get_logger(__name__)
 
 
-class LXC(base.Base):
+class LXC(Driver):
     """
     The class responsible for managing `LXC`_ containers.  `LXC`_ is `not` the
     default driver used in Molecule.

--- a/molecule/driver/lxd.py
+++ b/molecule/driver/lxd.py
@@ -19,12 +19,12 @@
 #  DEALINGS IN THE SOFTWARE.
 
 from molecule import logger
-from molecule.driver import base
+from molecule.api import Driver
 
 LOG = logger.get_logger(__name__)
 
 
-class LXD(base.Base):
+class LXD(Driver):
     """
     The class responsible for managing `LXD`_ containers.  `LXD`_ is `not` the
     default driver used in Molecule.

--- a/molecule/driver/openstack.py
+++ b/molecule/driver/openstack.py
@@ -19,14 +19,14 @@
 #  DEALINGS IN THE SOFTWARE.
 
 from molecule import logger
-from molecule.driver import base
+from molecule.api import Driver
 
 from molecule import util
 
 LOG = logger.get_logger(__name__)
 
 
-class Openstack(base.Base):
+class Openstack(Driver):
     """
     The class responsible for managing `OpenStack`_ instances.  `OpenStack`_
     is `not` the default driver used in Molecule.

--- a/molecule/driver/podman.py
+++ b/molecule/driver/podman.py
@@ -23,13 +23,13 @@ from __future__ import absolute_import
 import os
 
 from molecule import logger
-from molecule.driver import base
+from molecule.api import Driver
 from molecule.util import lru_cache
 
 log = logger.get_logger(__name__)
 
 
-class Podman(base.Base):
+class Podman(Driver):
     """
     The class responsible for managing `Podman`_ containers.  `Podman`_ is
     not default driver used in Molecule.

--- a/molecule/driver/vagrant.py
+++ b/molecule/driver/vagrant.py
@@ -22,12 +22,13 @@ import os
 
 from molecule import logger
 from molecule import util
-from molecule.driver import base
+from molecule.api import Driver
+
 
 LOG = logger.get_logger(__name__)
 
 
-class Vagrant(base.Base):
+class Vagrant(Driver):
     """
     The class responsible for managing `Vagrant`_ instances.  `Vagrant`_ is
     `not` the default driver used in Molecule.

--- a/molecule/test/unit/test_api.py
+++ b/molecule/test/unit/test_api.py
@@ -19,7 +19,7 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 
-from molecule.driver.base import Base
+from molecule.api import Driver
 from molecule.api import molecule_drivers
 
 
@@ -45,4 +45,4 @@ def test_api_molecule_drivers_as_dict():
     assert 'delegated' in results
 
     for driver in results.values():
-        assert isinstance(driver, Base)
+        assert isinstance(driver, Driver)


### PR DESCRIPTION
As part of #2278 we are now exposing the driver class in a stable
and less confusing name so external plugins can make use of it:
```
from molecule.api import Driver
```