### PR TITLE
fix: update __init_subclass__ method to accept additional keyword arguments

### DIFF
--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -79,8 +79,12 @@ class Base(abc.ABC):
         self._config.scenario.results.add_action_result(self._config.action or "unknown")
         self._setup()
 
-    def __init_subclass__(cls, **kwargs: Any) -> None:
-        """Decorate execute from all subclasses."""
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        """Decorate execute from all subclasses.
+
+        Args:
+            **kwargs: Keyword arguments forwarded to parent classes in the MRO.
+        """
         super().__init_subclass__(**kwargs)
         for wrapper in logger.get_section_loggers():
             cls.execute = wrapper(cls.execute)  # type: ignore[method-assign,assignment]

--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -79,9 +79,9 @@ class Base(abc.ABC):
         self._config.scenario.results.add_action_result(self._config.action or "unknown")
         self._setup()
 
-    def __init_subclass__(cls) -> None:
+    def __init_subclass__(cls, **kwargs: Any) -> None:
         """Decorate execute from all subclasses."""
-        super().__init_subclass__()
+        super().__init_subclass__(**kwargs)
         for wrapper in logger.get_section_loggers():
             cls.execute = wrapper(cls.execute)  # type: ignore[method-assign,assignment]
 


### PR DESCRIPTION
Modified the __init_subclass__ method in the Base class to accept **kwargs, ensuring compatibility with subclasses that may require additional parameters. This change enhances flexibility in subclassing while maintaining existing functionality.