### PR TITLE
feat: enable command borders and report by default

### DIFF
--- a/docs/getting-started-collections.md
+++ b/docs/getting-started-collections.md
@@ -519,14 +519,12 @@ Run all scenarios together for complete collection testing:
 
 ```bash
 # All scenarios with shared testing resources (configured via shared_state: true)
-molecule test --all --command-borders --report
+molecule test --all
 ```
 
 **Command options:**
 
 - `--all`: Run all scenarios found in extensions/molecule/
-- `--command-borders`: Visual separation of ansible-playbook executions
-- `--report`: Summary report at the end
 
 **Note:** Since `shared_state: true` is configured in the base `config.yml`, the `--shared-state` command-line flag is not required. However, it can still be used to override the configuration if needed.
 

--- a/docs/getting-started-playbooks.md
+++ b/docs/getting-started-playbooks.md
@@ -490,28 +490,28 @@ The destroy playbook removes the containerized network devices and networks, com
 
 ```bash
 # Test the complete lifecycle
-molecule test --scenario-name linux --report --command-borders
+molecule test --scenario-name linux
 
 # Run specific actions
-molecule create --scenario-name linux --report --command-borders
-molecule converge --scenario-name linux --report --command-borders
-molecule verify --scenario-name linux --report --command-borders
+molecule create --scenario-name linux
+molecule converge --scenario-name linux
+molecule verify --scenario-name linux
 ```
 
 **Network Scenario:**
 
 ```bash
 # Test the network scenario
-molecule test --scenario-name network --report --command-borders
+molecule test --scenario-name network
 
 # Converge only
-molecule converge --scenario-name network --report --command-borders
+molecule converge --scenario-name network
 ```
 
 ### Expected Output
 
 ```bash
-$ molecule test --scenario-name linux --report --command-borders
+$ molecule test --scenario-name linux
 
 INFO     linux ➜ discovery: scenario test matrix: dependency, create, prepare, converge, idempotence, verify, cleanup, destroy
 INFO     linux ➜ dependency: Executing
@@ -579,7 +579,7 @@ Test playbooks with different inventory configurations:
 
 ```bash
 # Test with specific inventory
-molecule converge --scenario-name linux --inventory inventory/production.yml --report --command-borders
+molecule converge --scenario-name linux --inventory inventory/production.yml
 ```
 
 ### Multiple Playbook Testing
@@ -591,7 +591,7 @@ Create scenarios to test different playbook combinations:
 molecule init scenario site-testing
 
 # Test the complete site playbook
-molecule test --scenario-name site-testing --report --command-borders
+molecule test --scenario-name site-testing
 ```
 
 ### Parallel Testing
@@ -600,7 +600,7 @@ Run multiple scenarios simultaneously:
 
 ```bash
 # Test both scenarios in parallel
-molecule test --parallel --report --command-borders
+molecule test --parallel
 ```
 
 ## Summary

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -566,47 +566,47 @@ Native inventory support enables various approaches to resource management and t
 
 ```bash
 # Complete isolation - each scenario manages its own resources
-molecule test --scenario-name feature-test --report --command-borders
+molecule test --scenario-name feature-test
 # Uses scenario-specific inventory and infrastructure
 
 # Shared inventory coordination - multiple scenarios use common inventory
-molecule test --scenario-name infrastructure-test --report --command-borders  # Uses ../shared_inventory/
-molecule test --scenario-name application-test --report --command-borders     # Uses ../shared_inventory/
-molecule test --scenario-name integration-test --report --command-borders     # Uses ../shared_inventory/
+molecule test --scenario-name infrastructure-test  # Uses ../shared_inventory/
+molecule test --scenario-name application-test     # Uses ../shared_inventory/
+molecule test --scenario-name integration-test     # Uses ../shared_inventory/
 
 # External inventory testing - test against existing systems
-molecule test --scenario-name staging-validation --report --command-borders   # Uses --inventory=staging_hosts.yml
-molecule test --scenario-name lab-verification --report --command-borders     # Uses --inventory=lab_inventory.py
+molecule test --scenario-name staging-validation   # Uses --inventory=staging_hosts.yml
+molecule test --scenario-name lab-verification     # Uses --inventory=lab_inventory.py
 
 # Single source of truth with selective targeting
-molecule test --scenario-name web-staging --report --command-borders          # Uses enterprise inventory --limit=web_staging
-molecule test --scenario-name db-lab --report --command-borders               # Uses enterprise inventory --limit=database_lab
-molecule test --scenario-name app-test --report --command-borders             # Uses enterprise inventory --limit=environment_test
+molecule test --scenario-name web-staging          # Uses enterprise inventory --limit=web_staging
+molecule test --scenario-name db-lab               # Uses enterprise inventory --limit=database_lab
+molecule test --scenario-name app-test             # Uses enterprise inventory --limit=environment_test
 
 # Playbook-level targeting (no --limit needed)
-molecule test --scenario-name staging-deployment --report --command-borders   # Playbooks use hosts: web_staging, hosts: db_staging
-molecule test --scenario-name lab-testing --report --command-borders          # Playbooks use hosts: lab_environment
-molecule test --scenario-name multi-tier --report --command-borders           # Different actions target different groups
+molecule test --scenario-name staging-deployment   # Playbooks use hosts: web_staging, hosts: db_staging
+molecule test --scenario-name lab-testing          # Playbooks use hosts: lab_environment
+molecule test --scenario-name multi-tier           # Different actions target different groups
 
 # Multi-source inventory patterns
-molecule test --scenario-name cloud-discovery --report --command-borders      # Uses cloud inventory + molecule config
-molecule test --scenario-name hybrid-infrastructure --report --command-borders # Uses multiple provider inventories + test config
-molecule test --scenario-name dynamic-targeting --report --command-borders    # Cloud provider discovers, molecule configures
+molecule test --scenario-name cloud-discovery      # Uses cloud inventory + molecule config
+molecule test --scenario-name hybrid-infrastructure # Uses multiple provider inventories + test config
+molecule test --scenario-name dynamic-targeting    # Cloud provider discovers, molecule configures
 
 # Multi-action data sharing patterns
-molecule test --scenario-name host-specific-data --report --command-borders   # Uses file-based vars sharing between actions
-molecule test --scenario-name secret-propagation --report --command-borders   # Shares secrets from create to converge/verify
-molecule test --scenario-name dynamic-configuration --report --command-borders # Generates host configs in create, uses in other actions
+molecule test --scenario-name host-specific-data   # Uses file-based vars sharing between actions
+molecule test --scenario-name secret-propagation   # Shares secrets from create to converge/verify
+molecule test --scenario-name dynamic-configuration # Generates host configs in create, uses in other actions
 
 # Shared-state with data propagation
-molecule test --all --shared-state --report --command-borders                 # Default creates infrastructure, other scenarios use shared data
-molecule test --scenario-name app-deploy --shared-state --report --command-borders    # Uses infrastructure data from default scenario
-molecule test --scenario-name integration --shared-state --report --command-borders   # Accesses database/LB endpoints from default
+molecule test --all --shared-state                 # Default creates infrastructure, other scenarios use shared data
+molecule test --scenario-name app-deploy --shared-state    # Uses infrastructure data from default scenario
+molecule test --scenario-name integration --shared-state   # Accesses database/LB endpoints from default
 
 # Mixed approach for comprehensive testing
-molecule test --scenario-name isolated-unit --report --command-borders        # Isolated resources
-molecule test --scenario-name shared-integration --report --command-borders   # Shared inventory
-molecule test --scenario-name lab-validation --report --command-borders       # External inventory
+molecule test --scenario-name isolated-unit        # Isolated resources
+molecule test --scenario-name shared-integration   # Shared inventory
+molecule test --scenario-name lab-validation       # External inventory
 ```
 
 This flexibility allows teams to optimize their testing strategies based on resource constraints, execution time requirements, and test isolation needs while maintaining the reliability and reproducibility essential for effective automation testing through native Ansible inventory integration.

--- a/src/molecule/click_cfg.py
+++ b/src/molecule/click_cfg.py
@@ -326,8 +326,7 @@ class CliOptions:
             name="report",
             help="Enable or disable end-of-run summary report.",
             is_flag=True,
-            default=False,
-            experimental=True,
+            default=True,
         )
 
     @property
@@ -384,8 +383,7 @@ class CliOptions:
             name="command-borders",
             help="Enable or disable borders around command output.",
             is_flag=True,
-            default=False,
-            experimental=True,
+            default=True,
         )
 
     @property

--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -237,7 +237,7 @@ def execute_cmdline_scenarios(
     except ScenarioFailureError as exc:
         util.sysexit_from_exception(exc)
     finally:
-        report(scenarios.results, report_flag=command_args.get("report", False))
+        report(scenarios.results, report_flag=command_args.get("report", True))
 
 
 def _generate_scenarios(

--- a/src/molecule/config.py
+++ b/src/molecule/config.py
@@ -225,7 +225,7 @@ class Config:
     @property
     def command_borders(self) -> bool:
         """Return if command borders are enabled."""
-        return self.command_args.get("command_borders", False)
+        return self.command_args.get("command_borders", True)
 
     @property
     def platform_name(self) -> str | None:

--- a/tests/unit/command/test_base.py
+++ b/tests/unit/command/test_base.py
@@ -705,7 +705,7 @@ def test_apply_cli_overrides_comprehensive(
         # CLI overrides both
         ("false", ["--report", "--command-borders"], True, True),  # CLI overrides both env vars
         # No env vars, no CLI (defaults)
-        (None, [], False, False),
+        (None, [], True, True),
     ),
     ids=(
         "env_both_true_no_cli",
@@ -788,8 +788,8 @@ def test_apply_env_overrides_comprehensive(  # noqa: PLR0913
     assert len(captured_configs) >= 1  # At least one config was created
 
     config_obj = captured_configs[0]
-    assert config_obj.command_args.get("report", False) is expected_report
-    assert config_obj.command_args.get("command_borders", False) is expected_borders
+    assert config_obj.command_args.get("report", True) is expected_report
+    assert config_obj.command_args.get("command_borders", True) is expected_borders
 
 
 @pytest.mark.parametrize(
@@ -810,9 +810,9 @@ def test_apply_env_overrides_comprehensive(  # noqa: PLR0913
         ("0", "no", [], False, False),  # Different falsy formats
         ("on", "off", [], True, False),  # More boolean formats
         # Test partial env vars (only one set)
-        ("true", None, [], True, False),  # Only report env var set
-        (None, "true", [], False, True),  # Only borders env var set
-        (None, None, ["--report"], True, False),  # No env vars, only CLI
+        ("true", None, [], True, True),  # Only report env var set, borders uses default
+        (None, "true", [], True, True),  # Only borders env var set, report uses default
+        (None, None, ["--report"], True, True),  # No env vars, CLI report (borders uses default)
     ),
     ids=(
         "cli_overrides_both_env_vars",
@@ -893,8 +893,8 @@ def test_env_var_cli_precedence(  # noqa: PLR0913
     assert len(captured_configs) >= 1
 
     config_obj = captured_configs[0]
-    assert config_obj.command_args.get("report", False) is expected_report
-    assert config_obj.command_args.get("command_borders", False) is expected_borders
+    assert config_obj.command_args.get("report", True) is expected_report
+    assert config_obj.command_args.get("command_borders", True) is expected_borders
 
 
 def test_env_overrides_invalid_values(

--- a/tests/unit/dependency/ansible_galaxy/test_collections.py
+++ b/tests/unit/dependency/ansible_galaxy/test_collections.py
@@ -168,7 +168,7 @@ def test_collections_execute(  # type: ignore[no-untyped-def]  # noqa: ANN201, D
         "patched-command",
         debug=False,
         check=True,
-        command_borders=False,
+        command_borders=True,
     )
 
     msg = "Dependency completed successfully."

--- a/tests/unit/dependency/ansible_galaxy/test_roles.py
+++ b/tests/unit/dependency/ansible_galaxy/test_roles.py
@@ -167,7 +167,7 @@ def test_execute(  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
         "patched-command",
         debug=False,
         check=True,
-        command_borders=False,
+        command_borders=True,
     )
 
     msg = "Dependency completed successfully."

--- a/tests/unit/dependency/test_shell.py
+++ b/tests/unit/dependency/test_shell.py
@@ -128,7 +128,7 @@ def test_shell_execute(  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
             "patched-command",
             debug=False,
             check=True,
-            command_borders=False,
+            command_borders=True,
         )
 
         # Check for scenario-aware log records instead of text

--- a/tests/unit/test_click_cfg.py
+++ b/tests/unit/test_click_cfg.py
@@ -472,12 +472,10 @@ def test_output_options() -> None:
     report = options.report
     assert report.name == "report"
     assert report.is_flag is True
-    assert report.experimental is True
+    assert report.experimental is False
     help_text = report._generate_help_text()
-    assert "EXPERIMENTAL:" in help_text
-    assert "(default: disabled)" in help_text
-
-    assert "(default: disabled)" in help_text
+    assert "EXPERIMENTAL:" not in help_text
+    assert "(default: enabled)" in help_text
 
     shared_state = options.shared_state
     assert shared_state.name == "shared-state"
@@ -856,7 +854,7 @@ def test_option_sort_order() -> None:
     test_options = [
         cli_options.force,  # Short form, non-experimental
         cli_options.scenario_name_with_default,  # Should be first (scenario-name)
-        cli_options.report,  # Experimental
+        cli_options.report,  # Long form, non-experimental
         cli_options.exclude,  # Should be second
         cli_options.all_scenarios,  # Should be third (all)
         cli_options.parallel,  # Long form, non-experimental
@@ -875,7 +873,7 @@ def test_option_sort_order() -> None:
         "driver-name",  # Section 2: short forms (alphabetical): driver-name
         "force",  # Section 2: short forms (alphabetical): force
         "parallel",  # Section 3: long forms (alphabetical)
-        "report",  # Section 4: experimental (alphabetical): report
+        "report",  # Section 3: long forms (alphabetical)
         "shared-state",  # Section 4: experimental (alphabetical): shared-state
     ]
 


### PR DESCRIPTION
## Summary

- Promote `--command-borders` and `--report` from experimental flags (default: disabled) to stable features (default: enabled).
- Remove the `EXPERIMENTAL:` prefix from their help text and re-sort them into the standard options section.
- Update fallback defaults in `config.py` and `base.py` to match the new Click defaults.
- Remove now-redundant `--report --command-borders` from all doc examples across 3 files (~38 commands).
- Update all affected unit tests for the new default values and option sort order.

Users who prefer the old behavior can pass `--no-command-borders` / `--no-report`, or set `MOLECULE_COMMAND_BORDERS=false` / `MOLECULE_REPORT=false`.

## Test plan

- [ ] Verify `molecule test` shows command borders and report by default (no flags needed)
- [ ] Verify `molecule test --no-command-borders --no-report` disables both features
- [ ] Verify `MOLECULE_REPORT=false MOLECULE_COMMAND_BORDERS=false molecule test` disables both via env
- [ ] Run `python -m pytest tests/unit/command/test_base.py -v` to confirm env/CLI precedence tests pass
- [ ] Run `python -m pytest tests/unit/test_click_cfg.py -v` to confirm option metadata and sort order tests pass
- [ ] Run `python -m pytest tests/unit/dependency/ -v` to confirm dependency tests pass with new defaults


Made with [Cursor](https://cursor.com)