### PR TITLE
fix: write the scenario state file atomically

### DIFF
--- a/src/molecule/state.py
+++ b/src/molecule/state.py
@@ -232,7 +232,8 @@ class State:
         return cast("StateData", util.safe_load_file(self._state_file))
 
     def _write_state_file(self) -> None:
-        util.write_file(self.state_file, util.safe_dump(self._data))
+        # Scenarios write this file concurrently under --workers + shared_state.
+        util.atomic_write_file(self.state_file, util.safe_dump(self._data))
 
     def _get_state_file(self) -> Path:
         return Path(self._config.scenario.ephemeral_directory) / "state.yml"

--- a/src/molecule/util.py
+++ b/src/molecule/util.py
@@ -26,6 +26,7 @@ import logging
 import os
 import re
 import sys
+import tempfile
 
 from pathlib import Path
 from typing import TYPE_CHECKING, overload
@@ -205,6 +206,26 @@ def render_template(template: str, **kwargs: str | dict[str, str]) -> str:
     return t.from_string(template).render(kwargs)
 
 
+def _prepare_write(
+    filename: str | Path,
+    content: str,
+    header: str | None,
+) -> tuple[Path, str]:
+    """Apply the default header and coerce ``filename`` to ``Path``.
+
+    Args:
+        filename: The target file.
+        content: The data to be written.
+        header: When None, prepend the default header; else leave content as-is.
+
+    Returns:
+        The target as a ``Path`` and the content to write.
+    """
+    if header is None:
+        content = MOLECULE_HEADER + "\n\n" + content
+    return Path(filename), content
+
+
 def write_file(filename: str | Path, content: str, header: str | None = None) -> None:
     """Write a file with the given filename and content.
 
@@ -213,13 +234,40 @@ def write_file(filename: str | Path, content: str, header: str | None = None) ->
         content: A string containing the data to be written.
         header: A header, if None it will use default header.
     """
-    if header is None:
-        content = MOLECULE_HEADER + "\n\n" + content
-
-    if isinstance(filename, str):
-        filename = Path(filename)
+    filename, content = _prepare_write(filename, content, header)
     filename.parent.mkdir(exist_ok=True)
     filename.write_text(content)
+
+
+def atomic_write_file(filename: str | Path, content: str, header: str | None = None) -> None:
+    """Write a file atomically: temp file in the target's dir, then ``Path.replace``.
+
+    A concurrent reader always sees the whole old or new file, never a partial
+    one. The file is created mode 0600 (via mkstemp), not umask-derived.
+
+    Args:
+        filename: The target file.
+        content: A string containing the data to be written.
+        header: A header, if None it will use default header.
+    """
+    filename, content = _prepare_write(filename, content, header)
+    filename.parent.mkdir(exist_ok=True)
+
+    fd, tmp_name = tempfile.mkstemp(
+        dir=filename.parent,
+        prefix=f".{filename.name}.",
+        suffix=".tmp",
+    )
+    tmp_path = Path(tmp_name)
+    replaced = False
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+        tmp_path.replace(filename)
+        replaced = True
+    finally:
+        if not replaced:
+            tmp_path.unlink(missing_ok=True)
 
 
 def molecule_prepender(content: str) -> str:

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -204,6 +204,70 @@ def test_write_file(test_cache_path: Path) -> None:
     assert x == data
 
 
+def test_atomic_write_file(test_cache_path: Path) -> None:
+    """Atomic write produces the same content as write_file and leaves no temp file.
+
+    Args:
+        test_cache_path: The path to the test cache directory for the test.
+    """
+    dest_file = test_cache_path / "test_util_atomic_write_file.tmp"
+    contents = binascii.b2a_hex(os.urandom(15)).decode("utf-8")
+    util.atomic_write_file(str(dest_file), contents)
+    assert dest_file.read_text() == f"# Molecule managed\n\n{contents}"
+    assert [p.name for p in test_cache_path.iterdir()] == [dest_file.name]
+
+
+def test_atomic_write_file_never_truncates_target(
+    test_cache_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A concurrent reader never sees a partial file: the target is swapped whole.
+
+    Args:
+        test_cache_path: The path to the test cache directory for the test.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    dest_file = test_cache_path / "state.yml"
+    util.atomic_write_file(dest_file, "old", header="")
+
+    observed: list[str] = []
+    real_replace = Path.replace
+
+    def spy(self: Path, target: str | Path) -> Path:
+        observed.append(Path(target).read_text())
+        return real_replace(self, target)
+
+    monkeypatch.setattr(Path, "replace", spy)
+    util.atomic_write_file(dest_file, "new", header="")
+
+    assert observed == ["old"]
+    assert dest_file.read_text() == "new"
+
+
+def test_atomic_write_file_cleans_up_on_error(
+    test_cache_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed replace leaves the original intact and drops no temp file behind.
+
+    Args:
+        test_cache_path: The path to the test cache directory for the test.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    dest_file = test_cache_path / "state.yml"
+    util.atomic_write_file(dest_file, "old", header="")
+
+    def boom(self: Path, target: str | Path) -> Path:
+        raise OSError
+
+    monkeypatch.setattr(Path, "replace", boom)
+    with pytest.raises(OSError):  # noqa: PT011
+        util.atomic_write_file(dest_file, "new", header="")
+
+    assert dest_file.read_text() == "old"
+    assert [p.name for p in test_cache_path.iterdir()] == [dest_file.name]
+
+
 def test_molecule_prepender(tmp_path: Path) -> None:  # noqa: D103
     fname = tmp_path / "some.txt"
     fname.write_text("foo bar")


### PR DESCRIPTION
Refs #4666.

First step of the phased plan in #4666: make the scenario `state.yml` write atomic, which removes the partial-read crash. It does not attempt the larger shared-state design change (defect 2 in the issue); that stays tracked in #4666.

## Problem

Molecule runs a collection's scenarios in parallel with `--workers`. The parallel-testing guide (`docs/guides/parallel.md:30-32`) pairs that with `shared_state: true`, so every scenario running at once reads and writes the *same* `state.yml`. That file is written non-atomically, so a scenario can read it mid-rewrite, get a truncated document, and abort with a YAML scanner error. It surfaces as the intermittent `test_workers` failure on the `py314-milestone` job (py3.14 timing just widens the window):

```
molecule.util.MoleculeError: while scanning a quoted scalar
  ...
yaml.scanner.ScannerError: could not find expected ':'
```

## Root cause

The state write is a truncate-then-rewrite with no atomicity:

- `State._write_state_file` (`src/molecule/state.py:234`) → `util.write_file` → `Path.write_text(content)` (`src/molecule/util.py:222`). `write_text` truncates the file, then writes — a window in which a concurrent reader sees an empty or partial document.
- `State._load_file` (`src/molecule/state.py:231`) → `util.safe_load_file` → `util.safe_load`, which turns the resulting `yaml.scanner.ScannerError` into a `MoleculeError` (`src/molecule/util.py:285-286`) and the worker aborts.
- A truncation that lands on an *empty* read is quieter but worse: `safe_load` returns `{}` (`util.py:347`, `... or {}`), so `State._get_data` (`state.py:214-218`) falls back to `_default_data()` and the worker silently resets shared state (e.g. `prepared` → `False`) with no error at all. Atomicity removes both this silent reset and the `ScannerError` crash.

`SharedState` (`src/molecule/state.py:241-249`) points every opted-in scenario at one `shared_ephemeral_directory/state.yml`, and molecule's own `test_workers` fixture sets `shared_state: true` (`tests/fixtures/integration/test_workers/extensions/molecule/config.yml:13`) — so CI exercises exactly this path.

## Fix

- Add `util.atomic_write_file`: write the content to a temp file in the target's **own directory**, then `Path.replace` onto the target. The replace is a same-filesystem rename — POSIX guarantees `rename(2)` is atomic — so a concurrent reader always opens either the complete old file or the complete new file, never a truncated one. The temp file is removed if the write fails.
- Point `State._write_state_file` at it. The file *content* is identical (`safe_dump` output with the same header); the only practically observable change is that `state.yml` is now created owner-only (`0600`) via `mkstemp` instead of umask-derived (`0644`) — harmless for this per-run ephemeral file, and if anything tighter.

`write_file` and `atomic_write_file` share a small `_prepare_write` helper for the header/`Path` prep, so the new function is not a copy-paste of the old; `write_file`'s write path itself is unchanged. Scoped deliberately to the state write, not a global `write_file` swap: in the normal `--workers` layout only `state.yml` is written concurrently — every other `write_file` caller writes under a per-scenario `ephemeral_directory` — so widening it would add churn without fixing anything new.

## Evidence

**Reproduction of the race and its removal.** Six workers (3 writers / 3 readers) hammer one shared `state.yml` through the exact functions `State` uses — `util.safe_load_file` to read, and `util.write_file` (before) vs. `util.atomic_write_file` (after) to write. Run against this branch on Python `3.10.20` (the race reproduces on every supported version; 3.14 timing widens the window):

```
===== BEFORE (util.write_file) =====
util.write_file -- py 3.10.20, 3000 iters x 6 workers
  reader outcome: ok  x8560
  reader outcome: TRUNCATED_DICT(missing keys)  x440
  CORRUPTION: 440 corrupt read(s)
===== AFTER (util.atomic_write_file) =====
util.atomic_write_file -- py 3.10.20, 3000 iters x 6 workers
  reader outcome: ok  x9000
  clean: 0 corrupt read(s)
summary: before=440 corrupt reads, after=0 corrupt reads
```

(The script is in #4666; earlier runs also caught the genuine `ScannerError` — which partial read you hit depends on where the truncation lands.)

**Unit tests** (`tests/unit/test_util.py`), three new, all deterministic:

- `test_atomic_write_file` — same content as `write_file`, and no temp file survives in the directory.
- `test_atomic_write_file_never_truncates_target` — spies on `Path.replace` to assert the live file still holds the complete *old* content right up to the atomic swap (proves the target is never truncated in place).
- `test_atomic_write_file_cleans_up_on_error` — a failing replace leaves the original intact and drops no temp file behind.

The last two patch `Path.replace` — exactly the call the code makes — so they exercise the real swap on every supported interpreter (verified on 3.10 and 3.14).

```
tests/unit/test_util.py::test_atomic_write_file PASSED
tests/unit/test_util.py::test_atomic_write_file_never_truncates_target PASSED
tests/unit/test_util.py::test_atomic_write_file_cleans_up_on_error PASSED
```

**Suite / lint:**

```
tox -e py -- tests/unit:  full unit suite green (Fedora container, py3.14)
python3.10 -m pytest tests/unit/test_util.py tests/unit/test_state.py:  98 passed
```

The single-process state flow (`tests/unit/test_state.py`) is unchanged and green, and the new `test_util.py` cases are included above. `tox -e lint` — `ruff`, `mypy`, `pydoclint`, `cspell` all pass on the diff.

## Regression / no-behavior-change checks

- `util.write_file`'s write path is unchanged (it now shares the `_prepare_write` header/`Path` helper); `test_write_file` still passes.
- `atomic_write_file` reproduces `write_file`'s output exactly (header prepend included), asserted by `test_atomic_write_file` — the on-disk *content* is byte-identical; the write path and the resulting file mode (`0600`, see Fix) are the only differences.
- The single-process state flow is unaffected: `tests/unit/test_state.py` passes unchanged.

## Notes for reviewers

- **This is intentionally step 1 of #4666, not the whole issue.** It removes the crash (defect 1). The second defect in #4666 — under `--workers`, each worker rewrites the whole shared file from its own in-memory snapshot, so one can silently overwrite another's flags — is a *design* question (who owns `prepare`, per-worker state vs. one shared file) that atomic writes do not solve. I left #4666 open for it rather than closing it here.
- **Why scoped to the state write** and not a global `atomic_write_file` swap: in the normal `--workers` layout only `state.yml` is written concurrently, so widening it would add churn without fixing anything new. `atomic_write_file` is left public (not `_private`) because it is a general helper worth reusing if another file ever needs the same guarantee.
- **Leftover temp files:** if a process is killed between `mkstemp` and the replace, a hidden `.<name>.*.tmp` can remain in the ephemeral dir. The `finally` unlinks it on any in-process failure; only a hard kill mid-write could leave one, and it's inert.

## Related

- #4666 — the issue; the full mechanism, both defects, and the phased plan.
- #4616 — added `--workers`; where the shared `state.yml` began being written concurrently.
- #4664, #4665 — where the `py314-milestone` flake was observed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved state-file updates to write changes atomically, preventing readers from seeing partially written content.
  * Preserved existing state files and ensured temporary files are cleaned up if an update fails.
* **Reliability**
  * State persistence now safely handles concurrent updates and interruptions by using atomic write behavior.
* **Tests**
  * Added unit tests covering atomic write correctness, concurrency safety, and failure/cleanup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->