### PR TITLE
Disable some pre-commit checks when running in pre-commit CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,9 @@
 ---
+ci:
+  skip:
+  # https://github.com/pre-commit-ci/issues/issues/55
+  - pip-compile
+  - pip-compile-upgrade
 exclude: |
     (?x)(
         ^docs/conf.py$


### PR DESCRIPTION
Pre-commit CI does not allow access to the network when running, which causes checks that need data from external services to fail.

This commit disables those checks when running in pre-commit CI.

#### PR Type

- Bugfix Pull Request
