### PR TITLE
Fix `molecule list` with ansible-native configs.

### DIFF
--- a/src/molecule/driver/base.py
+++ b/src/molecule/driver/base.py
@@ -235,7 +235,7 @@ class Driver(ABC):
 
         if not instances:
             # an ansible-native scenario
-            instances.append({"name": None})
+            instances.append({"name": ""})
 
         for platform in instances:
             instance_name = platform["name"]

--- a/tests/unit/command/conftest.py
+++ b/tests/unit/command/conftest.py
@@ -19,7 +19,13 @@
 #  DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
+
+
+if TYPE_CHECKING:
+    from molecule.types import ConfigData
 
 
 @pytest.fixture
@@ -45,3 +51,20 @@ def command_driver_delegated_section_data():  # type: ignore[no-untyped-def]  # 
 @pytest.fixture
 def command_driver_delegated_managed_section_data():  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
     return {"driver": {"name": "default", "managed": True}}
+
+
+@pytest.fixture
+def _molecule_data_native() -> ConfigData:
+    """Provide a default molecule data dictionary.
+
+    This version removes options unused in ansible-native configs.
+
+    Returns:
+      A molecule config dictionary.
+    """
+    return {
+        "ansible": {"executor": {"backend": "ansible-playbook"}},
+        "driver": {},
+        "platforms": [],
+        "provisioner": {},
+    }

--- a/tests/unit/command/test_list.py
+++ b/tests/unit/command/test_list.py
@@ -28,23 +28,7 @@ from molecule.status import Status
 
 
 if TYPE_CHECKING:
-    from typing import Any
-
     from molecule import config
-
-
-@pytest.fixture
-def _molecule_data_native() -> dict[str, Any]:
-    """Provide a default molecule data dictionary.
-
-    This version removes options unused in ansible-native configs.
-    """
-    return {
-        "ansible": {"executor": {"backend": "ansible-playbook"}},
-        "driver": {},
-        "platforms": [],
-        "provisioner": {},
-    }
 
 
 def test_list_execute(  # noqa: D103
@@ -86,7 +70,7 @@ def test_list_execute_native(  # noqa: D103
     l = list.List(config_instance)  # noqa: E741
     x = [
         Status(
-            instance_name=None,
+            instance_name="",
             driver_name="default",
             provisioner_name="ansible",
             scenario_name="default",


### PR DESCRIPTION
Fixes #4562

This config should be generalized to more tests, but the work is sufficiently complex that this band-aid is sufficient for now.