### PR TITLE
fix: add missing build_ignore entries to galaxy.yml

### DIFF
--- a/community.molecule/galaxy.yml
+++ b/community.molecule/galaxy.yml
@@ -20,5 +20,8 @@ build_ignore:
   - .ansible
   - .gitignore
   - .github
+  - .tox
+  - .venv
   - changelogs/.plugin-cache.yaml
+  - collections
   - Makefile


### PR DESCRIPTION
The ade install -e command auto-appends .tox, .venv, and collections to build_ignore in galaxy.yml when they are missing, making the working tree dirty. This causes tox-extra git-dirty checks to fail all collection test environments in CI.