### PR TITLE
chore: Temporarily ignore tombi schema strict checking in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+# cspell: ignore tombi
+#:tombi schema.strict = false
+
 [project]
 name = "molecule"
 description = "Molecule aids in the development and testing of Ansible roles"


### PR DESCRIPTION
Skips strict tombi-lint checking temporarily (https://github.com/SchemaStore/schemastore/issues/5145).
Intended to be reverted once the issue is resolved.