### PR TITLE
fix: remove use of click-help-colors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
   "ansible-compat>=25.1.4",
   "ansible-core>=2.15.0",
   "click>=8.0,<9",
-  "click-help-colors>=0.9.4",
   "enrich>=1.2.7",
   "jinja2>=2.11.3",
   "jsonschema>=4.9.1",
@@ -142,7 +141,6 @@ strict = true
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
 module = [
-  "click_help_colors",  # https://github.com/click-contrib/click-help-colors/issues/20
   "testinfra.*",  # https://github.com/pytest-dev/pytest-testinfra/issues/619
 ]
 

--- a/src/molecule/click_cfg.py
+++ b/src/molecule/click_cfg.py
@@ -15,8 +15,6 @@ from typing import TYPE_CHECKING, Any
 
 import click
 
-from click_help_colors import HelpColorsCommand, HelpColorsGroup
-
 from molecule import util
 from molecule.ansi_output import should_do_markup
 from molecule.api import drivers
@@ -524,14 +522,6 @@ class FirstLineHelpMixin:
             self.help = first_line
 
 
-class FirstLineHelpCommand(FirstLineHelpMixin, HelpColorsCommand):
-    """Override the default help generation to remove the args section."""
-
-
-class FirstLineHelpGroup(FirstLineHelpMixin, HelpColorsGroup):
-    """Override the default help generation to remove the args section."""
-
-
 def click_group_ex() -> ClickGroup:
     """Return extended version of click.group().
 
@@ -544,24 +534,12 @@ def click_group_ex() -> ClickGroup:
     # blue : molecule own command, not dependent on scenario
     # yellow : special commands, like full test sequence, or login
     return click.group(
-        cls=FirstLineHelpGroup,
         # Workaround to disable click help line truncation to ~80 chars
         # https://github.com/pallets/click/issues/486
         context_settings={
             "max_content_width": 9999,
             "color": should_do_markup(),
             "help_option_names": ["-h", "--help"],
-        },
-        help_headers_color="yellow",
-        help_options_color="green",
-        help_options_custom_colors={
-            "drivers": "blue",
-            "init": "blue",
-            "list": "blue",
-            "matrix": "blue",
-            "login": "bright_yellow",
-            "reset": "blue",
-            "test": "bright_yellow",
         },
     )
 
@@ -605,10 +583,7 @@ def click_command_ex(name: str | None = None) -> Callable[[Callable[..., Any]], 
 
         # Apply the click.command decorator to the wrapper
         return click.command(
-            cls=FirstLineHelpCommand,
             name=name,
-            help_headers_color="yellow",
-            help_options_color="green",
         )(wrapper)
 
     return decorator

--- a/uv.lock
+++ b/uv.lock
@@ -598,18 +598,6 @@ wheels = [
 ]
 
 [[package]]
-name = "click-help-colors"
-version = "0.9.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/50/76f51d9c7fcd72a12da466801f7c1fa3884424c947787333c74327b4fcf3/click-help-colors-0.9.4.tar.gz", hash = "sha256:f4cabe52cf550299b8888f4f2ee4c5f359ac27e33bcfe4d61db47785a5cc936c", size = 8048, upload-time = "2023-11-18T11:55:15.554Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/f8/8768f803151714640cb6f06fd9de490ce7db632d351da05f42f77330d2fd/click_help_colors-0.9.4-py3-none-any.whl", hash = "sha256:b33c5803eeaeb084393b1ab5899dc5476c7196b87a18713045afe76f840b42db", size = 6437, upload-time = "2023-11-18T11:55:09.775Z" },
-]
-
-[[package]]
 name = "codespell"
 version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1699,7 +1687,6 @@ dependencies = [
     { name = "ansible-core", version = "2.19.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "ansible-core", version = "2.20.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "click" },
-    { name = "click-help-colors" },
     { name = "enrich" },
     { name = "jinja2" },
     { name = "jsonschema" },
@@ -1768,7 +1755,6 @@ requires-dist = [
     { name = "ansible-compat", specifier = ">=25.1.4" },
     { name = "ansible-core", specifier = ">=2.15.0" },
     { name = "click", specifier = ">=8.0,<9" },
-    { name = "click-help-colors", specifier = ">=0.9.4" },
     { name = "enrich", specifier = ">=1.2.7" },
     { name = "jinja2", specifier = ">=2.11.3" },
     { name = "jsonschema", specifier = ">=4.9.1" },


### PR DESCRIPTION
Removes dependency on click-help-colors which is not maintained and causes some warnings with py314.

Partial: #4568
Related: https://github.com/click-contrib/click-help-colors/issues/29