### PR TITLE
Add shared_state configuration documentation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,6 +62,7 @@ shared_state: true
 **Configuration locations:**
 
 You can add this setting to:
+
 - `.config/molecule/config.yml` file in your `$HOME` directory (global default)
 - Base `config.yml` file at the project root (project default)
 - Collection molecule directory `extensions/molecule/config.yml`


### PR DESCRIPTION
Add documentation for the shared_state configuration option that enables scenarios to share ephemeral state and resources.

- Documents how shared_state works and its effects  
- Shows configuration file syntax and locations
- Explains benefits over command-line flags
- Follows existing documentation patterns