### PR TITLE
Fix KeyError command_borders in login and reset commands

### DIFF
--- a/src/molecule/command/login.py
+++ b/src/molecule/command/login.py
@@ -127,7 +127,6 @@ def login(ctx: click.Context) -> None:  # pragma: no cover
     args = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {
-        "command_borders": ctx.params["command_borders"],
         "host": ctx.params["host"],
         "subcommand": subcommand,
     }

--- a/src/molecule/command/reset.py
+++ b/src/molecule/command/reset.py
@@ -57,6 +57,7 @@ def reset(ctx: click.Context) -> None:  # pragma: no cover
     args = ctx.obj.get("args")
     subcommand = base._get_subcommand(__name__)  # noqa: SLF001
     command_args: CommandArgs = {
+        "command_borders": ctx.params["command_borders"],
         "subcommand": subcommand,
     }
 


### PR DESCRIPTION
This PR fixes the KeyError: 'command_borders' issue reported in #4513.

**Changes:**
- Remove command_borders reference from login.py since the login command does not have this CLI parameter available through its @options decorator
- Add missing command_borders reference to reset.py command_args since it has the CLI parameter but wasn't using it consistently

**Problem:**
The login command was trying to access ctx.params['command_borders'] but this parameter is not available because login uses @options(['host', 'scenario_name_single_with_default']) instead of @common_options() which includes command_borders.

**Solution:**
Align command_args dictionaries with their actual available CLI parameters:
- Commands using @options without command_borders should not reference it
- Commands using @options with command_borders or @common_options should reference it

Fixes #4513