### PR TITLE
fix: handle missing molecule_yml_date_modified key in state

### DIFF
--- a/src/molecule/state.py
+++ b/src/molecule/state.py
@@ -184,7 +184,7 @@ class State:
         Returns:
             The timestamp of the last modification date of molecule.yml.
         """
-        return self._data["molecule_yml_date_modified"]
+        return self._data.get("molecule_yml_date_modified")
 
     @marshal
     def reset(self) -> None:


### PR DESCRIPTION
## Summary
fixes the keyerror when molecule_yml_date_modified key is missing from state file

changed state.py line 187 to use .get() instead of direct dict access. older state files or files loaded from disk might not have this key, which was causing crashes.

the property type hint says float | None so returning None is correct behavior when the key is missing.

## Test plan
- ran existing unit tests - all pass
- tested with state files that have and don't have the key
- verified None is returned when key is missing
- verified timestamp is returned when key exists

fixes #4597