### PR TITLE
fix: report a clear error for unparseable molecule.yml instead of a traceback

### DIFF
--- a/src/molecule/click_cfg.py
+++ b/src/molecule/click_cfg.py
@@ -618,7 +618,7 @@ def _handle_immediate_exit(exc: ImmediateExit) -> NoReturn:
         logger.info(exc.message)
     else:
         debug_mode = util.is_debug_mode(click.get_current_context(silent=True))
-        logger.exception(exc.message, exc_info=debug_mode)
+        logger.error(exc.message, exc_info=debug_mode)
 
     util.sysexit(code=exc.code)
 
@@ -635,7 +635,7 @@ def _handle_molecule_error(exc: MoleculeError) -> NoReturn:
     """
     logger = logging.getLogger(__name__)
     if util.is_debug_mode(click.get_current_context(silent=True)):
-        logger.exception(exc.message or "Molecule encountered an error.")
+        logger.error(exc.message or "Molecule encountered an error.", exc_info=exc)
     elif not exc.message:
         # A message-less MoleculeError (e.g. a lock timeout) logs nothing on construction.
         logger.error("Molecule failed with exit code %s.", exc.code)

--- a/src/molecule/click_cfg.py
+++ b/src/molecule/click_cfg.py
@@ -12,7 +12,7 @@ import logging
 import os
 
 from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, NoReturn, cast
 
 import click
 
@@ -21,7 +21,7 @@ from molecule.ansi_output import should_do_markup
 from molecule.api import drivers
 from molecule.config import MOLECULE_PARALLEL
 from molecule.constants import MOLECULE_DEFAULT_SCENARIO_NAME, MOLECULE_PLATFORM_NAME
-from molecule.exceptions import ImmediateExit
+from molecule.exceptions import ImmediateExit, MoleculeError
 
 
 if TYPE_CHECKING:
@@ -607,6 +607,42 @@ def click_group_ex() -> ClickGroup:
     )
 
 
+def _handle_immediate_exit(exc: ImmediateExit) -> NoReturn:
+    """Log an ``ImmediateExit`` and terminate with its exit code.
+
+    Args:
+        exc: The raised ImmediateExit carrying the message and exit code.
+    """
+    logger = logging.getLogger(__name__)
+    if exc.code == 0:
+        logger.info(exc.message)
+    else:
+        debug_mode = util.is_debug_mode(click.get_current_context(silent=True))
+        logger.exception(exc.message, exc_info=debug_mode)
+
+    util.sysexit(code=exc.code)
+
+
+def _handle_molecule_error(exc: MoleculeError) -> NoReturn:
+    """Log a ``MoleculeError`` cleanly and terminate with its exit code.
+
+    MoleculeError already logs its message at CRITICAL on construction, so this
+    exits without letting the exception bubble up as a traceback. The full
+    traceback is still surfaced under ``--debug`` to aid troubleshooting.
+
+    Args:
+        exc: The raised MoleculeError carrying an optional message and exit code.
+    """
+    logger = logging.getLogger(__name__)
+    if util.is_debug_mode(click.get_current_context(silent=True)):
+        logger.exception(exc.message or "Molecule encountered an error.")
+    elif not exc.message:
+        # A message-less MoleculeError (e.g. a lock timeout) logs nothing on construction.
+        logger.error("Molecule failed with exit code %s.", exc.code)
+
+    util.sysexit(code=exc.code)
+
+
 def click_command_ex(name: str | None = None) -> Callable[[Callable[..., Any]], click.Command]:
     """Return extended version of click.command() with immediate exit exception handling.
 
@@ -623,20 +659,9 @@ def click_command_ex(name: str | None = None) -> Callable[[Callable[..., Any]], 
             try:
                 return func(*args, **kwargs)
             except ImmediateExit as exc:
-                logger = logging.getLogger(__name__)
-
-                # Check if debug mode is enabled
-                ctx = click.get_current_context(silent=True)
-                debug_mode = False
-                if ctx and ctx.obj and isinstance(ctx.obj, dict):
-                    debug_mode = ctx.obj.get("args", {}).get("debug", False)
-
-                if exc.code == 0:
-                    logger.info(exc.message)
-                else:
-                    logger.exception(exc.message, exc_info=debug_mode)
-
-                util.sysexit(code=exc.code)
+                _handle_immediate_exit(exc)
+            except MoleculeError as exc:
+                _handle_molecule_error(exc)
 
         # Apply the click.command decorator to the wrapper
         return click.command(

--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -42,7 +42,7 @@ from wcmatch import glob
 
 from molecule import config, logger, text, util
 from molecule.constants import MOLECULE_COLLECTION_ROOT, MOLECULE_DEFAULT_SCENARIO_NAME
-from molecule.exceptions import MoleculeError, ScenarioFailureError
+from molecule.exceptions import ConfigLoadError, MoleculeError, ScenarioFailureError
 from molecule.reporting.definitions import ScenarioResults
 from molecule.reporting.rendering import report
 from molecule.scenarios import Scenarios
@@ -197,6 +197,9 @@ def execute_cmdline_scenarios(
         command_args: dict of command arguments, including the target
         ansible_args: Optional tuple of arguments to pass to the `ansible-playbook` command
         excludes: Name of scenarios to not run.
+
+    Raises:
+        ConfigLoadError: If the default scenario is present but cannot be parsed.
     """
     if excludes is None:
         excludes = []
@@ -229,6 +232,9 @@ def execute_cmdline_scenarios(
     default_config = None
     try:
         default_config = get_configs(args, command_args, ansible_args, default_glob)[0]
+    except ConfigLoadError:
+        # A default that is present but fails to parse is a real error, not absent.
+        raise
     except MoleculeError:
         # Use a generic logger for this since it's not tied to a specific scenario
         logging.getLogger(__name__).info("default scenario not found, disabling shared state.")

--- a/src/molecule/config.py
+++ b/src/molecule/config.py
@@ -571,7 +571,7 @@ class Config:
             with open(base_config) as stream:  # noqa: PTH123
                 s = stream.read()
                 interpolated_config = self._interpolate(s, env, keep_string)
-                config_data = util.safe_load(interpolated_config)
+                config_data = util.safe_load(interpolated_config, base_config)
                 user_config_files.append((base_config, config_data))
 
         # Load molecule.yml
@@ -579,7 +579,7 @@ class Config:
             with open(self.molecule_file) as stream:  # noqa: PTH123
                 s = stream.read()
                 interpolated_config = self._interpolate(s, env, keep_string)
-                config_data = util.safe_load(interpolated_config)
+                config_data = util.safe_load(interpolated_config, self.molecule_file)
                 user_config_files.append((self.molecule_file, config_data))
 
         # Step 3: Debug log legacy keys that will be migrated

--- a/src/molecule/exceptions.py
+++ b/src/molecule/exceptions.py
@@ -37,6 +37,10 @@ class MoleculeError(Exception):
             LOG.critical(message, extra={"highlighter": False})
 
 
+class ConfigLoadError(MoleculeError):
+    """A configuration file was found but could not be parsed, distinct from a missing one."""
+
+
 class ScenarioFailureError(MoleculeError):
     """Details about a scenario that failed."""
 

--- a/src/molecule/util.py
+++ b/src/molecule/util.py
@@ -43,7 +43,7 @@ from molecule.constants import (
     MOLECULE_HEADER,
     MOLECULE_ROOT,
 )
-from molecule.exceptions import MoleculeError
+from molecule.exceptions import ConfigLoadError, MoleculeError
 
 
 if TYPE_CHECKING:
@@ -136,19 +136,27 @@ def sysexit_with_message(
     sysexit(code)
 
 
+def is_debug_mode(ctx: click.Context | None) -> bool:
+    """Return whether ``--debug`` is set on the given click context.
+
+    Args:
+        ctx: The active click context, or None if unavailable.
+
+    Returns:
+        True when debug mode is enabled, otherwise False.
+    """
+    if ctx and ctx.obj and isinstance(ctx.obj, dict):
+        return bool(ctx.obj.get("args", {}).get("debug", False))
+    return False
+
+
 def sysexit_from_exception(exc: MoleculeError) -> NoReturn:
     """Wrapper for sysexit to display messages and use return code from an exception.
 
     Args:
         exc: The exception to determine exit values from.
     """
-    # Check if debug mode is enabled
-    ctx = click.get_current_context(silent=True)
-    debug_mode = False
-    if ctx and ctx.obj and isinstance(ctx.obj, dict):
-        debug_mode = ctx.obj.get("args", {}).get("debug", False)
-
-    if debug_mode:
+    if is_debug_mode(click.get_current_context(silent=True)):
         # Show full traceback in debug mode for failures
         LOG.exception(exc.message)
         sysexit(exc.code)
@@ -267,27 +275,56 @@ def safe_dump(data: object, explicit_start: bool = True) -> str:  # noqa: FBT001
     )
 
 
-def safe_load(string: str | TextIOWrapper):  # type: ignore[no-untyped-def]  # noqa: ANN201
+def _friendly_yaml_error(exc: yaml.YAMLError, filename: str | Path | None) -> str:
+    """Build a readable message for a YAML parse failure.
+
+    Args:
+        exc: The YAML error raised while parsing.
+        filename: Source file name, when known.
+
+    Returns:
+        An error message describing the file, location, and problem.
+    """
+    source = f"'{filename}'" if filename else "the YAML content"
+    mark = getattr(exc, "problem_mark", None)
+    location = f" (line {mark.line + 1}, column {mark.column + 1})" if mark else ""
+
+    problem = getattr(exc, "problem", "") or ""
+    if isinstance(exc, yaml.constructor.ConstructorError) and "constructor for the tag" in problem:
+        tag = problem.rsplit(" ", 1)[-1].strip("'\"")
+        return (
+            f"Unable to load {source}{location}: the '{tag}' YAML tag is not "
+            "supported in Molecule configuration files. Remove the tag from the file."
+        )
+
+    # PyYAML splits some reasons across context and problem; keep both.
+    context = getattr(exc, "context", "") or ""
+    detail = f"{context}, {problem}" if context and problem else (problem or context or str(exc))
+    return f"Unable to load {source}{location}: {detail}"
+
+
+def safe_load(string: str | TextIOWrapper, filename: str | Path | None = None) -> Any:  # noqa: ANN401
     """Parse the provided string returns a dict.
 
     Args:
         string: A string to be parsed.
+        filename: Optional source file name, used only to make the error
+            message point at the offending file when parsing fails.
 
     Returns:
-        A dict of the parsed string.
-
+        The parsed YAML (dict, list, scalar, or {} if empty).
 
     Raises:
-        MoleculeError: when YAML loading fails.
+        ConfigLoadError: when YAML loading fails.
     """
     try:
         return yaml.safe_load(string) or {}
-    except yaml.scanner.ScannerError as e:
-        raise MoleculeError(str(e)) from None
-    return {}
+    except yaml.YAMLError as e:
+        msg = _friendly_yaml_error(e, filename)
+        raise ConfigLoadError(msg) from e
 
 
-def safe_load_file(filename: str | Path):  # type: ignore[no-untyped-def]  # noqa: ANN201
+def safe_load_file(filename: str | Path) -> Any:  # noqa: ANN401
     """Parse the provided YAML file and returns a dict.
 
     Args:
@@ -300,7 +337,7 @@ def safe_load_file(filename: str | Path):  # type: ignore[no-untyped-def]  # noq
         filename = Path(filename)
 
     with filename.open() as stream:
-        return safe_load(stream)
+        return safe_load(stream, filename)
 
 
 def instance_with_scenario_name(instance_name: str, scenario_name: str) -> str:

--- a/tests/unit/command/test_base.py
+++ b/tests/unit/command/test_base.py
@@ -18,6 +18,8 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 
+# pylint: disable=too-many-lines
+
 from __future__ import annotations
 
 import os
@@ -31,7 +33,12 @@ import pytest
 
 from molecule import config, util
 from molecule.command import base
-from molecule.exceptions import ImmediateExit, MoleculeError, ScenarioFailureError
+from molecule.exceptions import (
+    ConfigLoadError,
+    ImmediateExit,
+    MoleculeError,
+    ScenarioFailureError,
+)
 from molecule.shell import main
 
 
@@ -245,6 +252,34 @@ def test_execute_cmdline_scenarios(patched_execute_scenario: MagicMock) -> None:
 
     scenario_count = 1
     assert patched_execute_scenario.call_count == scenario_count
+
+
+def test_execute_cmdline_scenarios_corrupt_default_surfaces(
+    mocker: MockerFixture,
+) -> None:
+    """A default molecule.yml that fails to parse surfaces instead of exiting cleanly.
+
+    A ConfigLoadError raised while loading the default scenario must propagate,
+    not be swallowed as "default scenario not found" (which would disable shared
+    state and let an otherwise-valid run continue to a zero exit).
+
+    Args:
+        mocker: pytest-mock fixture for mocking.
+    """
+    requested = mocker.MagicMock()
+    requested.scenario.name = "smoke"
+    # First get_configs call resolves the requested scenario; the second (the
+    # default scenario) fails to parse.
+    mocker.patch.object(
+        base,
+        "get_configs",
+        side_effect=[[requested], ConfigLoadError("Unable to load molecule.yml")],
+    )
+
+    args: MoleculeArgs = {}
+    command_args: CommandArgs = {"subcommand": "test"}
+    with pytest.raises(ConfigLoadError):
+        base.execute_cmdline_scenarios(["smoke"], args, command_args)
 
 
 @pytest.mark.usefixtures("config_instance")

--- a/tests/unit/test_click_command_ex.py
+++ b/tests/unit/test_click_command_ex.py
@@ -23,7 +23,7 @@ def test_click_command_ex_with_immediate_exit_success(mocker: MockerFixture) -> 
         mocker: pytest-mock fixture for mocking.
     """
     # Mock the logger and util.sysexit
-    mock_logger = mocker.patch("logging.getLogger")
+    mock_logger = mocker.patch("molecule.click_cfg.logging.getLogger")
     mock_sysexit = mocker.patch("molecule.util.sysexit")
 
     # Create a command that raises ImmediateExit with success code
@@ -42,10 +42,8 @@ def test_click_command_ex_with_immediate_exit_success(mocker: MockerFixture) -> 
     runner.invoke(test_command, [])
 
     # Verify logging and sysexit were called correctly (info for success)
-    mock_logger.assert_called_once()
     mock_logger.return_value.info.assert_called_once_with("Operation completed successfully")
     mock_logger.return_value.error.assert_not_called()
-    mock_logger.return_value.exception.assert_not_called()
     mock_sysexit.assert_called_once_with(code=0)
 
 
@@ -56,14 +54,9 @@ def test_click_command_ex_with_immediate_exit_failure(mocker: MockerFixture) -> 
         mocker: pytest-mock fixture for mocking.
     """
     # Mock the logger and util.sysexit
-    mock_logger = mocker.patch("logging.getLogger")
+    mock_logger = mocker.patch("molecule.click_cfg.logging.getLogger")
     mock_sysexit = mocker.patch("molecule.util.sysexit")
-    mock_get_current_context = mocker.patch("click.get_current_context")
-
-    # Mock context without debug mode
-    mock_ctx = mocker.MagicMock()
-    mock_ctx.obj = {"args": {"debug": False}}
-    mock_get_current_context.return_value = mock_ctx
+    mocker.patch("molecule.click_cfg.util.is_debug_mode", return_value=False)
 
     # Create a command that raises ImmediateExit with failure code
     @click_command_ex()
@@ -81,10 +74,8 @@ def test_click_command_ex_with_immediate_exit_failure(mocker: MockerFixture) -> 
     runner = CliRunner()
     runner.invoke(test_command, [])
 
-    # Verify logging and sysexit were called correctly (exception with exc_info=False in non-debug)
-    mock_logger.assert_called_once()
-    mock_logger.return_value.exception.assert_called_once_with("Operation failed", exc_info=False)
-    mock_logger.return_value.error.assert_not_called()
+    # Verify logging and sysexit were called correctly (error with exc_info=False in non-debug)
+    mock_logger.return_value.error.assert_called_once_with("Operation failed", exc_info=False)
     mock_logger.return_value.info.assert_not_called()
     mock_sysexit.assert_called_once_with(code=42)
 
@@ -96,14 +87,9 @@ def test_click_command_ex_with_immediate_exit_failure_debug_mode(mocker: MockerF
         mocker: pytest-mock fixture for mocking.
     """
     # Mock the logger and util.sysexit
-    mock_logger = mocker.patch("logging.getLogger")
+    mock_logger = mocker.patch("molecule.click_cfg.logging.getLogger")
     mock_sysexit = mocker.patch("molecule.util.sysexit")
-    mock_get_current_context = mocker.patch("click.get_current_context")
-
-    # Mock context with debug mode enabled
-    mock_ctx = mocker.MagicMock()
-    mock_ctx.obj = {"args": {"debug": True}}
-    mock_get_current_context.return_value = mock_ctx
+    mocker.patch("molecule.click_cfg.util.is_debug_mode", return_value=True)
 
     # Create a command that raises ImmediateExit with failure code
     @click_command_ex()
@@ -121,10 +107,8 @@ def test_click_command_ex_with_immediate_exit_failure_debug_mode(mocker: MockerF
     runner = CliRunner()
     runner.invoke(test_command, [])
 
-    # Verify logging and sysexit were called correctly (exception with full traceback in debug mode)
-    mock_logger.assert_called_once()
-    mock_logger.return_value.exception.assert_called_once_with("Operation failed", exc_info=True)
-    mock_logger.return_value.error.assert_not_called()
+    # Verify logging and sysexit were called correctly (error with full traceback in debug mode)
+    mock_logger.return_value.error.assert_called_once_with("Operation failed", exc_info=True)
     mock_logger.return_value.info.assert_not_called()
     mock_sysexit.assert_called_once_with(code=42)
 
@@ -136,12 +120,9 @@ def test_click_command_ex_failure_no_context(mocker: MockerFixture) -> None:
         mocker: pytest-mock fixture for mocking.
     """
     # Mock the logger and util.sysexit
-    mock_logger = mocker.patch("logging.getLogger")
+    mock_logger = mocker.patch("molecule.click_cfg.logging.getLogger")
     mock_sysexit = mocker.patch("molecule.util.sysexit")
-    mock_get_current_context = mocker.patch("click.get_current_context")
-
-    # Mock no context available
-    mock_get_current_context.return_value = None
+    mocker.patch("molecule.click_cfg.util.is_debug_mode", return_value=False)
 
     # Create a command that raises ImmediateExit with failure code
     @click_command_ex()
@@ -159,10 +140,8 @@ def test_click_command_ex_failure_no_context(mocker: MockerFixture) -> None:
     runner = CliRunner()
     runner.invoke(test_command, [])
 
-    # Verify it defaults to non-debug behavior (exception with exc_info=False)
-    mock_logger.assert_called_once()
-    mock_logger.return_value.exception.assert_called_once_with("Operation failed", exc_info=False)
-    mock_logger.return_value.error.assert_not_called()
+    # Verify it defaults to non-debug behavior (error with exc_info=False)
+    mock_logger.return_value.error.assert_called_once_with("Operation failed", exc_info=False)
     mock_logger.return_value.info.assert_not_called()
     mock_sysexit.assert_called_once_with(code=42)
 
@@ -176,13 +155,9 @@ def test_click_command_ex_with_molecule_error(mocker: MockerFixture) -> None:
     Args:
         mocker: pytest-mock fixture for mocking.
     """
-    mock_logger = mocker.patch("logging.getLogger")
+    mock_logger = mocker.patch("molecule.click_cfg.logging.getLogger")
     mock_sysexit = mocker.patch("molecule.util.sysexit")
-    mock_get_current_context = mocker.patch("click.get_current_context")
-
-    mock_ctx = mocker.MagicMock()
-    mock_ctx.obj = {"args": {"debug": False}}
-    mock_get_current_context.return_value = mock_ctx
+    mocker.patch("molecule.click_cfg.util.is_debug_mode", return_value=False)
 
     @click_command_ex()
     def test_command() -> None:
@@ -198,7 +173,6 @@ def test_click_command_ex_with_molecule_error(mocker: MockerFixture) -> None:
     runner.invoke(test_command, [])
 
     mock_logger.return_value.error.assert_not_called()
-    mock_logger.return_value.exception.assert_not_called()
     mock_sysexit.assert_called_once_with(code=3)
 
 
@@ -211,13 +185,9 @@ def test_click_command_ex_with_message_less_molecule_error(mocker: MockerFixture
     Args:
         mocker: pytest-mock fixture for mocking.
     """
-    mock_logger = mocker.patch("logging.getLogger")
+    mock_logger = mocker.patch("molecule.click_cfg.logging.getLogger")
     mock_sysexit = mocker.patch("molecule.util.sysexit")
-    mock_get_current_context = mocker.patch("click.get_current_context")
-
-    mock_ctx = mocker.MagicMock()
-    mock_ctx.obj = {"args": {"debug": False}}
-    mock_get_current_context.return_value = mock_ctx
+    mocker.patch("molecule.click_cfg.util.is_debug_mode", return_value=False)
 
     @click_command_ex()
     def test_command() -> None:
@@ -244,13 +214,9 @@ def test_click_command_ex_with_molecule_error_debug_mode(mocker: MockerFixture) 
     Args:
         mocker: pytest-mock fixture for mocking.
     """
-    mock_logger = mocker.patch("logging.getLogger")
+    mock_logger = mocker.patch("molecule.click_cfg.logging.getLogger")
     mock_sysexit = mocker.patch("molecule.util.sysexit")
-    mock_get_current_context = mocker.patch("click.get_current_context")
-
-    mock_ctx = mocker.MagicMock()
-    mock_ctx.obj = {"args": {"debug": True}}
-    mock_get_current_context.return_value = mock_ctx
+    mocker.patch("molecule.click_cfg.util.is_debug_mode", return_value=True)
 
     @click_command_ex()
     def test_command() -> None:
@@ -265,7 +231,10 @@ def test_click_command_ex_with_molecule_error_debug_mode(mocker: MockerFixture) 
     runner = CliRunner()
     runner.invoke(test_command, [])
 
-    mock_logger.return_value.exception.assert_called_once_with("Unable to load molecule.yml")
+    mock_logger.return_value.error.assert_called_once()
+    call_args = mock_logger.return_value.error.call_args
+    assert call_args[0][0] == "Unable to load molecule.yml"
+    assert isinstance(call_args[1]["exc_info"], MoleculeError)
     mock_sysexit.assert_called_once_with(code=3)
 
 

--- a/tests/unit/test_click_command_ex.py
+++ b/tests/unit/test_click_command_ex.py
@@ -9,7 +9,7 @@ import click
 from click.testing import CliRunner
 
 from molecule.click_cfg import click_command_ex
-from molecule.exceptions import ImmediateExit
+from molecule.exceptions import ImmediateExit, MoleculeError
 
 
 if TYPE_CHECKING:
@@ -165,6 +165,108 @@ def test_click_command_ex_failure_no_context(mocker: MockerFixture) -> None:
     mock_logger.return_value.error.assert_not_called()
     mock_logger.return_value.info.assert_not_called()
     mock_sysexit.assert_called_once_with(code=42)
+
+
+def test_click_command_ex_with_molecule_error(mocker: MockerFixture) -> None:
+    """A MoleculeError exits with its code without an extra log line.
+
+    MoleculeError logs its message at CRITICAL on construction, so the handler
+    should not re-log it in non-debug mode.
+
+    Args:
+        mocker: pytest-mock fixture for mocking.
+    """
+    mock_logger = mocker.patch("logging.getLogger")
+    mock_sysexit = mocker.patch("molecule.util.sysexit")
+    mock_get_current_context = mocker.patch("click.get_current_context")
+
+    mock_ctx = mocker.MagicMock()
+    mock_ctx.obj = {"args": {"debug": False}}
+    mock_get_current_context.return_value = mock_ctx
+
+    @click_command_ex()
+    def test_command() -> None:
+        """Test command that raises MoleculeError.
+
+        Raises:
+            MoleculeError: Always raised for testing.
+        """
+        msg = "Unable to load molecule.yml"
+        raise MoleculeError(msg, code=3)
+
+    runner = CliRunner()
+    runner.invoke(test_command, [])
+
+    mock_logger.return_value.error.assert_not_called()
+    mock_logger.return_value.exception.assert_not_called()
+    mock_sysexit.assert_called_once_with(code=3)
+
+
+def test_click_command_ex_with_message_less_molecule_error(mocker: MockerFixture) -> None:
+    """A message-less MoleculeError still reports the failure before exiting.
+
+    Such an error (for example a lock timeout carrying only an exit code) logs
+    nothing on construction, so the handler must surface it.
+
+    Args:
+        mocker: pytest-mock fixture for mocking.
+    """
+    mock_logger = mocker.patch("logging.getLogger")
+    mock_sysexit = mocker.patch("molecule.util.sysexit")
+    mock_get_current_context = mocker.patch("click.get_current_context")
+
+    mock_ctx = mocker.MagicMock()
+    mock_ctx.obj = {"args": {"debug": False}}
+    mock_get_current_context.return_value = mock_ctx
+
+    @click_command_ex()
+    def test_command() -> None:
+        """Test command that raises a message-less MoleculeError.
+
+        Raises:
+            MoleculeError: Always raised for testing.
+        """
+        raise MoleculeError(code=7)
+
+    runner = CliRunner()
+    runner.invoke(test_command, [])
+
+    mock_logger.return_value.error.assert_called_once_with(
+        "Molecule failed with exit code %s.",
+        7,
+    )
+    mock_sysexit.assert_called_once_with(code=7)
+
+
+def test_click_command_ex_with_molecule_error_debug_mode(mocker: MockerFixture) -> None:
+    """In debug mode a MoleculeError shows the full traceback before exiting.
+
+    Args:
+        mocker: pytest-mock fixture for mocking.
+    """
+    mock_logger = mocker.patch("logging.getLogger")
+    mock_sysexit = mocker.patch("molecule.util.sysexit")
+    mock_get_current_context = mocker.patch("click.get_current_context")
+
+    mock_ctx = mocker.MagicMock()
+    mock_ctx.obj = {"args": {"debug": True}}
+    mock_get_current_context.return_value = mock_ctx
+
+    @click_command_ex()
+    def test_command() -> None:
+        """Test command that raises MoleculeError.
+
+        Raises:
+            MoleculeError: Always raised for testing.
+        """
+        msg = "Unable to load molecule.yml"
+        raise MoleculeError(msg, code=3)
+
+    runner = CliRunner()
+    runner.invoke(test_command, [])
+
+    mock_logger.return_value.exception.assert_called_once_with("Unable to load molecule.yml")
+    mock_sysexit.assert_called_once_with(code=3)
 
 
 def test_click_command_ex_normal_execution() -> None:

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -36,7 +36,7 @@ import yaml
 
 from molecule import util
 from molecule.constants import MOLECULE_COLLECTION_GLOB, MOLECULE_HEADER
-from molecule.exceptions import MoleculeError
+from molecule.exceptions import ConfigLoadError, MoleculeError
 
 
 if TYPE_CHECKING:
@@ -251,6 +251,104 @@ def test_safe_load_exits_when_cannot_parse() -> None:  # noqa: D103
         util.safe_load(data)
 
     assert e.value.code == 1
+
+
+def test_safe_load_exits_on_unsupported_yaml_tag() -> None:
+    """An unsupported YAML tag raises a MoleculeError naming the tag.
+
+    Regression test for a `!unsafe` (or any unknown) tag causing an unhandled
+    traceback rather than a readable error.
+    """
+    data = 'foo: !unsafe "{{ bar }}"'
+
+    with pytest.raises(MoleculeError) as e:
+        util.safe_load(data)
+
+    assert e.value.code == 1
+    assert "!unsafe" in e.value.message
+    assert "not supported" in e.value.message
+
+
+def test_safe_load_exits_on_yaml_syntax_error() -> None:
+    """A malformed document raises a clean MoleculeError, not a traceback.
+
+    `ParserError` is not a `ScannerError`, so it previously escaped uncaught.
+    """
+    with pytest.raises(MoleculeError) as e:
+        util.safe_load("foo: [unclosed", filename="molecule.yml")
+
+    assert e.value.code == 1
+    assert "molecule.yml" in e.value.message
+
+
+def test_safe_load_error_includes_filename() -> None:
+    """The failure message names the source file when one is provided."""
+    with pytest.raises(MoleculeError) as e:
+        util.safe_load("foo: !unsafe bar", filename="molecule.yml")
+
+    assert "molecule.yml" in e.value.message
+
+
+def test_safe_load_raises_config_load_error() -> None:
+    """A parse failure raises ConfigLoadError, still a MoleculeError for callers.
+
+    Callers that only care about "something went wrong" keep catching
+    MoleculeError, while ``command.base`` can tell a malformed file apart from
+    an absent one.
+    """
+    with pytest.raises(ConfigLoadError) as e:
+        util.safe_load("foo: !unsafe bar")
+
+    assert isinstance(e.value, MoleculeError)
+    assert e.value.code == 1
+
+
+def test_safe_load_reports_non_tag_constructor_error() -> None:
+    """A ConstructorError that is not an unknown tag keeps its own detail.
+
+    The unknown-tag message is specific to the "constructor for the tag" case;
+    any other construction failure (here an unhashable list key) must fall back
+    to PyYAML's own reason rather than claiming a tag is unsupported.
+    """
+    data = "? [1, 2]\n: value"
+
+    with pytest.raises(ConfigLoadError) as e:
+        util.safe_load(data, filename="molecule.yml")
+
+    assert "molecule.yml" in e.value.message
+    assert "unhashable" in e.value.message
+    assert "not supported" not in e.value.message
+
+
+def test_safe_load_error_includes_yaml_context() -> None:
+    """Both halves of PyYAML's reason (context and problem) reach the message.
+
+    PyYAML splits some errors across ``context`` and ``problem``; keeping only
+    one half yields a cropped, cryptic message.
+    """
+    data = "---\na: 1\n---\nb: 2\n"
+
+    with pytest.raises(ConfigLoadError) as e:
+        util.safe_load(data, filename="molecule.yml")
+
+    assert "single document" in e.value.message
+    assert "another document" in e.value.message
+
+
+def test_safe_load_file_reports_filename(tmp_path: Path) -> None:
+    """safe_load_file names the offending file and tag in its error.
+
+    Args:
+        tmp_path: pytest temporary-directory fixture.
+    """
+    bad_file = tmp_path / "molecule.yml"
+    bad_file.write_text('foo: !unsafe "{{ bar }}"')
+
+    with pytest.raises(ConfigLoadError) as e:
+        util.safe_load_file(bad_file)
+
+    assert str(bad_file) in e.value.message
+    assert "!unsafe" in e.value.message
 
 
 def test_safe_load_file(test_cache_path: Path) -> None:


### PR DESCRIPTION
Fixes #4348.

## Problem

Loading a `molecule.yml` that PyYAML's safe loader cannot parse crashes with a raw Python traceback instead of a message the user can act on. The reported case (#4348) is Ansible's `!unsafe` tag, which Molecule intentionally does not support in its own configuration but surfaced as a stack dump.

**Before (clean `upstream/main`, `molecule list` with `mypass: !unsafe "b{{c"`):**

```text
$ molecule list
[exit code: 1]
  File ".../yaml/constructor.py", line 427, in construct_undefined
    raise ConstructorError(None, None,
            "could not determine a constructor for the tag %r" % node.tag,
            node.start_mark)
yaml.constructor.ConstructorError: could not determine a constructor for the tag '!unsafe'
  in "<unicode string>", line 9, column 17:
            mypass: !unsafe "b{{c"
                    ^
```

## Root cause

`util.safe_load` caught only `yaml.scanner.ScannerError`:

```python
except yaml.scanner.ScannerError as e:
    raise MoleculeError(str(e)) from None
```

`ScannerError` is one leaf of the `yaml.YAMLError` hierarchy. An unknown tag raises `yaml.constructor.ConstructorError`, and a malformed document raises `yaml.parser.ParserError` — **neither is a `ScannerError`**, so both escaped uncaught. Separately, nothing caught `MoleculeError` at the command wrapper (`click_command_ex` handled only `ImmediateExit`), so even a deliberately raised `MoleculeError` printed a traceback, despite `MoleculeError` already logging its message at `CRITICAL` on construction.

## Fix

The one-line intent is "catch the error and print a message." Each change below is entailed by the one before it, so the diff touches more than the load site:

- **The error itself** — `util.safe_load` now catches `yaml.YAMLError` (the base class) and routes it through a small `_friendly_yaml_error` helper that reports the file, the `(line, column)`, and — for an unknown tag — names the tag in the user's terms rather than passing PyYAML's "could not determine a constructor" wording through. The source filename is threaded in from the two configuration load sites (`base_config` and `molecule.yml`), and the original error is chained (`from e`) so `--debug` still shows the cause.
- **The click wrapper had to learn to catch `MoleculeError`** — otherwise the clean error this fix raises still reaches the top of the stack as a traceback (the issue's path raises during `Config` construction, outside every existing `except MoleculeError`). It now exits with the exception's code; the full traceback is preserved under `--debug`. A message-less `MoleculeError` (for example the lock-timeout `MoleculeError(code=RC_TIMEOUT)` in `scenario.py`, which logs nothing on construction) is reported here rather than exiting silently. The two handler bodies are extracted into `_handle_immediate_exit` and `_handle_molecule_error` so the wrapper stays a small dispatch and each handler is independently testable.
- **`ConfigLoadError(MoleculeError)` + a guard in `command/base.py`** close the one behavior regression this fix would otherwise introduce. Broadening `safe_load` funnels a corrupt `default/molecule.yml` into the pre-existing `except MoleculeError` in `execute_cmdline_scenarios` that treats it as "default scenario not found, disabling shared state" — turning a loud crash into a silent `exit 0` for a run of a *different* scenario. The new subclass lets that site tell "could not parse" apart from "not present"; a genuinely absent default still just disables shared state.
- **`is_debug_mode` moved into `util`** and is now shared by `sysexit_from_exception`, which previously carried an inline copy of the same `--debug` lookup (per CodeRabbit's dedup note on this PR).
- **Typing** — `safe_load` / `safe_load_file` are annotated `-> Any` (matching `command/base.py::execute_subcommand`), dropping the blanket `# type: ignore[no-untyped-def]`; `src/` now carries no `no-untyped-def` suppressions.

**After (this branch, same input):**

```text
$ molecule list
[exit code: 1]  [python traceback present: False]
CRITICAL  Unable to load '.../molecule/default/molecule.yml' (line 9, column 17):
the '!unsafe' YAML tag is not supported in Molecule configuration files. Remove
the tag from the file.
```

## Coverage matrix

Every row below is a `molecule list` run against a generated scenario; "before" is clean `upstream/main` at `ab625b40`, "after" is this branch on top of it. Environment: molecule `26.6.1.dev9`, Python 3.14.6, ansible-core 2.20.7rc1.

| `molecule.yml` input | before (main) | after (this PR) |
| --- | --- | --- |
| `!unsafe` tag (the #4348 report) | `ConstructorError` **traceback** | clean `CRITICAL`, exit 1 |
| `!vault` tag (and any `!custom` tag) | `ConstructorError` **traceback** | clean `CRITICAL`, **names the tag**, exit 1 |
| genuine syntax error (`foo: [unclosed`) | `ParserError` **traceback** | clean `CRITICAL` with location, exit 1 |
| scanner error (`%foo`) | already clean (caught) | **unchanged** — still clean |
| valid `molecule.yml` | works, exit 0 | **unchanged** — works, exit 0 |
| any of the above with `--debug` | traceback | traceback **preserved** |

Two things worth calling out from the matrix:

1. The fix is **generic**, not special-cased to `!unsafe`. `!vault` and any custom tag hit the identical path; the message substitutes whichever tag was found. Evidence — `!vault` after the fix:
   ```text
   CRITICAL  Unable to load '.../molecule.yml' (line 9, column 17): the '!vault'
   YAML tag is not supported in Molecule configuration files. Remove the tag from
   the file.
   ```
2. A **genuine YAML syntax error also tracebacks on `main`** today (`yaml.parser.ParserError`), because it too is not a `ScannerError`. This PR fixes that case as well, without changing the already-handled `ScannerError` path:
   ```text
   # after, foo: [unclosed
   CRITICAL  Unable to load '.../molecule.yml' (line 5, column 1): expected ','
   or ']', but got '<stream end>'
   ```

## Shared-state / default-scenario behavior

The `ConfigLoadError` guard is exercised end-to-end (a valid `smoke` scenario plus a corrupt `default/molecule.yml`):

| situation | before this PR | after |
| --- | --- | --- |
| corrupt `default`, running `-s smoke` | `ConstructorError` traceback, non-zero | clean `CRITICAL`, **exit 1** (no longer a silent `exit 0`) |
| corrupt `default`, running `-s default` | traceback | clean `CRITICAL`, exit 1, no traceback |
| **absent** `default`, running `-s smoke` | exit 0, shared state disabled | **unchanged** — exit 0, shared state disabled |

## Regression / no-behavior-change checks

- Valid `molecule.yml` still lists normally (exit 0, table unchanged).
- The pre-existing `ScannerError` case still raises a clean error (existing `test_safe_load_exits_when_cannot_parse` unchanged and passing; `ConfigLoadError` is a `MoleculeError`, so every existing `except MoleculeError` still catches it).
- A genuinely absent default scenario still disables shared state silently (`test_execute_cmdline_scenarios_missing` unchanged and passing).
- `--debug` still yields the full traceback for all failure modes.

## Test / lint / type evidence

The corrupt-default guard is covered by `test_execute_cmdline_scenarios_corrupt_default_surfaces`, and the absent-default path by `test_execute_cmdline_scenarios_missing`:

```text
$ python -m pytest tests/unit/command/test_base.py::test_execute_cmdline_scenarios_corrupt_default_surfaces -v
============================= test session starts ==============================
platform linux -- Python 3.13.14, pytest-9.1.1, pluggy-1.6.0
rootdir: molecule
configfile: pyproject.toml
plugins: instafail-0.5.0, mock-3.15.1, plus-0.8.1, xdist-3.8.0
collected 1 item

tests/unit/command/test_base.py::test_execute_cmdline_scenarios_corrupt_default_surfaces PASSED [100%]

============================== 1 passed in 0.06s ===============================

$ python -m pytest tests/unit/test_util.py tests/unit/test_exceptions.py \
    tests/unit/command/test_base.py::test_execute_cmdline_scenarios_corrupt_default_surfaces \
    tests/unit/command/test_base.py::test_execute_cmdline_scenarios_missing -n auto
============================= test session starts ==============================
plugins: instafail-0.5.0, mock-3.15.1, plus-0.8.1, xdist-3.8.0
96 passed
```

Lint and type gates run through `tox -e lint` (the project's `prek` aggregator — `ruff`, `mypy`, `pydoclint`, and `pylint`):

```text
$ tox -e lint
ruff......................................................................Passed
mypy......................................................................Passed
pydoclint.................................................................Passed
pylint....................................................................Passed
```

## Notes for reviewers

- The `MoleculeError` handler in `click_command_ex` is intentionally broader than the literal issue: it makes **every** `MoleculeError` exit cleanly, not just YAML load failures. A "nice error message" that is still followed by a stack dump is not a fix. `MoleculeError` already logs at `CRITICAL` on construction, so the handler only suppresses the redundant traceback (kept under `--debug`) and exits with the exception's code. Happy to split this into its own PR if you'd prefer the YAML change to land in isolation.
- `_friendly_yaml_error` reads the unknown tag out of PyYAML's message text (guarded by a substring check, with a graceful fallback to PyYAML's own reason for any other `ConstructorError`). If you'd rather not depend on that wording, I'm happy to change it — the fallback path is covered by a test.
