### PR TITLE
Avoid including check-jsonschema in test dependencies

### DIFF
--- a/.config/constraints.txt
+++ b/.config/constraints.txt
@@ -18,8 +18,7 @@ cffi==1.17.1              # via cairocffi, cryptography
 cfgv==3.4.0               # via pre-commit
 chardet==5.2.0            # via tox
 charset-normalizer==3.4.1  # via requests
-check-jsonschema==0.30.0  # via molecule (pyproject.toml)
-click==8.1.8              # via black, check-jsonschema, click-help-colors, mkdocs, mkdocstrings, pip-tools, pydoclint, molecule (pyproject.toml)
+click==8.1.8              # via black, click-help-colors, mkdocs, mkdocstrings, pip-tools, pydoclint, molecule (pyproject.toml)
 click-help-colors==0.9.4  # via molecule (pyproject.toml)
 colorama==0.4.6           # via griffe, mkdocs-material, tox
 coverage==7.6.10          # via molecule (pyproject.toml)
@@ -47,7 +46,7 @@ iniconfig==2.0.0          # via pytest
 isort==5.13.2             # via pylint
 jinja2==3.1.5             # via ansible-core, mkdocs, mkdocs-macros-plugin, mkdocs-material, mkdocstrings, molecule (pyproject.toml)
 jsmin==3.0.1              # via mkdocs-minify-plugin
-jsonschema==4.23.0        # via ansible-compat, ansible-lint, check-jsonschema, molecule (pyproject.toml)
+jsonschema==4.23.0        # via ansible-compat, ansible-lint, molecule (pyproject.toml)
 jsonschema-specifications==2024.10.1  # via jsonschema
 linkchecker==10.5.0       # via mkdocs-ansible, molecule (pyproject.toml)
 markdown==3.7             # via markdown-include, mkdocs, mkdocs-autorefs, mkdocs-htmlproofer-plugin, mkdocs-material, mkdocstrings, pymdown-extensions
@@ -104,11 +103,10 @@ pyyaml==6.0.2             # via ansible-compat, ansible-core, ansible-lint, mkdo
 pyyaml-env-tag==0.1       # via mkdocs
 referencing==0.36.1       # via jsonschema, jsonschema-specifications, types-jsonschema
 regex==2024.11.6          # via mkdocs-material
-regress==2024.11.1        # via check-jsonschema
-requests==2.32.3          # via check-jsonschema, docker, linkchecker, mkdocs-htmlproofer-plugin, mkdocs-material, molecule (pyproject.toml)
+requests==2.32.3          # via docker, linkchecker, mkdocs-htmlproofer-plugin, mkdocs-material, molecule (pyproject.toml)
 rich==13.9.4              # via enrich, molecule (pyproject.toml)
 rpds-py==0.22.3           # via jsonschema, referencing
-ruamel-yaml==0.18.6       # via ansible-lint, check-jsonschema
+ruamel-yaml==0.18.6       # via ansible-lint
 ruamel-yaml-clib==0.2.12  # via ruamel-yaml
 ruff==0.9.2               # via molecule (pyproject.toml)
 setuptools==75.8.0        # via pip-tools
@@ -120,7 +118,7 @@ termcolor==2.5.0          # via mkdocs-macros-plugin
 text-unidecode==1.3       # via python-slugify
 tinycss2==1.4.0           # via cairosvg, cssselect2
 toml-sort==0.24.2         # via molecule (pyproject.toml)
-tomli==2.2.1              # via black, build, check-jsonschema, coverage, mypy, pip-tools, pydoclint, pylint, pyproject-api, pytest, tox
+tomli==2.2.1              # via black, build, coverage, mypy, pip-tools, pydoclint, pylint, pyproject-api, pytest, tox
 tomlkit==0.13.2           # via pylint, toml-sort
 tox==4.23.2               # via molecule (pyproject.toml)
 types-jsonschema==4.23.0.20241208  # via molecule (pyproject.toml)

--- a/.config/requirements-test.txt
+++ b/.config/requirements-test.txt
@@ -1,7 +1,6 @@
 ansi2html >= 1.8.0
 ansible-lint >= 6.12.1
 black
-check-jsonschema
 coverage[toml]
 docker >= 7.1.0 # testing
 filelock >= 3.9.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,14 +62,14 @@ repos:
       - id: tox-ini-fmt
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.1
+    rev: v0.9.2
     hooks:
       - id: ruff
         args:
           - --exit-non-zero-on-fix
 
   - repo: https://github.com/streetsidesoftware/cspell-cli
-    rev: v8.17.0
+    rev: v8.17.1
     hooks:
       - id: cspell
         name: Spell check with cspell
@@ -134,17 +134,18 @@ repos:
         stages:
           - manual
         additional_dependencies:
-          - uv>=0.4.3
+          - uv>=0.5.21
       - id: pip-compile
         name: Check constraints files and requirements
-        files: ^(pyproject\.toml|requirements\.txt)$
+        always_run: true
+        files: ^(pyproject\.toml|\.config/.*)$
         language: python
-        entry: python3 -m uv pip compile -q --all-extras --output-file=.config/constraints.txt pyproject.toml
+        entry: python3 -m uv pip compile --refresh --all-extras --output-file=.config/constraints.txt pyproject.toml
         pass_filenames: false
         additional_dependencies:
-          - uv>=0.4.3
+          - uv>=0.5.21
   - repo: https://github.com/ansible/ansible-lint
-    rev: v24.12.2
+    rev: v25.1.0
     hooks:
       - id: ansible-lint
         stages: [manual]

--- a/tests/unit/model/v2/test_schema.py
+++ b/tests/unit/model/v2/test_schema.py
@@ -37,6 +37,9 @@ def test_molecule_schema(resources_folder_path: Path) -> None:
     """
     app = get_app(Path())
     cmd = [
+        "uv",
+        "tool",
+        "run",
         "check-jsonschema",
         "-v",
         "--schemafile",
@@ -46,6 +49,9 @@ def test_molecule_schema(resources_folder_path: Path) -> None:
     assert app.run_command(cmd).returncode == 0
 
     cmd = [
+        "uv",
+        "tool",
+        "run",
         "check-jsonschema",
         "-v",
         "--schemafile",


### PR DESCRIPTION
Run check-jsonschema using uv tool in order to decouple it from our own test environment.

See: https://github.com/python-jsonschema/check-jsonschema/issues/259
Fixes: #4368