### PR TITLE
ci: point Podman at /usr/local/bin/crun on Ubuntu GHA runners

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -32,3 +32,15 @@ jobs:
       other_names_also: |
         collection
         eco
+      # Temporary: ubuntu-24.04 image 20260726.254 ships Podman 5.8.4 but leaves
+      # Podman pointed at /usr/bin/crun 1.14.1 while /usr/local/bin/crun 1.28 exists.
+      # Promote into team-devtools tox.yml if this unblocks Linux integration tests.
+      # See https://github.com/actions/runner-images/issues/14473
+      run_pre: |
+        set -euxo pipefail
+        if [[ "$(uname -s)" == Linux && -x /usr/local/bin/crun ]]; then
+          sudo mkdir -p /etc/containers/containers.conf.d
+          printf '%s\n' '[engine.runtimes]' 'crun = ["/usr/local/bin/crun"]' \
+            | sudo tee /etc/containers/containers.conf.d/99-gha-crun.conf >/dev/null
+          podman info --format '{{.Host.OCIRuntime.Path}}' || true
+        fi


### PR DESCRIPTION
## Summary
- Work around broken Podman/crun pairing on GitHub Actions `ubuntu-24.04` image `20260726.254`, which breaks molecule Linux integration tests (`test_podman`, `test_native_inventory`, `test_with_backend_as_ansible_navigator`) with `Error: OCI runtime error: crun: unknown version specified`.
- Upstream tracker: [actions/runner-images#14473](https://github.com/actions/runner-images/issues/14473) (Podman 5.8.4 still resolves `/usr/bin/crun` 1.14.1 instead of `/usr/local/bin/crun` 1.28).

## Changes
- Add a temporary `run_pre` in `.github/workflows/tox.yml` that writes a containers.conf.d drop-in so Podman uses `/usr/local/bin/crun` on Linux runners when that binary exists.
- Guarded with `uname` so macOS jobs are unaffected.

## Follow-up
If CI goes green on the new runner image, **promote this workaround into `ansible/team-devtools` `.github/workflows/tox.yml`** so all consumers of the shared tox workflow get the fix, then remove the molecule-local `run_pre`.

## Test plan
- [ ] `tox / py310` and `tox / py312` pass on image `20260726.254` (no more `crun: unknown version specified`)
- [ ] macOS jobs still pass (Linux-only guard)
- [ ] Actionlint / workflow lint clean on this YAML
- [ ] After merge + confirmation, open team-devtools PR to absorb the same `run_pre` (or equivalent step)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automated test workflow reliability on Linux runners by resolving Podman and OCI runtime compatibility issues.
  - Added a non-blocking environment check to help diagnose container runtime problems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->