### PR TITLE
fix: remove git-ignore-based scenario filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,8 +174,7 @@ cython_debug/
 
 node_modules/
 
-# There is a test for this, otherwise unknown
-# tests/b_functional/test_command.py test_w_gitignore
+# Used by tests/integration/test_command.py::test_gitignored_scenario_is_discovered
 tests/fixtures/resources/.extensions/
 
 # docs output

--- a/src/molecule/command/base.py
+++ b/src/molecule/command/base.py
@@ -23,14 +23,12 @@ from __future__ import annotations
 
 import abc
 import collections
-import contextlib
 import copy
 import fnmatch
 import importlib
 import logging
 import re
 import shutil
-import subprocess
 
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -483,35 +481,6 @@ def execute_scenario(scenario: Scenario, *, shared_state: bool = False) -> None:
             scenario._remove_scenario_state_directory()  # noqa: SLF001
 
 
-def filter_ignored_scenarios(scenario_paths: list[str]) -> list[str]:
-    """Filter out candidate scenario paths that are ignored by git.
-
-    Args:
-        scenario_paths: List of candidate scenario paths.
-
-    Returns:
-        Filtered list of scenario paths.
-    """
-    command = ["git", "check-ignore", *scenario_paths]
-
-    with contextlib.suppress(subprocess.CalledProcessError, FileNotFoundError):
-        proc = subprocess.run(
-            args=command,
-            capture_output=True,
-            check=True,
-            text=True,
-            shell=False,
-        )
-
-    try:
-        ignored = proc.stdout.splitlines()
-        paths = [candidate for candidate in scenario_paths if str(candidate) not in ignored]
-    except NameError:
-        paths = scenario_paths
-
-    return paths
-
-
 def get_configs(
     args: MoleculeArgs,
     command_args: CommandArgs,
@@ -540,7 +509,6 @@ def get_configs(
         flags=wcmatch.pathlib.GLOBSTAR | wcmatch.pathlib.BRACE | wcmatch.pathlib.DOTGLOB,
     )
 
-    scenario_paths = filter_ignored_scenarios(scenario_paths)
     configs = [
         config.Config(
             molecule_file=util.abs_path(c),

--- a/tests/integration/test_command.py
+++ b/tests/integration/test_command.py
@@ -384,44 +384,27 @@ def test_sample_collection(
 
 
 @pytest.mark.usefixtures("test_cache_path")
-@pytest.mark.parametrize(("scenario_name"), (("test_w_gitignore"), ("test_wo_gitignore")))
-def test_with_and_without_gitignore(
+def test_gitignored_scenario_is_discovered(
     monkeypatch: pytest.MonkeyPatch,
-    scenario_name: str,
     resources_folder_path: Path,
 ) -> None:
-    """Test with and without gitignore.
+    """A scenario under a git-ignored directory is discovered, not dropped.
 
     Args:
         monkeypatch: Pytest fixture.
-        scenario_name: The scenario name.
         resources_folder_path: Path to the resources folder.
     """
-    if scenario_name == "test_wo_gitignore":
-
-        def mock_return(scenario_paths: list[str]) -> list[str]:
-            return scenario_paths
-
-        monkeypatch.setattr(
-            "molecule.command.base.filter_ignored_scenarios",
-            mock_return,
-        )
-
     monkeypatch.chdir(resources_folder_path)
 
+    scenario_name = "gitignored"
     scenario_dir = resources_folder_path / ".extensions" / "molecule" / scenario_name
     scenario_dir.mkdir(parents=True, exist_ok=True)
-
-    molecule_file = scenario_dir / "molecule.yml"
-    molecule_file.touch()
+    (scenario_dir / "molecule.yml").touch()
 
     op = base.get_configs({}, {}, glob_str="**/molecule/*/molecule.yml")
 
-    names = [config.scenario.name for config in op]
-    if scenario_name == "test_w_gitignore":
-        assert scenario_name not in names
-    elif scenario_name == "test_wo_gitignore":
-        assert scenario_name in names
+    names = [cfg.scenario.name for cfg in op]
+    assert scenario_name in names
 
 
 @mac_on_gh

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -81,9 +81,6 @@ def config_instance(
     resulting data to a molecule file.  Return a Config instance with the
     molecule file path.
 
-    Because the test_cache_path is gitignored, monkeypatch the filter_ignored_scenarios
-    function to return the original list of scenarios.
-
     Args:
         monkeypatch: The pytest fixture for patching
         molecule_data: The pytest fixture for molecule data.
@@ -116,11 +113,6 @@ def config_instance(
     molecule_dir.mkdir(parents=True, exist_ok=True)
     molecule_file = molecule_dir / "molecule.yml"
     write_molecule_file(molecule_file, mdc)
-
-    def _filter_ignored_scenarios(scenario_paths: list[str]) -> list[str]:
-        return scenario_paths
-
-    monkeypatch.setattr("molecule.command.base.filter_ignored_scenarios", _filter_ignored_scenarios)
 
     _environ = dict(os.environ)
     c = config.Config(str(molecule_file))

--- a/tests/unit/test_nested_scenarios.py
+++ b/tests/unit/test_nested_scenarios.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 import pytest
 
-from molecule import config
+from molecule import config, util
 from molecule.command import base
 from molecule.constants import MOLECULE_COLLECTION_GLOB
 from molecule.exceptions import ScenarioFailureError
@@ -251,10 +251,6 @@ def fixture_collection_project(
     (nested_dir2 / "molecule.yml").write_text("---\n")
 
     monkeypatch.chdir(project)
-    monkeypatch.setattr(
-        "molecule.command.base.filter_ignored_scenarios",
-        lambda paths: paths,
-    )
 
     return project
 
@@ -301,6 +297,41 @@ def test_get_configs_all_discovers_nested_with_recursive_glob(
     )
     names = sorted(c.scenario.name for c in configs)
     assert names == ["appliance_vlans/merged", "appliance_vlans/replaced", "default"]
+
+
+def test_get_configs_default_glob_ignores_vendored_venv_scenarios(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default discovery does not descend into an installed virtualenv.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.delenv("MOLECULE_GLOB", raising=False)
+    util.get_collection_metadata.cache_clear()
+    util.get_effective_molecule_glob.cache_clear()
+    _make_molecule_file(tmp_path, "molecule", "default")
+    _make_molecule_file(
+        tmp_path,
+        "venv",
+        "lib",
+        "python3.12",
+        "site-packages",
+        "molecule",
+        "test",
+        "scenarios",
+        "cleanup",
+        "molecule",
+        "default",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    configs = base.get_configs({}, {"subcommand": "test"})
+
+    assert [c.scenario.name for c in configs] == ["default"]
+    assert all("site-packages" not in c.molecule_file for c in configs)
 
 
 def test_resolve_scenario_glob_wildcard_preserved(


### PR DESCRIPTION
## What

Removes `filter_ignored_scenarios()` and its call in `get_configs()`. Scenario discovery no longer consults `git check-ignore`, so it is decoupled from git entirely.

Fixes #4659. Reverts the mechanism added in #3996 (for #3992).

## Why the git filter is vestigial

The filter was added in #3996 to stop `molecule list` from discovering scenarios that a `pip install` had dropped inside a project-local virtualenv (`venv/lib/pythonX.Y/site-packages/.../molecule/*/molecule.yml`). Because `venv/` is virtually always git-ignored, "is this git-ignored?" was used as a proxy for "this is installed, not part of my project."

Discovery has since become anchored and collection-aware, and that already keeps installed scenarios out before the git filter is ever consulted. `get_configs()` finds scenarios through a single source, `util.get_effective_molecule_glob()`, and both patterns it returns are rooted where a project actually keeps its scenarios:

- `molecule/*/molecule.yml` for a normal project. The single `*` does not cross directory separators, so it only matches `./molecule/<name>/molecule.yml` at the top of the project.
- `extensions/molecule/**/molecule.yml` once a collection is detected (#4499). This one is recursive but rooted under `extensions/molecule/`, where a virtualenv never lives.

Neither pattern can descend into `venv/lib/.../site-packages/`, so the installed scenarios #3992 was about are excluded by *where discovery looks*. The filter's only remaining effect on real projects is a bug: it drops a user's own scenarios when they keep their `molecule/` directory out of version control (#4659).

| Scenario on disk | When #3996 was added | Today, filter in place | With the filter removed |
|---|---|---|---|
| Vendored scenarios in a git-ignored virtualenv, *should be ignored* | excluded by the git filter | excluded by discovery; filter redundant | excluded by discovery |
| Your own scenarios in a git-ignored `molecule/` dir, *should be found* | dropped by the git filter | dropped by the git filter, `glob failed` (#4659) | found |

## The one behavior change, and its guardrail

Removing the filter changes behavior in exactly one, opt-in situation. If a user has *both* deliberately set a **recursive** custom `MOLECULE_GLOB` (e.g. `**/molecule.yml`) *and* a project-local virtualenv with vendored scenarios in it, then `list` and `matrix` will now surface those vendored scenarios, because git-ignore is no longer there to prune them. That combination is an explicit opt-in to scanning everything under the project root; the default globs are rooted (see above) and are unaffected.

The default path is pinned by test: `test_get_configs_default_glob_ignores_vendored_venv_scenarios` places a real `molecule/default` scenario alongside a vendored `venv/lib/python3.12/site-packages/.../molecule/default/molecule.yml` and asserts default discovery returns only the project's own scenario. So the #3992 case stays fixed without the git heuristic; only the recursive-custom-glob-plus-venv combination changes.

Molecule already has a git-independent way to prune under a recursive glob: the `--exclude` option (`_is_excluded()`), which today applies to `run` but not to `list`/`matrix`. Extending that coverage is the natural git-independent replacement for this narrow case.

## The fix, reproduced

`molecule 26.6.1.dev9`, python 3.14. Base `upstream/main` at `ab625b40`; fix commit `cf502126`.

A project whose `molecule/` directory is git-ignored:

```console
$ git init -q && printf 'molecule/\n' > .gitignore
$ mkdir -p molecule/default && $EDITOR molecule/default/molecule.yml
$ git check-ignore molecule/default/molecule.yml
molecule/default/molecule.yml
```

Before (on `ab625b40`), the scenario is dropped and there is nothing left to discover:

```console
$ molecule list
CRITICAL 'molecule/*/molecule.yml' glob failed.  Exiting.
ERROR    'molecule/*/molecule.yml' glob failed.  Exiting.
$ echo $?
1
```

After (this branch), the same git-ignored scenario is discovered:

```console
$ molecule list
INFO     default ➜ list: Executing
INFO     default ➜ list: Executed: Successful
  Instance    Driver Name   Provisioner   Scenario    Created   Converged
  Name                      Name          Name
  instance    default       ansible       default     false     false
$ echo $?
0
```

## Tests

- Removed `test_with_and_without_gitignore` (the direct behavior test for the filter) and reworked it into `test_gitignored_scenario_is_discovered`, which asserts the new contract: a scenario whose directory is git-ignored is discovered. Its docstring states this contract explicitly (discovery is now git-agnostic; the test does not consult git-ignore status). It reuses the pre-existing git-ignored `.extensions/` fixture path.
- Removed the two test-only monkeypatches of `filter_ignored_scenarios` (in `tests/unit/conftest.py` and `tests/unit/test_nested_scenarios.py`) that existed only to defeat the filter on the git-ignored test cache path. Those tests now rely on real discovery.
- Added `test_get_configs_default_glob_ignores_vendored_venv_scenarios`: with both a real `molecule/default` scenario and a vendored one under a `venv/lib/python3.12/site-packages/.../molecule/default/molecule.yml` path, default discovery returns only the project's own scenario. This pins the #3992 behavior in place without the git filter.

## Local pipeline results

Run with the repo's `tox`/`uv`/`prek` dev-env, python 3.14, host is rootless podman (no docker).

- **lint** (`prek run` over the changed files: ruff, mypy, pydoclint, pylint, cspell, codespell): all pass.
- **unit** (`tox -e py -- tests/unit`): 824 passed, 6 skipped. Coverage total 90%, unchanged from the `ab625b40` baseline (823 passed, 90%); `command/base.py` stays at 89% (removing the covered filter plus its tests, and adding one discovery test, is coverage-neutral).
- **integration** (`tests/integration/test_command.py`, the modified file): 26 passed, 1 skipped. `test_podman` runs and passes on host rootless podman; the single skip is `test_docker`, gated off by design when docker is absent (community.docker#660). `tests/integration/test_workers.py`: 4 passed.

Not run locally: the container-driver paths that specifically require Docker (`test_docker`) since only rootless podman is available here; CI exercises those.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scenario discovery now includes valid scenarios located in git-ignored directories.
  * Default scenario discovery avoids traversing vendored virtual environments (for example, under `site-packages`).
  * Scenario configuration discovery remains restricted to appropriate project locations to reduce unexpected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->