### PR TITLE
add missing "test --destroy=never" to documentation

### DIFF
--- a/src/molecule/command/test.py
+++ b/src/molecule/command/test.py
@@ -68,6 +68,10 @@ class Test(base.Base):
 
         Always destroy instances at the conclusion of a Molecule run.
 
+    .. option:: molecule test --destroy=never
+
+        Never destroy instances at the conclusion of a Molecule run.
+
     .. program:: molecule --debug test
 
     .. option:: molecule --debug test


### PR DESCRIPTION
Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>

This PR:
- Adds missing `test --destroy=never` option to the documentation
- Closes #3009 

#### PR Type

- Docs Pull Request

