### PR TITLE
docs: migrate RTD URLs to docs.ansible.com

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
 # Community Code of Conduct
 
 Please see the official
-[Ansible Community Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html).
+[Ansible Community Code of Conduct](https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html).

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -15,7 +15,7 @@ body:
     attributes:
       label: Prerequisites
       description: >
-        Create new issues only if all checks were made and you checked [FAQ](https://ansible.readthedocs.io/projects/molecule/faq/) and the
+        Create new issues only if all checks were made and you checked [FAQ](https://docs.ansible.com/projects/molecule/faq/) and the
         [discussions forum](https://github.com/ansible/molecule/discussions).
       options:
         - label: This was not already reported in the past (duplicate check)
@@ -36,7 +36,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Also check [FAQ](https://ansible.readthedocs.io/projects/molecule/faq/) and the
+        Also check [FAQ](https://docs.ansible.com/projects/molecule/faq/) and the
         [discussions forum](https://github.com/ansible/molecule/discussions) before creating a new issue.
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/security_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/security_bug_report.md
@@ -5,4 +5,4 @@ about: How to report security vulnerabilities
 
 For all security related bugs, email security@ansible.com instead of using this issue tracker and you will receive a prompt response.
 
-For more information, see https://docs.ansible.com/ansible/latest/community/reporting_bugs_and_features.html
+For more information, see https://docs.ansible.com/projects/ansible/latest/community/reporting_bugs_and_features.html

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # About Ansible Molecule
 
 [![PyPI Package](https://img.shields.io/pypi/v/molecule)](https://pypi.org/project/molecule/)
-[![Documentation Status](https://readthedocs.org/projects/molecule/badge/?version=latest)](https://ansible.readthedocs.io/projects/molecule)
+[![Documentation Status](https://readthedocs.org/projects/molecule/badge/?version=latest)](https://docs.ansible.com/projects/molecule/)
 [![image](https://github.com/ansible-community/molecule/workflows/tox/badge.svg)](https://github.com/ansible-community/molecule/actions)
 [![Python Black Code Style](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
-[![Ansible Code of Conduct](https://img.shields.io/badge/Code%20of%20Conduct-silver.svg)](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html)
+[![Ansible Code of Conduct](https://img.shields.io/badge/Code%20of%20Conduct-silver.svg)](https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html)
 [![Discussions](https://img.shields.io/badge/Discussions-silver.svg)](https://forum.ansible.com/tag/molecule)
 [![Repository License](https://img.shields.io/badge/license-MIT-brightgreen.svg)](LICENSE)
 
@@ -33,14 +33,14 @@ python3 -m molecule ...  # python module calling method
 
 # Documentation
 
-Read the documentation and more at <https://ansible.readthedocs.io/projects/molecule/>.
+Read the documentation and more at <https://docs.ansible.com/projects/molecule//>.
 
 # Get Involved
 
-See the [Talk to us](https://ansible.readthedocs.io/projects/molecule/contributing/#talk-to-us) section of the documentation to ask questions, find help, and join the conversation.
+See the [Talk to us](https://docs.ansible.com/projects/molecule//contributing/#talk-to-us) section of the documentation to ask questions, find help, and join the conversation.
 
 For complete details, see the
-[Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html).
+[Ansible communication guide](https://docs.ansible.com/projects/ansible/devel/community/communication.html).
 
 If you want to get moving fast and make a quick patch:
 

--- a/community.molecule/README.md
+++ b/community.molecule/README.md
@@ -26,9 +26,9 @@ See the [changelog](https://github.com/ansible/molecule/tree/main/community.mole
 
 - [Ansible Developers](https://docs.ansible.com/developers.html)
 - [Ansible User guide](https://docs.ansible.com/users.html)
-- [Ansible Developer guide](https://docs.ansible.com/ansible/latest/dev_guide/index.html)
-- [Ansible Collections Checklist](https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_requirements.html)
-- [Ansible Community code of conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html)
+- [Ansible Developer guide](https://docs.ansible.com/projects/ansible/latest/dev_guide/index.html)
+- [Ansible Collections Checklist](https://docs.ansible.com/projects/ansible/devel/community/collection_contributors/collection_requirements.html)
+- [Ansible Community code of conduct](https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html)
 - [The Bullhorn (the Ansible Contributor newsletter)](https://forum.ansible.com/c/news/bullhorn/17)
 
 ## Licensing

--- a/community.molecule/galaxy.yml
+++ b/community.molecule/galaxy.yml
@@ -1,4 +1,4 @@
-# See https://docs.ansible.com/ansible/latest/dev_guide/collections_galaxy_meta.html
+# See https://docs.ansible.com/projects/ansible/latest/dev_guide/collections_galaxy_meta.html
 # cspell: ignore Sorin Sbarnea
 namespace: community
 name: molecule

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -292,7 +292,7 @@ pipeline {
 }
 ```
 
-The following Jenkinsfile uses the [Ansible Dev Tools](https://ansible.readthedocs.io/projects/dev-tools/container/) image.
+The following Jenkinsfile uses the [Ansible Dev Tools](https://docs.ansible.com/projects/dev-tools/container/) image.
 
 ```groovy
 pipeline {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,9 +30,9 @@ If the computed fully qualified role name does not follow current galaxy
 requirements, you can ignore it by adding `role_name_check:1` inside the configuration file.
 
 It is strongly recommended to follow the name standard of
-[namespace](https://docs.ansible.com/ansible/latest/dev_guide/collections_galaxy_meta.html#structure)
+[namespace](https://docs.ansible.com/projects/ansible/latest/dev_guide/collections_galaxy_meta.html#structure)
 and
-[role](https://ansible.readthedocs.io/projects/lint/rules/role-name/#role-name).
+[role](https://docs.ansible.com/projects/lint/rules/role-name/#role-name).
 A `computed fully qualified role name` may further contain the dot character.
 
 ## Shared State
@@ -201,8 +201,8 @@ managers.
 
 ### Ansible Galaxy
 
-[DEFAULT_ROLES_PATH]: https://docs.ansible.com/ansible/latest/cli/ansible-galaxy.html#cmdoption-ansible-galaxy-role-remove-p
-[ANSIBLE_HOME]: https://docs.ansible.com/ansible/latest/reference_appendices/config.html#ansible-home
+[DEFAULT_ROLES_PATH]: https://docs.ansible.com/projects/ansible/latest/cli/ansible-galaxy.html#cmdoption-ansible-galaxy-role-remove-p
+[ANSIBLE_HOME]: https://docs.ansible.com/projects/ansible/latest/reference_appendices/config.html#ansible-home
 
 Galaxy is the default dependency manager.
 
@@ -506,7 +506,7 @@ data, and the developer's destroy playbook must reset the instance-config.
 ```
 
 This article covers how to configure and use WinRM with Ansible:
-https://docs.ansible.com/ansible/latest/user_guide/windows_winrm.html
+https://docs.ansible.com/projects/ansible/latest/user_guide/windows_winrm.html
 
 Molecule can also skip the provisioning/deprovisioning steps. It is the
 developers responsibility to manage the instances, and properly configure
@@ -975,7 +975,7 @@ Don't forget to add a tag `always` in `converge.yml` as below.
             - always
 ```
 
-.. \_`variables defined in a playbook`: https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#defining-variables-in-a-playbook
+.. \_`variables defined in a playbook`: https://docs.ansible.com/projects/ansible/latest/user_guide/playbooks_variables.html#defining-variables-in-a-playbook
 
 Add arguments to ansible-playbook when running converge:
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -37,10 +37,10 @@ community.
   announcements including social events.
 
 To get release announcements and important changes from the community, see the
-[Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn).
+[Bullhorn newsletter](https://docs.ansible.com/projects/ansible/devel/community/communication.html#the-bullhorn).
 
 You can find more information in the
-[Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html).
+[Ansible communication guide](https://docs.ansible.com/projects/ansible/devel/community/communication.html).
 
 Possible security bugs should be reported via email to
 <mailto:security@ansible.com>.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -17,7 +17,7 @@ confirm that Ansible itself is reporting task idempotence (changed=0).
 ## Why does Molecule make so many shell calls?
 
 Ansible provides a Python API. However, it is not intended for [direct
-consumption](https://docs.ansible.com/ansible/latest/dev_guide/developing_api.html).
+consumption](https://docs.ansible.com/projects/ansible/latest/dev_guide/developing_api.html).
 We wanted to focus on making Molecule useful, so our efforts were spent
 consuming Ansible's CLI.
 
@@ -52,7 +52,7 @@ the scenario's molecule.yml.
 ## Are there similar tools to Molecule?
 
 - Ansible's own [Testing
-  Strategies](https://docs.ansible.com/ansible/latest/reference_appendices/test_strategies.html)
+  Strategies](https://docs.ansible.com/projects/ansible/latest/reference_appendices/test_strategies.html)
 - [RoleSpec](https://github.com/nickjj/rolespec)
 
 ## Can I run Molecule processes in parallel?
@@ -86,7 +86,7 @@ working order by running `molecule list`.
 
 ## Where can I configure my `roles-path` and `collections-paths`?
 
-As of molecule v6, users are expected to make use of [`ansible.cfg`](https://docs.ansible.com/ansible/latest/reference_appendices/config.html) file to
+As of molecule v6, users are expected to make use of [`ansible.cfg`](https://docs.ansible.com/projects/ansible/latest/reference_appendices/config.html) file to
 alter them when needed.
 
 ## Does Molecule support monorepos?

--- a/docs/getting-started-playbooks.md
+++ b/docs/getting-started-playbooks.md
@@ -6,9 +6,9 @@ This guide demonstrates testing Ansible playbooks using Molecule within an ansib
 
 Before starting, ensure you have the following installed:
 
-- [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html) (ansible-core)
-- [Molecule](https://molecule.readthedocs.io/en/latest/installation/)
-- [ansible-creator](https://ansible.readthedocs.io/projects/creator/) for scaffolding
+- [Ansible](https://docs.ansible.com/projects/ansible/latest/installation_guide/intro_installation.html) (ansible-core)
+- [Molecule](https://docs.ansible.com/projects/molecule/installation/)
+- [ansible-creator](https://docs.ansible.com/projects/creator/) for scaffolding
 - [Podman](https://podman.io/getting-started/installation) for container testing
 
 ```bash

--- a/docs/guides/inside-a-container.md
+++ b/docs/guides/inside-a-container.md
@@ -1,6 +1,6 @@
 ## Running inside a container
 
-Molecule is built into a Docker image by the [Ansible Dev Tools](https://ansible.readthedocs.io/projects/dev-tools/container/) project.
+Molecule is built into a Docker image by the [Ansible Dev Tools](https://docs.ansible.com/projects/dev-tools/container/) project.
 
 Any questions or bugs related to use of Molecule from within a container
 should be addressed by the Ansible Dev Tools

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -104,7 +104,7 @@ has some benefits:
 ## Container
 
 `Molecule` is built into a [container image for Ansible Development Tools
-(ADT)](https://ansible.readthedocs.io/projects/dev-tools/container/)
+(ADT)](https://docs.ansible.com/projects/dev-tools/container/)
 
 Any questions or bugs related to the use of Molecule from within a container
 should be addressed by the ADT project.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -64,9 +64,9 @@ are available.
 
 Options leveraging the resources defined in the ansible inventory include:
 
-- [ansible adhoc commands](https://docs.ansible.com/ansible/latest/command_guide/intro_adhoc.html)
+- [ansible adhoc commands](https://docs.ansible.com/projects/ansible/latest/command_guide/intro_adhoc.html)
 
-- [ansible-console](https://docs.ansible.com/ansible/latest/cli/ansible-console.html)
+- [ansible-console](https://docs.ansible.com/projects/ansible/latest/cli/ansible-console.html)
 
 Resource native connection options include:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 ---
 site_name: Ansible Molecule
-site_url: https://ansible.readthedocs.io/projects/molecule/
+site_url: https://docs.ansible.com/projects/molecule/
 repo_url: https://github.com/ansible/molecule
 edit_uri: blob/main/docs/
 copyright: Copyright © Red Hat, Inc.
@@ -108,7 +108,7 @@ plugins:
             merge_init_into_class: yes
             show_submodules: yes
           inventories:
-            - url: https://docs.ansible.com/ansible/latest/objects.inv
+            - url: https://docs.ansible.com/projects/ansible/latest/objects.inv
               domains: [py, std, "std:doc", "std:label"]
             - url: https://pip.pypa.io/en/latest/objects.inv
               domains: [py, std]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dynamic = ["version"]
 
 [project.urls]
 changelog = "https://github.com/ansible-community/molecule/releases"
-documentation = "https://molecule.readthedocs.io/"
+documentation = "https://docs.ansible.com/projects/molecule/"
 homepage = "https://github.com/ansible-community/molecule"
 repository = "https://github.com/ansible-community/molecule"
 

--- a/src/molecule/command/login.py
+++ b/src/molecule/command/login.py
@@ -83,7 +83,7 @@ class Login(base.Base):
         if len(match) == 0:
             msg = (
                 f"Unable to find host '{hostname}'.\n"
-                "For more information: https://ansible.readthedocs.io/projects/molecule/usage/#molecule-login"
+                "For more information: https://docs.ansible.com/projects/molecule/usage/#molecule-login"
             )
             sysexit_with_message(msg, code=1)
         if len(match) != 1:

--- a/src/molecule/data/molecule.json
+++ b/src/molecule/data/molecule.json
@@ -413,7 +413,7 @@
         },
         "interpreter_python": {
           "default": "auto_silent",
-          "description": "See https://docs.ansible.com/ansible/devel/reference_appendices/interpreter_discovery.html",
+          "description": "See https://docs.ansible.com/projects/ansible/devel/reference_appendices/interpreter_discovery.html",
           "title": "Interpreter Python",
           "type": "string"
         },

--- a/tests/fixtures/integration/test_command/scenarios/dependency/molecule/ansible-galaxy/requirements.yml
+++ b/tests/fixtures/integration/test_command/scenarios/dependency/molecule/ansible-galaxy/requirements.yml
@@ -1,4 +1,4 @@
-# See https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#installing-roles-and-collections-from-the-same-requirements-yml-file
+# See https://docs.ansible.com/projects/ansible/latest/galaxy/user_guide.html#installing-roles-and-collections-from-the-same-requirements-yml-file
 collections:
   - community.molecule
 roles:

--- a/tests/unit/provisioner/test_ansible.py
+++ b/tests/unit/provisioner/test_ansible.py
@@ -146,7 +146,7 @@ def test_default_config_options_property(instance):  # type: ignore[no-untyped-d
             "display_failed_stderr": True,
             "forks": 50,
             "host_key_checking": False,
-            # https://docs.ansible.com/ansible/devel/reference_appendices/interpreter_discovery.html
+            # https://docs.ansible.com/projects/ansible/devel/reference_appendices/interpreter_discovery.html
             "interpreter_python": "auto_silent",
             "nocows": 1,
             "retry_files_enabled": False,


### PR DESCRIPTION
## Summary

This PR updates `readthedocs.io` URLs to their `docs.ansible.com` equivalents with proper anchor preservation.

## Changes (55 URLs updated)

- https://ansible.readthedocs.io/projects/molecule → https://docs.ansible.com/projects/molecule/
- https://ansible.readthedocs.io/projects/molecule/ → https://docs.ansible.com/projects/molecule/
- https://ansible.readthedocs.io/projects/molecule/contributing/#talk-to-us → https://docs.ansible.com/projects/molecule/contributing/#talk-to-us
- https://ansible.readthedocs.io/projects/molecule/faq/ → https://docs.ansible.com/projects/molecule/faq/
- https://ansible.readthedocs.io/projects/molecule/ → https://docs.ansible.com/projects/molecule/
- https://ansible.readthedocs.io/projects/dev-tools/container/ → https://docs.ansible.com/projects/dev-tools/container/
- https://ansible.readthedocs.io/projects/dev-tools/container/ → https://docs.ansible.com/projects/dev-tools/container/
- https://ansible.readthedocs.io/projects/dev-tools/container/ → https://docs.ansible.com/projects/dev-tools/container/
- https://ansible.readthedocs.io/projects/lint/rules/role-name/#role-name → https://docs.ansible.com/projects/lint/rules/role-name/#role-name
- https://ansible.readthedocs.io/projects/creator/ → https://docs.ansible.com/projects/creator/
- https://ansible.readthedocs.io/projects/molecule/usage/#molecule-login → https://docs.ansible.com/projects/molecule/usage/#molecule-login
- https://molecule.readthedocs.io/ → https://docs.ansible.com/projects/molecule/
- https://molecule.readthedocs.io/en/latest/installation/ → https://docs.ansible.com/projects/molecule/installation/
- https://docs.ansible.com/ansible/latest/community/code_of_conduct.html → https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html
- https://docs.ansible.com/ansible/devel/community/communication.html → https://docs.ansible.com/projects/ansible/devel/community/communication.html
- https://docs.ansible.com/ansible/latest/objects.inv → https://docs.ansible.com/projects/ansible/latest/objects.inv
- https://docs.ansible.com/ansible/latest/community/code_of_conduct.html → https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html
- https://docs.ansible.com/ansible/latest/command_guide/intro_adhoc.html → https://docs.ansible.com/projects/ansible/latest/command_guide/intro_adhoc.html
- https://docs.ansible.com/ansible/latest/cli/ansible-console.html → https://docs.ansible.com/projects/ansible/latest/cli/ansible-console.html
- https://docs.ansible.com/ansible/latest/dev_guide/collections_galaxy_meta.html → https://docs.ansible.com/projects/ansible/latest/dev_guide/collections_galaxy_meta.html
- https://docs.ansible.com/ansible/latest/dev_guide/collections_galaxy_meta.html#structure → https://docs.ansible.com/projects/ansible/latest/dev_guide/collections_galaxy_meta.html#structure
- https://docs.ansible.com/ansible/latest/cli/ansible-galaxy.html#cmdoption-ansible-galaxy-role-remove-p → https://docs.ansible.com/projects/ansible/latest/cli/ansible-galaxy.html#cmdoption-ansible-galaxy-role-remove-p
- https://docs.ansible.com/ansible/latest/reference_appendices/config.html#ansible-home → https://docs.ansible.com/projects/ansible/latest/reference_appendices/config.html#ansible-home
- https://docs.ansible.com/ansible/latest/user_guide/windows_winrm.html → https://docs.ansible.com/projects/ansible/latest/user_guide/windows_winrm.html
- https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#defining-variables-in-a-playbook → https://docs.ansible.com/projects/ansible/latest/user_guide/playbooks_variables.html#defining-variables-in-a-playbook
- https://docs.ansible.com/ansible/latest/community/reporting_bugs_and_features.html → https://docs.ansible.com/projects/ansible/latest/community/reporting_bugs_and_features.html
- https://docs.ansible.com/ansible/latest/dev_guide/developing_api.html → https://docs.ansible.com/projects/ansible/latest/dev_guide/developing_api.html
- https://docs.ansible.com/ansible/latest/reference_appendices/test_strategies.html → https://docs.ansible.com/projects/ansible/latest/reference_appendices/test_strategies.html
- https://docs.ansible.com/ansible/latest/reference_appendices/config.html → https://docs.ansible.com/projects/ansible/latest/reference_appendices/config.html
- https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html → https://docs.ansible.com/projects/ansible/latest/installation_guide/intro_installation.html
- https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn → https://docs.ansible.com/projects/ansible/devel/community/communication.html#the-bullhorn
- https://docs.ansible.com/ansible/devel/community/communication.html → https://docs.ansible.com/projects/ansible/devel/community/communication.html
- https://docs.ansible.com/developers.html → https://docs.ansible.com/developers.html
- https://docs.ansible.com/users.html → https://docs.ansible.com/users.html
- https://docs.ansible.com/ansible/latest/dev_guide/index.html → https://docs.ansible.com/projects/ansible/latest/dev_guide/index.html
- https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_requirements.html → https://docs.ansible.com/projects/ansible/devel/community/collection_contributors/collection_requirements.html
- https://docs.ansible.com/ansible/latest/community/code_of_conduct.html → https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html
- https://docs.ansible.com/ansible/devel/reference_appendices/interpreter_discovery.html → https://docs.ansible.com/projects/ansible/devel/reference_appendices/interpreter_discovery.html
- https://docs.ansible.com/ansible/devel/reference_appendices/interpreter_discovery.html → https://docs.ansible.com/projects/ansible/devel/reference_appendices/interpreter_discovery.html
- https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#installing-roles-and-collections-from-the-same-requirements-yml-file → https://docs.ansible.com/projects/ansible/latest/galaxy/user_guide.html#installing-roles-and-collections-from-the-same-requirements-yml-file
- https://readthedocs.io/ → https://about.readthedocs.com/?ref=app.readthedocs.org
- https://readthedocs.io/projects/molecule/ → https://about.readthedocs.com/?ref=app.readthedocs.org
- https://readthedocs.io/projects/molecule/faq/ → https://about.readthedocs.com/?ref=app.readthedocs.org
- https://readthedocs.io/projects/molecule → https://about.readthedocs.com/?ref=app.readthedocs.org
- https://readthedocs.io/projects/molecule/ → https://about.readthedocs.com/?ref=app.readthedocs.org
- https://readthedocs.io/projects/molecule/contributing/#talk-to-us → https://about.readthedocs.com/?ref=app.readthedocs.org#talk-to-us
- https://readthedocs.io/projects/dev-tools/container/ → https://about.readthedocs.com/?ref=app.readthedocs.org
- https://readthedocs.io/en/latest → https://about.readthedocs.com/?ref=app.readthedocs.org
- https://readthedocs.io/projects/dev-tools/container/ → https://about.readthedocs.com/?ref=app.readthedocs.org
- https://readthedocs.io/en/latest/installation/ → https://about.readthedocs.com/?ref=app.readthedocs.org
- https://readthedocs.io/projects/creator/ → https://about.readthedocs.com/?ref=app.readthedocs.org
- https://readthedocs.io/projects/lint/rules/role-name/#role-name → https://about.readthedocs.com/?ref=app.readthedocs.org#role-name
- https://readthedocs.io → https://about.readthedocs.com/?ref=app.readthedocs.org
- https://readthedocs.io/projects/dev-tools/container/ → https://about.readthedocs.com/?ref=app.readthedocs.org
- https://readthedocs.io/projects/molecule/usage/#molecule-login → https://about.readthedocs.com/?ref=app.readthedocs.org#molecule-login

## Technical Details

- ✅ Anchor fragments preserved during URL transformations
- ✅ HTTP redirects followed to final destinations  
- ✅ URL validation completed before applying changes
- ✅ Configuration-driven URL mapping system

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>