### PR TITLE
Debug missing galaxy.yml file not warning

### DIFF
--- a/src/molecule/util.py
+++ b/src/molecule/util.py
@@ -611,7 +611,7 @@ def get_collection_metadata() -> tuple[Path, CollectionData] | tuple[None, None]
             )
             return None, None
     except FileNotFoundError:
-        LOG.warning("No galaxy.yml found at %s", galaxy_file)
+        LOG.debug("No galaxy.yml found at %s", galaxy_file)
         return None, None
     except (OSError, yaml.YAMLError, MoleculeError) as exc:
         LOG.warning("Failed to load galaxy.yml at %s: %s", galaxy_file, exc)


### PR DESCRIPTION
This was shown for every non-collection use of molecule, just debug it instead.