### PR TITLE
Add finalize workflow for secure sonarcloud checks

### DIFF
--- a/.github/workflows/finalize.yml
+++ b/.github/workflows/finalize.yml
@@ -1,0 +1,25 @@
+---
+name: finalize
+on:
+  workflow_run:
+    workflows:
+      - tox
+    types:
+      - completed
+
+permissions: read-all
+
+jobs:
+  finalize:
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      (github.event.workflow_run.event == 'pull_request' ||
+       (github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main'))
+    uses: ansible/team-devtools/.github/workflows/finalize.yml@main
+    with:
+      run-id: ${{ github.event.workflow_run.id }}
+      workflow-event: ${{ github.event.workflow_run.event }}
+      head-sha: ${{ github.event.workflow_run.head_sha }}
+      head-branch: ${{ github.event.workflow_run.head_branch }}
+      head-repository: ${{ github.event.workflow_run.head_repository.full_name }}
+    secrets: inherit


### PR DESCRIPTION
Related: [AAP-52660](https://issues.redhat.com/browse/AAP-52660)

Adds the finalize workflow for sonarcloud checks. Runs only after tox checks pass.

This creates support for sonarcloud scanning on PRs from forks.

Workflow will not run until merged.