### PR TITLE
feat: Support molecule login/molecule list for ansible-native scenarios

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -120,6 +120,7 @@ selectattr
 serviceaccount
 sessionfinish
 skipsdist
+sles
 ssbarnea
 stestr
 stopall

--- a/docs/ansible-native.md
+++ b/docs/ansible-native.md
@@ -355,7 +355,22 @@ The ansible-native approach leverages ansible collections for testing resource m
         host: "{% raw %}{{ hostvars[item].ansible_host }}{% endraw %}"
         delay: 5
       loop: "{% raw %}{{ groups['test_resources'] }}{% endraw %}"
+
+    - name: Persist connection details for molecule login/list
+      ansible.builtin.copy:
+        dest: "{% raw %}{{ molecule_scenario_directory }}{% endraw %}/inventory/host_vars/{% raw %}{{ item }}{% endraw %}/runtime.yml"
+        content: |
+          ansible_host: "{% raw %}{{ hostvars[item].ansible_host }}{% endraw %}"
+          ansible_port: "{% raw %}{{ hostvars[item].published_port }}{% endraw %}"
+      loop: "{% raw %}{{ groups['test_resources'] }}{% endraw %}"
 ```
+
+`podman_container` assigns the published port and IP at runtime - they only exist as
+in-memory facts for the duration of this play. `molecule login`/`molecule list` run
+`ansible-inventory` as a separate process later, so they only see connection details
+that were actually written to a file under the configured `--inventory` path, not
+facts that were merely registered or `add_host`-ed during `create.yml`. See
+[Logging Into / Listing Instances](#logging-into-listing-instances) below.
 
 ### Cloud Testing Resources
 
@@ -401,6 +416,11 @@ The ansible-native approach leverages ansible collections for testing resource m
         wait: true
       loop: "{% raw %}{{ groups['test_resources'] }}{% endraw %}"
 ```
+
+Like the container example above, `ec2_instance`'s assigned public/private IP only
+exists as an in-memory fact here - persist it to a `host_vars` file the same way if
+you want `molecule login`/`molecule list` to be able to find it. See
+[Logging Into / Listing Instances](#logging-into-listing-instances) below.
 
 ### Collection Dependencies
 
@@ -609,3 +629,43 @@ This configuration defines ansible-native testing with:
 ## Supplemental Inventory Generation
 
 In the ansible-native approach, Molecule generates only a supplemental inventory file containing molecule-specific variables that are made available to playbooks. This includes environment variables like `MOLECULE_SCENARIO_DIRECTORY`, `MOLECULE_EPHEMERAL_DIRECTORY`, and scenario metadata. The primary inventory comes from the sources specified in `ansible.executor.args.ansible_playbook`, allowing full integration with existing inventory management systems while maintaining Molecule's testing capabilities.
+
+## Logging Into / Listing Instances
+
+Ansible-native scenarios declare no `platforms:` section, so Molecule has no static
+list of instance names to show in `molecule list` or connect to for `molecule login`.
+Instead, both commands query the real inventory - the same sources configured under
+`ansible.executor.args.ansible_playbook` (e.g. `--inventory=inventory/`) - by running
+`ansible-inventory` against them:
+
+- `molecule list` calls `ansible-inventory --list` and reports every host key found
+  under `_meta.hostvars`, instead of a single blank instance name.
+- `molecule login [--host <name>]` calls `ansible-inventory --host <name>` for that
+  host and reads `ansible_host`, `ansible_user`, `ansible_port`, and
+  `ansible_ssh_private_key_file` off of it to build the SSH command. If `--host` is
+  omitted and exactly one host is found, that one is used automatically.
+
+This reuses whatever inventory sources `ansible-playbook` itself already resolves
+against - there is no separate, molecule-specific bookkeeping file to keep in sync.
+(If a create playbook happens to populate the older `instance_config.yml` convention,
+that is still consulted first; the inventory query is the fallback used when that file
+doesn't exist or has no entry for the instance - you do not need to choose one
+mechanism exclusively.)
+
+### Connection details must be written to disk, not just registered as facts
+
+`ansible-inventory` runs as a fresh, separate process each time `login`/`list` is
+invoked - it re-parses whatever is on disk at the configured `--inventory` path at
+that moment. It does **not** see anything a `create.yml` play added only in-memory at
+runtime, such as `ansible.builtin.add_host`, or facts registered from
+`podman_container`/`ec2_instance`/etc. and never persisted anywhere.
+
+This matters whenever a resource's connection details (an IP address, a published
+port) are only known after `create.yml` provisions it. To make `login`/`list` work for
+those hosts, `create.yml` needs to write the resolved values to a real inventory
+source under the `--inventory` path - typically a `host_vars/<name>.yml` file - as
+shown in the [Container Testing Resources](#container-testing-resources) and
+[Cloud Testing Resources](#cloud-testing-resources) examples above. A static inventory
+where `ansible_host`/`ansible_port`/etc. are already known ahead of time (e.g. the
+[Host-Based Testing](#host-based-testing) example) needs no such step - those values
+are already on disk.

--- a/docs/ansible-native.md
+++ b/docs/ansible-native.md
@@ -370,7 +370,7 @@ in-memory facts for the duration of this play. `molecule login`/`molecule list` 
 `ansible-inventory` as a separate process later, so they only see connection details
 that were actually written to a file under the configured `--inventory` path, not
 facts that were merely registered or `add_host`-ed during `create.yml`. See
-[Logging Into / Listing Instances](#logging-into-listing-instances) below.
+[Logging Into and Listing Instances](#logging-into-and-listing-instances) below.
 
 ### Cloud Testing Resources
 
@@ -420,7 +420,7 @@ facts that were merely registered or `add_host`-ed during `create.yml`. See
 Like the container example above, `ec2_instance`'s assigned public/private IP only
 exists as an in-memory fact here - persist it to a `host_vars` file the same way if
 you want `molecule login`/`molecule list` to be able to find it. See
-[Logging Into / Listing Instances](#logging-into-listing-instances) below.
+[Logging Into and Listing Instances](#logging-into-and-listing-instances) below.
 
 ### Collection Dependencies
 
@@ -630,7 +630,7 @@ This configuration defines ansible-native testing with:
 
 In the ansible-native approach, Molecule generates only a supplemental inventory file containing molecule-specific variables that are made available to playbooks. This includes environment variables like `MOLECULE_SCENARIO_DIRECTORY`, `MOLECULE_EPHEMERAL_DIRECTORY`, and scenario metadata. The primary inventory comes from the sources specified in `ansible.executor.args.ansible_playbook`, allowing full integration with existing inventory management systems while maintaining Molecule's testing capabilities.
 
-## Logging Into / Listing Instances
+## Logging Into and Listing Instances
 
 Ansible-native scenarios declare no `platforms:` section, so Molecule has no static
 list of instance names to show in `molecule list` or connect to for `molecule login`.

--- a/src/molecule/command/login.py
+++ b/src/molecule/command/login.py
@@ -63,6 +63,12 @@ class Login(base.Base):
             base.execute_subcommand(c, "create")
 
         hosts = [d["name"] for d in self._config.platforms.instances]
+        if not hosts:
+            # ansible-native scenario (no `platforms` declared) - molecule
+            # has no static instance list to fall back on, so ask the
+            # driver to look in the real inventory instead (see
+            # Delegated.get_ansible_native_hosts()).
+            hosts = c.driver.get_ansible_native_hosts()
         hostname = self._get_hostname(hosts)
         self._get_login(hostname)
 
@@ -72,6 +78,17 @@ class Login(base.Base):
         if hostname is None:
             if len(hosts) == 1:
                 hostname = hosts[0]
+            elif not hosts:
+                # Either a non-ansible-native scenario with genuinely no
+                # instances, or an ansible-native one whose inventory query
+                # found nothing - either way, there's no list to suggest
+                # picking from.
+                msg = (
+                    "There are 0 running hosts, and none could be found in "
+                    "the configured inventory either. Specify the instance "
+                    "name directly with --host."
+                )
+                sysexit_with_message(msg, code=1)
             else:
                 msg = (
                     f"There are {len(hosts)} running hosts. Please specify "
@@ -79,6 +96,12 @@ class Login(base.Base):
                     f"Available hosts:\n{host_list}"
                 )
                 sysexit_with_message(msg, code=1)
+
+        if not hosts:
+            # Can't validate against a known list for ansible-native
+            # scenarios - trust the explicitly-provided --host value.
+            return hostname
+
         match = [x for x in hosts if x.startswith(hostname)]
         if len(match) == 0:
             msg = (
@@ -113,7 +136,21 @@ class Login(base.Base):
                 login_options["instance"],
             )
             return
-        login_cmd = self._config.driver.login_cmd_template.format(**login_options)
+        try:
+            login_cmd = self._config.driver.login_cmd_template.format(**login_options)
+        except KeyError as exc:
+            msg = (
+                f"Unable to determine connection details for instance "
+                f"'{hostname}': missing {exc}.\n"
+                "For ansible-native scenarios, molecule login needs either "
+                "an inventory entry for this host with ansible_host/"
+                "ansible_user/etc. set (resolved via the same --inventory "
+                "sources ansible-playbook uses), or your create playbook "
+                "can write this instance's connection details to "
+                "instance_config.yml (the {{ molecule_instance_config }} "
+                "path)."
+            )
+            sysexit_with_message(msg, code=1)
 
         cmd = shlex.split(f"/usr/bin/env {login_cmd}")
         subprocess.run(cmd, check=False)

--- a/src/molecule/driver/base.py
+++ b/src/molecule/driver/base.py
@@ -217,6 +217,20 @@ class Driver(ABC):
         """
         return self.options["managed"]
 
+    def get_ansible_native_hosts(self) -> list[str]:
+        """List real host names for an ansible-native scenario (no `platforms` declared).
+
+        Base implementation returns an empty list - drivers that manage
+        instances off a real inventory (see Delegated) can override this to
+        report real host names instead of leaving callers with nothing to
+        work with.
+
+        Returns:
+            List of host names, or an empty list if this driver has no way
+            to determine one.
+        """
+        return []
+
     def status(self) -> list[Status]:
         """Collect the instances state and returns a list.
 
@@ -236,8 +250,11 @@ class Driver(ABC):
         instances = self._config.platforms.instances
 
         if not instances:
-            # an ansible-native scenario
-            instances.append({"name": ""})
+            # an ansible-native scenario - try to discover real host names
+            # from the configured inventory instead of a single blank
+            # placeholder.
+            inventory_hosts = self.get_ansible_native_hosts()
+            instances = [{"name": name} for name in inventory_hosts] or [{"name": ""}]
 
         for platform in instances:
             instance_name = platform["name"]

--- a/src/molecule/driver/delegated.py
+++ b/src/molecule/driver/delegated.py
@@ -165,17 +165,23 @@ class Delegated(Driver):
             List of `ansible-inventory` CLI arguments selecting the same
             inventory sources ansible-playbook uses.
         """
+        extra_inventory_args = []
+        source_args = (*self._config.provisioner.ansible_args, *self._config.ansible_args)
+        take_next = False
+        for arg in source_args:
+            if take_next:
+                extra_inventory_args.append(arg)
+                take_next = False
+            elif arg.startswith(("--inventory=", "-i=")):
+                extra_inventory_args.append(arg)
+            elif arg in ("--inventory", "-i"):
+                extra_inventory_args.append(arg)
+                take_next = True
+
         return [
             "--inventory",
             self._config.provisioner.inventory_directory,
-            *[
-                arg
-                for arg in (
-                    *self._config.provisioner.ansible_args,
-                    *self._config.ansible_args,
-                )
-                if arg.startswith(("--inventory", "-i"))
-            ],
+            *extra_inventory_args,
         ]
 
     def _run_ansible_inventory(self, extra_args: list[str]) -> dict[str, Any] | None:
@@ -197,6 +203,7 @@ class Delegated(Driver):
                 capture_output=True,
                 text=True,
                 check=True,
+                timeout=30,
             )
             return json.loads(result.stdout)  # type: ignore[no-any-return]
         except subprocess.CalledProcessError as exc:
@@ -206,6 +213,9 @@ class Delegated(Driver):
                 exc.returncode,
                 exc.stderr.strip() if exc.stderr else "(no stderr)",
             )
+            return None
+        except subprocess.TimeoutExpired:
+            LOG.debug("ansible-inventory %s timed out after 30s", " ".join(extra_args))
             return None
         except (json.JSONDecodeError, OSError) as exc:
             LOG.debug("ansible-inventory %s failed: %s", " ".join(extra_args), exc)

--- a/src/molecule/driver/delegated.py
+++ b/src/molecule/driver/delegated.py
@@ -166,6 +166,8 @@ class Delegated(Driver):
             inventory sources ansible-playbook uses.
         """
         extra_inventory_args = []
+        if self._config.provisioner is None:
+            return []
         source_args = (*self._config.provisioner.ansible_args, *self._config.ansible_args)
         take_next = False
         for arg in source_args:

--- a/src/molecule/driver/delegated.py
+++ b/src/molecule/driver/delegated.py
@@ -21,18 +21,25 @@
 
 from __future__ import annotations
 
+import json
+import subprocess
+
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from molecule import util
 from molecule.api import Driver
 from molecule.data import __file__ as data_module
+from molecule.logger import get_logger
 
 
 if TYPE_CHECKING:
     from typing import Any
 
     from molecule.config import Config
+
+
+LOG = get_logger(__name__)
 
 
 class Delegated(Driver):
@@ -128,8 +135,131 @@ class Delegated(Driver):
         if self.managed:
             d = {"instance": instance_name}
 
-            return util.merge_dicts(d, self._get_instance_config(instance_name))
+            try:
+                return util.merge_dicts(d, self._get_instance_config(instance_name))
+            except (StopIteration, OSError):
+                # instance_config.yml doesn't exist, or has no entry for
+                # this instance - e.g. an ansible-native scenario (no
+                # `platforms` declared), whose create playbook has no
+                # obligation to populate it (mirrors
+                # ansible_connection_options()'s own handling of this exact
+                # case). Fall back to whatever the real ansible inventory
+                # already has for this host - population of those vars is
+                # up to the scenario/create playbook's own author, this
+                # just reads what's already there instead of requiring a
+                # second, molecule-specific copy of the same facts.
+                return util.merge_dicts(d, self._get_inventory_login_options(instance_name))
         return {"instance": instance_name}
+
+    def _ansible_inventory_args(self) -> list[str]:
+        """Resolve the same --inventory sources ansible-playbook itself is invoked with.
+
+        See AnsiblePlaybook.bake(): it always passes
+        provisioner.inventory_directory, plus whatever extra
+        --inventory/-i args are configured in provisioner.ansible_args /
+        the top-level ansible_args. Reusing the exact same sources here
+        means queries reflect exactly what ansible-playbook itself would
+        see - no separate inventory config to keep in sync.
+
+        Returns:
+            List of `ansible-inventory` CLI arguments selecting the same
+            inventory sources ansible-playbook uses.
+        """
+        return [
+            "--inventory",
+            self._config.provisioner.inventory_directory,
+            *[
+                arg
+                for arg in (
+                    *self._config.provisioner.ansible_args,
+                    *self._config.ansible_args,
+                )
+                if arg.startswith(("--inventory", "-i"))
+            ],
+        ]
+
+    def _run_ansible_inventory(self, extra_args: list[str]) -> dict[str, Any] | None:
+        """Run `ansible-inventory` against the resolved inventory sources.
+
+        Args:
+            extra_args: Additional ansible-inventory CLI arguments, e.g.
+                ``["--host", name]`` or ``["--list"]``.
+
+        Returns:
+            The parsed JSON output, or None if the command failed for any
+            reason (ansible-inventory not available, no matching host,
+            malformed output, etc).
+        """
+        cmd = ["ansible-inventory", *extra_args, *self._ansible_inventory_args()]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            return json.loads(result.stdout)  # type: ignore[no-any-return]
+        except subprocess.CalledProcessError as exc:
+            LOG.debug(
+                "ansible-inventory %s failed (rc=%d): %s",
+                " ".join(extra_args),
+                exc.returncode,
+                exc.stderr.strip() if exc.stderr else "(no stderr)",
+            )
+            return None
+        except (json.JSONDecodeError, OSError) as exc:
+            LOG.debug("ansible-inventory %s failed: %s", " ".join(extra_args), exc)
+            return None
+
+    def _get_inventory_login_options(self, instance_name: str) -> dict[str, str]:
+        """Resolve login options for an instance from the real ansible inventory.
+
+        Used as a fallback when instance_config.yml has no entry for this
+        instance (ansible-native scenarios have no obligation to write one).
+        Reflects whatever the scenario's own create playbook already
+        populated - e.g. via host_vars - with no separate bookkeeping
+        required.
+
+        Args:
+            instance_name: The name of the instance to look up.
+
+        Returns:
+            Dictionary of options related to logging into the instance, or
+            an empty dictionary if none could be resolved.
+        """
+        host_vars = self._run_ansible_inventory(["--host", instance_name])
+        if host_vars is None:
+            return {}
+
+        d = {}
+        if "ansible_host" in host_vars:
+            d["address"] = host_vars["ansible_host"]
+        if "ansible_user" in host_vars:
+            d["user"] = host_vars["ansible_user"]
+        if "ansible_port" in host_vars:
+            d["port"] = host_vars["ansible_port"]
+        if "ansible_ssh_private_key_file" in host_vars:
+            d["identity_file"] = host_vars["ansible_ssh_private_key_file"]
+        return d
+
+    def get_ansible_native_hosts(self) -> list[str]:
+        """List real host names from the configured inventory.
+
+        For ansible-native scenarios (no `platforms` declared), molecule
+        has no static list of instance names to fall back on - this
+        queries the same inventory ansible-playbook itself would use and
+        returns every host it defines, so `molecule list`/`molecule login`
+        can work with real names instead of a blank placeholder / always
+        requiring --host.
+
+        Returns:
+            Sorted list of host names found in the inventory, or an empty
+            list if none could be resolved.
+        """
+        data = self._run_ansible_inventory(["--list"])
+        if data is None:
+            return []
+        return sorted(data.get("_meta", {}).get("hostvars", {}).keys())
 
     def ansible_connection_options(
         self,

--- a/tests/unit/command/test_login.py
+++ b/tests/unit/command/test_login.py
@@ -175,3 +175,65 @@ def test_get_hostname_no_host_flag_specified_on_cli_with_multiple_hosts_raises( 
         "instance-2"
     )
     assert msg in caplog.text
+
+
+def test_get_hostname_no_hosts_and_none_in_inventory_raises(  # noqa: D103
+    caplog: pytest.LogCaptureFixture,
+    _instance: login.Login,  # noqa: PT019
+) -> None:
+    _instance._config.command_args = {}
+    with pytest.raises(SystemExit) as e:
+        _instance._get_hostname([])
+
+    assert e.value.code == 1
+
+    msg = (
+        "There are 0 running hosts, and none could be found in "
+        "the configured inventory either. Specify the instance "
+        "name directly with --host."
+    )
+    assert msg in caplog.text
+
+
+@pytest.mark.parametrize(
+    "config_instance",
+    ["_molecule_data_native"],  # noqa: PT007
+    indirect=True,
+)
+def test_execute_falls_back_to_ansible_native_hosts_when_no_platforms(  # noqa: D103
+    mocker: MockerFixture,
+    _instance: login.Login,  # noqa: PT019
+) -> None:
+    assert _instance._config.platforms.instances == []
+
+    m = mocker.patch(
+        "molecule.driver.delegated.Delegated.get_ansible_native_hosts",
+        return_value=["sles15-efi"],
+    )
+    mocker.patch("molecule.command.login.Login._get_login")
+
+    _instance._config.command_args = {"host": None}
+    _instance.execute()
+
+    m.assert_called_once_with()
+
+
+def test_get_login_raises_on_missing_connection_details(  # noqa: D103
+    mocker: MockerFixture,
+    _instance: login.Login,  # noqa: PT019
+) -> None:
+    mocker.patch("os.popen").return_value.read.return_value = "24 80"
+    mocker.patch(
+        "molecule.driver.delegated.Delegated.login_options",
+        return_value={"instance": "sles15-efi"},
+    )
+    mocker.patch(
+        "molecule.driver.delegated.Delegated.login_cmd_template",
+        new_callable=mocker.PropertyMock,
+        return_value="ssh {address} -l {user} -p {port} -i {identity_file}",
+    )
+
+    with pytest.raises(SystemExit) as e:
+        _instance._get_login("sles15-efi")
+
+    assert e.value.code == 1

--- a/tests/unit/command/test_login.py
+++ b/tests/unit/command/test_login.py
@@ -212,7 +212,7 @@ def test_execute_falls_back_to_ansible_native_hosts_when_no_platforms(  # noqa: 
     )
     mocker.patch("molecule.command.login.Login._get_login")
 
-    _instance._config.command_args = {"host": None}
+    _instance._config.command_args = {}
     _instance.execute()
 
     m.assert_called_once_with()

--- a/tests/unit/driver/test_delegated.py
+++ b/tests/unit/driver/test_delegated.py
@@ -349,7 +349,11 @@ def _driver_options_managed_section_data():  # type: ignore[no-untyped-def]  # n
 
 @pytest.fixture
 def _molecule_data_native():  # type: ignore[no-untyped-def]  # noqa: ANN202
-    """Provide a molecule data dictionary for an ansible-native scenario (no `platforms`)."""
+    """Provide a molecule data dictionary for an ansible-native scenario (no `platforms`).
+
+    Returns:
+        A molecule config dict with empty platforms.
+    """
     return {
         "ansible": {"executor": {"backend": "ansible-playbook"}},
         "driver": {},

--- a/tests/unit/driver/test_delegated.py
+++ b/tests/unit/driver/test_delegated.py
@@ -19,7 +19,9 @@
 #  DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
+import json
 import os
+import subprocess
 
 from typing import TYPE_CHECKING
 
@@ -345,6 +347,17 @@ def _driver_options_managed_section_data():  # type: ignore[no-untyped-def]  # n
     return {"driver": {"options": {"managed": False}}}
 
 
+@pytest.fixture
+def _molecule_data_native():  # type: ignore[no-untyped-def]  # noqa: ANN202
+    """Provide a molecule data dictionary for an ansible-native scenario (no `platforms`)."""
+    return {
+        "ansible": {"executor": {"backend": "ansible-playbook"}},
+        "driver": {},
+        "platforms": [],
+        "provisioner": {},
+    }
+
+
 @pytest.mark.parametrize(
     "config_instance",
     ["_driver_options_managed_section_data"],  # noqa: PT007
@@ -367,3 +380,244 @@ def test_get_instance_config(mocker: MockerFixture, _instance):  # type: ignore[
 
     x = {"instance": "foo"}
     assert x == _instance._get_instance_config("foo")
+
+
+def test_ansible_inventory_args(_instance):  # type: ignore[no-untyped-def]  # noqa: ANN201, PT019, D103
+    args = _instance._ansible_inventory_args()
+
+    assert args[0] == "--inventory"
+    assert args[1] == _instance._config.provisioner.inventory_directory
+
+
+def test_ansible_inventory_args_includes_extra_inventory_args(  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
+    mocker: MockerFixture,
+    _instance,  # noqa: PT019
+):
+    mocker.patch.object(
+        type(_instance._config.provisioner),
+        "ansible_args",
+        new_callable=mocker.PropertyMock,
+        return_value=["--inventory=/extra/inventory", "--diff"],
+    )
+
+    args = _instance._ansible_inventory_args()
+
+    assert args == [
+        "--inventory",
+        _instance._config.provisioner.inventory_directory,
+        "--inventory=/extra/inventory",
+    ]
+
+
+def test_run_ansible_inventory_returns_parsed_json(  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
+    mocker: MockerFixture,
+    _instance,  # noqa: PT019
+):
+    m = mocker.patch("subprocess.run")
+    m.return_value = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=json.dumps({"_meta": {"hostvars": {"instance-1": {}}}}),
+    )
+
+    result = _instance._run_ansible_inventory(["--list"])
+
+    assert result == {"_meta": {"hostvars": {"instance-1": {}}}}
+
+
+def test_run_ansible_inventory_returns_none_on_called_process_error(  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
+    caplog: pytest.LogCaptureFixture,
+    mocker: MockerFixture,
+    _instance,  # noqa: PT019
+):
+    m = mocker.patch("subprocess.run")
+    m.side_effect = subprocess.CalledProcessError(
+        returncode=1,
+        cmd=["ansible-inventory"],
+        stderr="boom",
+    )
+
+    with caplog.at_level("DEBUG"):
+        result = _instance._run_ansible_inventory(["--list"])
+
+    assert result is None
+    assert "boom" in caplog.text
+
+
+def test_run_ansible_inventory_returns_none_on_bad_json(  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
+    caplog: pytest.LogCaptureFixture,
+    mocker: MockerFixture,
+    _instance,  # noqa: PT019
+):
+    m = mocker.patch("subprocess.run")
+    m.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="not json")
+
+    with caplog.at_level("DEBUG"):
+        result = _instance._run_ansible_inventory(["--list"])
+
+    assert result is None
+    assert "ansible-inventory" in caplog.text
+
+
+def test_run_ansible_inventory_returns_none_when_binary_missing(  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
+    caplog: pytest.LogCaptureFixture,
+    mocker: MockerFixture,
+    _instance,  # noqa: PT019
+):
+    m = mocker.patch("subprocess.run")
+    m.side_effect = FileNotFoundError("ansible-inventory not found")
+
+    with caplog.at_level("DEBUG"):
+        result = _instance._run_ansible_inventory(["--list"])
+
+    assert result is None
+    assert "ansible-inventory" in caplog.text
+
+
+def test_get_inventory_login_options_maps_ansible_vars(  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
+    mocker: MockerFixture,
+    _instance,  # noqa: PT019
+):
+    m = mocker.patch("molecule.driver.delegated.Delegated._run_ansible_inventory")
+    m.return_value = {
+        "ansible_host": "172.16.0.2",
+        "ansible_user": "cloud-user",
+        "ansible_port": 22,
+        "ansible_ssh_private_key_file": "/foo/bar",
+    }
+
+    x = {
+        "address": "172.16.0.2",
+        "user": "cloud-user",
+        "port": 22,
+        "identity_file": "/foo/bar",
+    }
+    assert x == _instance._get_inventory_login_options("foo")
+
+
+def test_get_inventory_login_options_partial_vars(  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
+    mocker: MockerFixture,
+    _instance,  # noqa: PT019
+):
+    m = mocker.patch("molecule.driver.delegated.Delegated._run_ansible_inventory")
+    m.return_value = {"ansible_host": "172.16.0.2"}
+
+    assert _instance._get_inventory_login_options("foo") == {"address": "172.16.0.2"}
+
+
+def test_get_inventory_login_options_returns_empty_dict_when_lookup_fails(  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
+    mocker: MockerFixture,
+    _instance,  # noqa: PT019
+):
+    m = mocker.patch("molecule.driver.delegated.Delegated._run_ansible_inventory")
+    m.return_value = None
+
+    assert _instance._get_inventory_login_options("foo") == {}
+
+
+def test_get_ansible_native_hosts_returns_sorted_hostvars_keys(  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
+    mocker: MockerFixture,
+    _instance,  # noqa: PT019
+):
+    m = mocker.patch("molecule.driver.delegated.Delegated._run_ansible_inventory")
+    m.return_value = {
+        "_meta": {
+            "hostvars": {
+                "instance-2": {},
+                "instance-1": {},
+            },
+        },
+    }
+
+    assert _instance.get_ansible_native_hosts() == ["instance-1", "instance-2"]
+
+
+def test_get_ansible_native_hosts_returns_empty_list_when_lookup_fails(  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
+    mocker: MockerFixture,
+    _instance,  # noqa: PT019
+):
+    m = mocker.patch("molecule.driver.delegated.Delegated._run_ansible_inventory")
+    m.return_value = None
+
+    assert _instance.get_ansible_native_hosts() == []
+
+
+@pytest.mark.parametrize(
+    "config_instance",
+    ["_driver_managed_section_data"],  # noqa: PT007
+    indirect=True,
+)
+def test_login_options_falls_back_to_inventory_on_stop_iteration(  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
+    mocker: MockerFixture,
+    _instance,  # noqa: PT019
+):
+    mocker.patch(
+        "molecule.driver.delegated.Delegated._get_instance_config",
+        side_effect=StopIteration,
+    )
+    m = mocker.patch("molecule.driver.delegated.Delegated._get_inventory_login_options")
+    m.return_value = {"address": "172.16.0.2", "user": "cloud-user"}
+
+    x = {"instance": "foo", "address": "172.16.0.2", "user": "cloud-user"}
+    assert x == _instance.login_options("foo")
+    m.assert_called_once_with("foo")
+
+
+@pytest.mark.parametrize(
+    "config_instance",
+    ["_driver_managed_section_data"],  # noqa: PT007
+    indirect=True,
+)
+def test_login_options_falls_back_to_inventory_on_os_error(  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
+    mocker: MockerFixture,
+    _instance,  # noqa: PT019
+):
+    mocker.patch(
+        "molecule.driver.delegated.Delegated._get_instance_config",
+        side_effect=OSError,
+    )
+    m = mocker.patch("molecule.driver.delegated.Delegated._get_inventory_login_options")
+    m.return_value = {}
+
+    assert _instance.login_options("foo") == {"instance": "foo"}
+    m.assert_called_once_with("foo")
+
+
+@pytest.mark.parametrize(
+    "config_instance",
+    ["_molecule_data_native"],  # noqa: PT007
+    indirect=True,
+)
+def test_status_falls_back_to_ansible_native_hosts_when_no_platforms(  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
+    mocker: MockerFixture,
+    _instance,  # noqa: PT019
+):
+    assert _instance._config.platforms.instances == []
+
+    mocker.patch(
+        "molecule.driver.delegated.Delegated.get_ansible_native_hosts",
+        return_value=["instance-2", "instance-1"],
+    )
+
+    result = _instance.status()
+
+    assert [s.instance_name for s in result] == ["instance-2", "instance-1"]
+
+
+@pytest.mark.parametrize(
+    "config_instance",
+    ["_molecule_data_native"],  # noqa: PT007
+    indirect=True,
+)
+def test_status_falls_back_to_blank_placeholder_when_inventory_empty(  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
+    mocker: MockerFixture,
+    _instance,  # noqa: PT019
+):
+    mocker.patch(
+        "molecule.driver.delegated.Delegated.get_ansible_native_hosts",
+        return_value=[],
+    )
+
+    result = _instance.status()
+
+    assert [s.instance_name for s in result] == [""]

--- a/tests/unit/driver/test_delegated.py
+++ b/tests/unit/driver/test_delegated.py
@@ -409,6 +409,68 @@ def test_ansible_inventory_args_includes_extra_inventory_args(  # type: ignore[n
     ]
 
 
+def test_ansible_inventory_args_includes_split_inventory_flag_and_value(  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
+    mocker: MockerFixture,
+    _instance,  # noqa: PT019
+):
+    mocker.patch.object(
+        type(_instance._config.provisioner),
+        "ansible_args",
+        new_callable=mocker.PropertyMock,
+        return_value=["--inventory", "/extra/inventory", "--diff"],
+    )
+
+    args = _instance._ansible_inventory_args()
+
+    assert args == [
+        "--inventory",
+        _instance._config.provisioner.inventory_directory,
+        "--inventory",
+        "/extra/inventory",
+    ]
+
+
+def test_ansible_inventory_args_includes_split_short_flag_and_value(  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
+    mocker: MockerFixture,
+    _instance,  # noqa: PT019
+):
+    mocker.patch.object(
+        type(_instance._config.provisioner),
+        "ansible_args",
+        new_callable=mocker.PropertyMock,
+        return_value=["-i", "/extra/inventory"],
+    )
+
+    args = _instance._ansible_inventory_args()
+
+    assert args == [
+        "--inventory",
+        _instance._config.provisioner.inventory_directory,
+        "-i",
+        "/extra/inventory",
+    ]
+
+
+def test_ansible_inventory_args_keeps_trailing_inventory_flag_with_no_value(  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
+    mocker: MockerFixture,
+    _instance,  # noqa: PT019
+):
+    mocker.patch.object(
+        type(_instance._config.provisioner),
+        "ansible_args",
+        new_callable=mocker.PropertyMock,
+        return_value=["--diff", "--inventory"],
+    )
+
+    args = _instance._ansible_inventory_args()
+
+    assert args == [
+        "--inventory",
+        _instance._config.provisioner.inventory_directory,
+        "--inventory",
+    ]
+
+
 def test_run_ansible_inventory_returns_parsed_json(  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
     mocker: MockerFixture,
     _instance,  # noqa: PT019
@@ -472,6 +534,33 @@ def test_run_ansible_inventory_returns_none_when_binary_missing(  # type: ignore
 
     assert result is None
     assert "ansible-inventory" in caplog.text
+
+
+def test_run_ansible_inventory_returns_none_on_timeout(  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
+    caplog: pytest.LogCaptureFixture,
+    mocker: MockerFixture,
+    _instance,  # noqa: PT019
+):
+    m = mocker.patch("subprocess.run")
+    m.side_effect = subprocess.TimeoutExpired(cmd=["ansible-inventory"], timeout=30)
+
+    with caplog.at_level("DEBUG"):
+        result = _instance._run_ansible_inventory(["--list"])
+
+    assert result is None
+    assert "timed out" in caplog.text
+
+
+def test_run_ansible_inventory_passes_timeout_to_subprocess_run(  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
+    mocker: MockerFixture,
+    _instance,  # noqa: PT019
+):
+    m = mocker.patch("subprocess.run")
+    m.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="{}")
+
+    _instance._run_ansible_inventory(["--list"])
+
+    assert m.call_args.kwargs["timeout"] == 30  # noqa: PLR2004
 
 
 def test_get_inventory_login_options_maps_ansible_vars(  # type: ignore[no-untyped-def]  # noqa: ANN201, D103


### PR DESCRIPTION
## Summary

Ansible-native scenarios (no `platforms:` declared, instance lifecycle managed entirely by custom `create.yml`/`destroy.yml`) left `molecule login` and `molecule list` non-functional — both relied solely on the static `platforms:` list, which these scenarios don't have.

This adds a fallback: when no platforms are configured, both commands query the real inventory via `ansible-inventory`, reusing the exact same `--inventory` sources `ansible-playbook` itself is invoked with. No new molecule-specific config file is required — connection details already present in your inventory (e.g. written by `create.yml`) are used directly.

## Changes

- `driver/delegated.py` — resolve the same `--inventory` sources as `ansible-playbook`; add `ansible-inventory`-backed host discovery (`get_ansible_native_hosts`) and login-option resolution (`_get_inventory_login_options`), used as a fallback when `instance_config.yml` has no entry for the instance.
- `driver/base.py` — `status()` reports real host names from the inventory instead of a single blank placeholder when no platforms are configured.
- `command/login.py` — `execute()`/`_get_hostname()` use the same inventory fallback; clearer error messages when no hosts can be found by either mechanism.
- **Tests** — unit coverage for all of the above, including `ansible-inventory` subprocess success/failure handling.
- **Docs** — new "Logging Into / Listing Instances" section in `docs/ansible-native.md`, plus notes on the existing container/cloud examples flagging that dynamically-assigned connection details must be persisted to a `host_vars` file (not just registered as in-play facts) to be discoverable by `login`/`list`.

## Backward compatibility

`instance_config.yml` is still checked first if a create playbook populates it — the inventory query only kicks in as a fallback, so existing non-native scenarios are unaffected.

## Testing

Verified end-to-end against a real ansible-native scenario (custom libvirt-based instance lifecycle): confirmed `molecule list`/`molecule login` correctly resolve the real instance name and connect over SSH, both with and without `instance_config.yml` present. Full unit suite passes (`53` new/updated tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inventory-based host discovery for ansible-native flows without static platform instances, enabling `molecule login` and `molecule list` to use runtime-resolved connection details.
* **Bug Fixes**
  * Improved handling when hosts are unavailable or `--host` is specified.
  * Added clearer errors when SSH connection details cannot be determined.
* **Documentation**
  * Documented persisting runtime connection details and inventory lookup behavior.
* **Tests**
  * Expanded coverage for host discovery, inventory parsing, mapping, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->