### PR TITLE
Share state between molecule scenarios

### DIFF
--- a/src/molecule/config.py
+++ b/src/molecule/config.py
@@ -408,13 +408,14 @@ class Config:
         Returns:
             A molecule State instance.
         """
-        myState = state.State(self)  # noqa: N806
+        my_state = state.State(self)
+
         # look at state file for molecule.yml date modified and warn if they do not match
         if self.molecule_file and os.path.isfile(self.molecule_file):  # noqa: PTH113
             modTime = os.path.getmtime(self.molecule_file)  # noqa: PTH204, N806
-            if myState.molecule_yml_date_modified is None:
-                myState.change_state("molecule_yml_date_modified", modTime)
-            elif myState.molecule_yml_date_modified != modTime:
+            if my_state.molecule_yml_date_modified is None:
+                my_state.change_state("molecule_yml_date_modified", modTime)
+            elif my_state.molecule_yml_date_modified != modTime:
                 LOG.warning(
                     "The scenario config file ('%s') has been modified since the scenario was created. "
                     "If recent changes are important, reset the scenario with 'molecule destroy' to clean up created items or "
@@ -422,7 +423,7 @@ class Config:
                     self.molecule_file,
                 )
 
-        return state.State(self)
+        return state.SharedState(self) if self.shared_data else state.State(self)
 
     @cached_property
     def verifier(self) -> Verifier:

--- a/src/molecule/state.py
+++ b/src/molecule/state.py
@@ -237,3 +237,14 @@ class State:
 
     def _get_state_file(self) -> Path:
         return Path(self._config.scenario.ephemeral_directory) / "state.yml"
+
+
+class SharedState(State):
+    """A class which manages the state file.
+
+    This is exactly like the normal State object but it's backed by the shared ephemeral directory,
+    so state is maintained between scenarios.
+    """
+
+    def _get_state_file(self) -> Path:
+        return Path(self._config.scenario.shared_ephemeral_directory) / "state.yml"


### PR DESCRIPTION
Closes #4001
AAP https://issues.redhat.com/browse/AAP-48519

This creates a SharedState object which works exactly like a State object, but uses the shared ephemeral directory. It will be used when the `--shared-state` parameter is used.