### PR TITLE
fix: attribute idempotence failures to handlers correctly

### DIFF
--- a/src/molecule/command/idempotence.py
+++ b/src/molecule/command/idempotence.py
@@ -104,7 +104,7 @@ class Idempotence(base.Base):
         res = []
         task_line = ""
         for _, line in enumerate(output_lines):
-            if line.startswith("TASK"):
+            if line.startswith(("TASK", "RUNNING HANDLER")):
                 task_line = line
             elif line.startswith("changed"):
                 host_name = re.search(r"\[(.*)\]", line).groups()[0]  # type: ignore[union-attr]

--- a/tests/unit/command/test_idempotence.py
+++ b/tests/unit/command/test_idempotence.py
@@ -166,3 +166,27 @@ check-command-02: ok=2    changed=1    unreachable=0    failed=0
         "* [check-command-01] => Idempotence test",
         "* [check-command-02] => Idempotence test",
     ]
+
+
+def test_non_idempotent_tasks_handler(_instance):  # type: ignore[no-untyped-def]  # noqa: ANN201, PT019, D103
+    output = """
+PLAY [all] ***********************************************************
+
+TASK [Gathering Facts] ***********************************************
+ok: [instance]
+
+TASK [Test task] *****************************************************
+changed: [instance]
+
+RUNNING HANDLER [some handler] ***************************************
+changed: [instance]
+
+PLAY RECAP ***********************************************************
+instance: ok=3    changed=2    unreachable=0    failed=0
+"""
+    result = _instance._non_idempotent_tasks(output)
+
+    assert result == [
+        "* [instance] => Test task",
+        "* [instance] => some handler",
+    ]


### PR DESCRIPTION
## Summary

Fix idempotence test failure attribution for Ansible handlers.

When a handler is not idempotent, `_non_idempotent_tasks()` incorrectly
reports the calling task name instead of the handler name. This happens
because the parser only matches `TASK` prefixes in Ansible output, but
handlers appear as `RUNNING HANDLER [name]`.

- Add `"RUNNING HANDLER"` to the prefix match in `_non_idempotent_tasks()`
- Add unit test verifying correct handler attribution

Fixes #4414

## Test plan

- [x] Existing unit tests pass (8/8)
- [x] New test `test_non_idempotent_tasks_handler` validates the fix
- [x] Ruff lint passes with no warnings