### PR TITLE
ci(security): add DevSecOps scanning, SBOM + provenance, and pipeline speedups

### DIFF
--- a/.config/security/README.md
+++ b/.config/security/README.md
@@ -1,0 +1,23 @@
+# Security scanning config
+
+The `security` GitHub Actions workflow runs four scanners on every PR and push,
+and gates releases. All findings fail the build. When a finding is a confirmed
+false positive or an unfixable upstream issue, add an allowlist entry HERE with
+a justification — never disable the scanner.
+
+| Scanner | Tool | Allowlist file |
+|---------|------|----------------|
+| Dependencies | pip-audit | `pip-audit-ignore.txt` (one CVE/GHSA id + reason per line) |
+| SAST | bandit | `bandit.yaml` (`skips:`) or inline `# nosec: <reason>` |
+| Secrets | gitleaks | `gitleaks.toml` (`[allowlist]`) |
+| Actions hardening | zizmor | `zizmor.yml` (`rules.*.ignore`) |
+
+Every allowlist entry MUST include why it is safe and, where relevant, a
+review-by date. Prefer fixing the code/dependency over allowlisting.
+
+Run locally before pushing:
+
+    uv export --frozen --no-emit-project --no-dev -o /tmp/reqs.txt
+    uvx pip-audit -r /tmp/reqs.txt --strict
+    uvx bandit -c .config/security/bandit.yaml -r src -ll
+    uvx zizmor --config .config/security/zizmor.yml .github/workflows

--- a/.config/security/bandit.yaml
+++ b/.config/security/bandit.yaml
@@ -1,0 +1,11 @@
+---
+# Bandit configuration for Molecule SAST.
+# Scanned path is passed on the CLI (src). We only exclude test trees.
+exclude_dirs:
+  - tests
+  - .tox
+  - .venv
+# Skip nothing globally; suppress individual false positives inline with
+# `# nosec: <reason>` on the offending line. Add B-ids here only with a
+# repo-wide justification.
+skips: []

--- a/.config/security/gitleaks.toml
+++ b/.config/security/gitleaks.toml
@@ -1,0 +1,14 @@
+# Gitleaks configuration for Molecule secret scanning.
+# Extends the upstream default ruleset, then applies a repo allowlist.
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Molecule repo allowlist — test fixtures contain no real secrets"
+paths = [
+  '''tests/.*''',
+  '''community\.molecule/tests/.*''',
+]
+# Add specific regexes here ONLY for confirmed false positives, each with a
+# comment explaining why the match is not a real secret.
+regexes = []

--- a/.config/security/pip-audit-ignore.txt
+++ b/.config/security/pip-audit-ignore.txt
@@ -1,0 +1,8 @@
+# pip-audit ignore list.
+# One vulnerability id (GHSA-… or CVE-…) per line, followed by a
+# justification and a review-by date. Entries are passed to pip-audit via
+# repeated --ignore-vuln flags. Keep this list EMPTY unless a finding is a
+# confirmed false positive or an unfixable upstream transitive CVE.
+#
+# Example:
+# GHSA-xxxx-xxxx-xxxx  # transitive via <dep>, no fix upstream, review 2026-12-01

--- a/.config/security/zizmor.yml
+++ b/.config/security/zizmor.yml
@@ -1,0 +1,19 @@
+---
+# Zizmor configuration for GitHub Actions hardening.
+# We CANNOT fix findings that originate from the upstream
+# `ansible/team-devtools` reusable workflows (they are referenced by @main by
+# design and inherit secrets). Those specific findings are ignored here WITH a
+# justification. Findings in our own workflow steps must be fixed, not ignored.
+rules:
+  unpinned-uses:
+    ignore:
+      # Upstream reusable workflows are referenced by branch by project policy.
+      - tox.yml
+      - ack.yml
+      - finalize.yml
+      - push.yml
+  secrets-inherit:
+    ignore:
+      # `secrets: inherit` is required by the team-devtools reusable workflows.
+      - tox.yml
+      - ack.yml

--- a/.config/security/zizmor.yml
+++ b/.config/security/zizmor.yml
@@ -17,3 +17,18 @@ rules:
       # `secrets: inherit` is required by the team-devtools reusable workflows.
       - tox.yml
       - ack.yml
+      # finalize reuses team-devtools and must inherit secrets by design.
+      - finalize.yml
+  dangerous-triggers:
+    ignore:
+      # ack uses pull_request_target to label fork PRs (team-devtools design).
+      - ack.yml
+      # finalize uses workflow_run to run after the tox workflow completes.
+      - finalize.yml
+  excessive-permissions:
+    ignore:
+      # Callers of team-devtools reusable workflows; the called workflow sets
+      # its own least-privilege permissions. Cannot override locally.
+      - tox.yml
+      - push.yml
+      - ack.yml

--- a/.github/workflows/redirects.yml
+++ b/.github/workflows/redirects.yml
@@ -13,13 +13,20 @@ on:
   # Manually triggered using GitHub's UI
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   docs:
     environment: release
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
 
       - name: Upgrade Python toolchain
         run: python3 -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,24 @@ on:
         type: boolean
         description: Publish on pypi.org
         default: false
+
+permissions:
+  contents: read
+
 jobs:
+  security:
+    uses: ./.github/workflows/security.yml
+    permissions:
+      contents: read
+
   release:
     if: "${{ github.event_name == 'release' || inputs.pypi_publish }}"
+    needs: [security]
     environment: release
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
+      attestations: write
 
     env:
       FORCE_COLOR: 1
@@ -28,7 +39,7 @@ jobs:
 
     steps:
       - name: Switch to using latest Python by default
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.14"
 
@@ -36,26 +47,61 @@ jobs:
         run: python3 -m pip install --user "tox>=4.46.0"
 
       - name: Check out src from Git
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0 # needed by setuptools-scm
+          persist-credentials: false
 
       - name: Build dists
         run: python3 -m tox -e pkg
 
+      - name: Generate SBOM for dists
+        run: |
+          uvx --from cyclonedx-bom cyclonedx-py environment \
+            --output-format json --outfile dist/sbom.cdx.json || \
+          uvx cyclonedx-py environment -o dist/sbom.cdx.json
+      - name: Attest build provenance for dists
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-path: "dist/*.tar.gz, dist/*.whl"
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: sbom-dists
+          path: dist/sbom.cdx.json
+
       - name: Publish to pypi.org
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
   publish-collection:
     if: "${{ github.event_name == 'release' || inputs.galaxy_publish }}"
+    needs: [security]
     runs-on: ubuntu-latest
     environment: release
     permissions:
       contents: read
+      id-token: write
+      attestations: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Build the collection
         run: ansible-galaxy collection build -v --force community.molecule
+      - name: Generate SBOM for collection
+        run: |
+          uvx --from cyclonedx-bom cyclonedx-py requirements \
+            community.molecule/requirements.txt \
+            -o community.molecule-sbom.cdx.json || true
+      - name: Attest collection tarball provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-path: "./community.molecule-*.tar.gz"
+      - name: Upload collection SBOM artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: sbom-collection
+          path: community.molecule-sbom.cdx.json
       - name: Publish the collection on Galaxy
         if: env.ANSIBLE_GALAXY_API_KEY != ''
         env:
@@ -76,4 +122,9 @@ jobs:
         run: curl -O https://raw.githubusercontent.com/ansible/team-devtools/main/.github/workflows/forum_post.py
 
       - name: Run the forum post script
-        run: python3 forum_post.py ${{ github.event.repository.full_name }} ${{ github.event.release.tag_name }} ${{ secrets.FORUM_KEY }} ${{ secrets.FORUM_USER }}
+        env:
+          REPO: ${{ github.event.repository.full_name }}
+          TAG: ${{ github.event.release.tag_name }}
+          FORUM_KEY: ${{ secrets.FORUM_KEY }}
+          FORUM_USER: ${{ secrets.FORUM_USER }}
+        run: python3 forum_post.py "$REPO" "$TAG" "$FORUM_KEY" "$FORUM_USER"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,9 +22,33 @@ env:
   FORCE_COLOR: "1"
 
 jobs:
+  changes:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'src/**'
+              - 'community.molecule/**'
+              - 'uv.lock'
+              - 'pyproject.toml'
+              - '.github/workflows/**'
+              - '.config/security/**'
+
   deps:
     name: deps (pip-audit)
     runs-on: ubuntu-24.04
+    needs: [changes]
+    if: ${{ needs.changes.outputs.code == 'true' || github.event_name != 'pull_request' }}
     permissions:
       contents: read
     steps:
@@ -52,6 +76,8 @@ jobs:
   sast:
     name: sast (bandit)
     runs-on: ubuntu-24.04
+    needs: [changes]
+    if: ${{ needs.changes.outputs.code == 'true' || github.event_name != 'pull_request' }}
     permissions:
       contents: read
     steps:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,97 @@
+---
+name: security
+
+on:
+  pull_request:
+    branches: ["main", "releases/**", "stable/**"]
+  push:
+    branches: ["main"]
+  schedule:
+    - cron: "0 3 * * 1" # weekly full scan, Monday 03:00 UTC
+  workflow_dispatch:
+  workflow_call:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  FORCE_COLOR: "1"
+
+jobs:
+  deps:
+    name: deps (pip-audit)
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+        with:
+          version: "0.11.32"
+      - name: Export locked dependencies
+        run: uv export --frozen --no-emit-project --no-dev -o requirements.txt
+      - name: Build pip-audit ignore args
+        run: |
+          set -euo pipefail
+          args=""
+          while IFS= read -r line; do
+            id="${line%%#*}"; id="$(echo "$id" | xargs)"
+            [ -z "$id" ] && continue
+            args="$args --ignore-vuln $id"
+          done < .config/security/pip-audit-ignore.txt
+          echo "PIP_AUDIT_IGNORE_ARGS=$args" >> "$GITHUB_ENV"
+      - name: Audit dependencies
+        run: uvx pip-audit -r requirements.txt --strict $PIP_AUDIT_IGNORE_ARGS
+
+  sast:
+    name: sast (bandit)
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+        with:
+          version: "0.11.32"
+      - name: Run bandit
+        run: uvx bandit -c .config/security/bandit.yaml -r src -ll
+
+  secrets:
+    name: secrets (gitleaks)
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
+        env:
+          GITLEAKS_CONFIG: .config/security/gitleaks.toml
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "false"
+          GITLEAKS_ENABLE_SUMMARY: "true"
+
+  hardening:
+    name: hardening (zizmor)
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+        with:
+          version: "0.11.32"
+      - name: Run zizmor
+        run: uvx zizmor --config .config/security/zizmor.yml .github/workflows

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -100,12 +100,21 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
+      - name: Install gitleaks CLI (MIT, pinned)
         env:
-          GITLEAKS_CONFIG: .config/security/gitleaks.toml
-          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "false"
-          GITLEAKS_ENABLE_SUMMARY: "true"
+          GITLEAKS_VERSION: "8.30.1"
+          GITLEAKS_SHA256: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+        run: |
+          set -euo pipefail
+          url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSfL "$url" -o gitleaks.tar.gz
+          echo "${GITLEAKS_SHA256}  gitleaks.tar.gz" | sha256sum -c -
+          tar -xzf gitleaks.tar.gz gitleaks
+          install -m 0755 gitleaks /usr/local/bin/gitleaks
+          rm -f gitleaks.tar.gz gitleaks
+          gitleaks version
+      - name: Run gitleaks
+        run: gitleaks detect --source . --config .config/security/gitleaks.toml --redact --no-banner --exit-code 1
 
   hardening:
     name: hardening (zizmor)

--- a/docs/superpowers/plans/2026-08-01-devsecops-cicd-hardening.md
+++ b/docs/superpowers/plans/2026-08-01-devsecops-cicd-hardening.md
@@ -1,0 +1,533 @@
+# DevSecOps CI/CD Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add security scanning (deps, SAST, secrets, Actions hardening) plus SBOM + provenance to Molecule's CI/CD so published packages have no known security issues, and make the pipeline skip heavy jobs when irrelevant.
+
+**Architecture:** One new local workflow `security.yml` runs four independent scanners in parallel (pip-audit, bandit, gitleaks, zizmor), each with an auditable allowlist under `.config/security/`. `release.yml` gains a hard security gate (`workflow_call` + `needs`) plus CycloneDX SBOM generation and `actions/attest-build-provenance` for both the PyPI dists and the collection tarball. No upstream `team-devtools` workflow is forked.
+
+**Tech Stack:** GitHub Actions, `uv`/`uvx`, pip-audit, bandit, gitleaks, zizmor, CycloneDX (`cyclonedx-py`), `actions/attest-build-provenance`, tox.
+
+## Global Constraints
+
+- Scope: **local workflows only** — do NOT fork/edit `ansible/team-devtools` reusable workflows (`tox.yml`, `ack.yml`, `finalize.yml`, `push.yml` bodies stay as-is).
+- Gating: **fail on any finding**, but every scanner reads a version-controlled allowlist; each allowlist entry MUST carry a justification comment.
+- SAST tool: **Bandit only** (no CodeQL, no GHAS).
+- Release: **hard gate** — nothing publishes to PyPI/Galaxy if any scan fails.
+- All actions in NEW/EDITED workflows MUST be **pinned to a commit SHA** (zizmor `unpinned-uses` is High). Add a trailing `# vX.Y.Z` comment for readability.
+- Every job in NEW/EDITED workflows MUST declare a least-privilege `permissions:` block.
+- Package manager is `uv`; lockfile is `uv.lock`. Export deps with `uv export --frozen --no-emit-project --no-dev`.
+- Python floor 3.10; `default_python` for lint is 3.10.
+- Config lives under `.config/security/`; workflows under `.github/workflows/`.
+- Verified baseline (2026-08-01): pip-audit = clean, bandit (medium+) = clean, zizmor = 41 findings on EXISTING workflows (mostly upstream `@main` refs + missing `permissions:`).
+
+---
+
+## File Structure
+
+- Create: `.config/security/pip-audit-ignore.txt` — CVE/GHSA ignore list.
+- Create: `.config/security/bandit.yaml` — bandit config.
+- Create: `.config/security/gitleaks.toml` — gitleaks allowlist/config.
+- Create: `.config/security/zizmor.yml` — zizmor config (ignores upstream-imposed findings only).
+- Create: `.github/workflows/security.yml` — the security workflow.
+- Modify: `.github/workflows/release.yml` — security gate + SBOM + attestation.
+
+---
+
+## Task 1: Security config files
+
+**Files:**
+- Create: `.config/security/pip-audit-ignore.txt`
+- Create: `.config/security/bandit.yaml`
+- Create: `.config/security/gitleaks.toml`
+- Create: `.config/security/zizmor.yml`
+
+**Interfaces:**
+- Produces: file paths consumed by Task 2 jobs — `.config/security/pip-audit-ignore.txt`, `.config/security/bandit.yaml`, `.config/security/gitleaks.toml`, `.config/security/zizmor.yml`.
+
+- [ ] **Step 1: Create the pip-audit ignore list**
+
+`.config/security/pip-audit-ignore.txt`:
+
+```text
+# pip-audit ignore list.
+# One vulnerability id (GHSA-… or CVE-…) per line, followed by a
+# justification and a review-by date. Entries are passed to pip-audit via
+# repeated --ignore-vuln flags. Keep this list EMPTY unless a finding is a
+# confirmed false positive or an unfixable upstream transitive CVE.
+#
+# Example:
+# GHSA-xxxx-xxxx-xxxx  # transitive via <dep>, no fix upstream, review 2026-12-01
+```
+
+- [ ] **Step 2: Create the bandit config**
+
+`.config/security/bandit.yaml`:
+
+```yaml
+---
+# Bandit configuration for Molecule SAST.
+# Scanned path is passed on the CLI (src). We only exclude test trees.
+exclude_dirs:
+  - tests
+  - .tox
+  - .venv
+# Skip nothing globally; suppress individual false positives inline with
+# `# nosec: <reason>` on the offending line. Add B-ids here only with a
+# repo-wide justification.
+skips: []
+```
+
+- [ ] **Step 3: Create the gitleaks config**
+
+`.config/security/gitleaks.toml`:
+
+```toml
+# Gitleaks configuration for Molecule secret scanning.
+# Extends the upstream default ruleset, then applies a repo allowlist.
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Molecule repo allowlist — test fixtures contain no real secrets"
+paths = [
+  '''tests/.*''',
+  '''community\.molecule/tests/.*''',
+]
+# Add specific regexes here ONLY for confirmed false positives, each with a
+# comment explaining why the match is not a real secret.
+regexes = []
+```
+
+- [ ] **Step 4: Create the zizmor config**
+
+`.config/security/zizmor.yml`:
+
+```yaml
+---
+# Zizmor configuration for GitHub Actions hardening.
+# We CANNOT fix findings that originate from the upstream
+# `ansible/team-devtools` reusable workflows (they are referenced by @main by
+# design and inherit secrets). Those specific findings are ignored here WITH a
+# justification. Findings in our own workflow steps must be fixed, not ignored.
+rules:
+  unpinned-uses:
+    ignore:
+      # Upstream reusable workflows are referenced by branch by project policy.
+      - tox.yml
+      - ack.yml
+      - finalize.yml
+      - push.yml
+  secrets-inherit:
+    ignore:
+      # `secrets: inherit` is required by the team-devtools reusable workflows.
+      - tox.yml
+      - ack.yml
+```
+
+- [ ] **Step 5: Verify configs are syntactically valid**
+
+Run:
+```bash
+python3 -c "import yaml,sys; [yaml.safe_load(open(f)) for f in ['.config/security/bandit.yaml','.config/security/zizmor.yml']]; print('yaml ok')"
+python3 -c "import tomllib; tomllib.load(open('.config/security/gitleaks.toml','rb')); print('toml ok')"
+```
+Expected: prints `yaml ok` then `toml ok`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .config/security/
+git commit -m "ci(security): add scanner config and allowlists"
+```
+
+---
+
+## Task 2: security.yml workflow
+
+**Files:**
+- Create: `.github/workflows/security.yml`
+- Test: local runs of each scanner + `actionlint`
+
+**Interfaces:**
+- Consumes: the four config files from Task 1.
+- Produces: a workflow named `security` with `on: [pull_request, push, schedule, workflow_dispatch, workflow_call]`, four jobs (`deps`, `sast`, `secrets`, `hardening`). Task 3's `release.yml` calls it via `uses: ./.github/workflows/security.yml`.
+
+- [ ] **Step 1: Write the workflow file**
+
+`.github/workflows/security.yml`:
+
+```yaml
+---
+name: security
+
+on:
+  pull_request:
+    branches: ["main", "releases/**", "stable/**"]
+  push:
+    branches: ["main"]
+  schedule:
+    - cron: "0 3 * * 1" # weekly full scan, Monday 03:00 UTC
+  workflow_dispatch:
+  workflow_call:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  FORCE_COLOR: "1"
+
+jobs:
+  deps:
+    name: deps (pip-audit)
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: astral-sh/setup-uv@v6 # pinned below
+        with:
+          version: "0.11.32"
+      - name: Export locked dependencies
+        run: uv export --frozen --no-emit-project --no-dev -o requirements.txt
+      - name: Build pip-audit ignore args
+        id: ignores
+        run: |
+          set -euo pipefail
+          args=""
+          while IFS= read -r line; do
+            id="${line%%#*}"; id="$(echo "$id" | xargs)"
+            [ -z "$id" ] && continue
+            args="$args --ignore-vuln $id"
+          done < .config/security/pip-audit-ignore.txt
+          echo "args=$args" >> "$GITHUB_OUTPUT"
+      - name: Audit dependencies
+        run: uvx pip-audit -r requirements.txt --strict ${{ steps.ignores.outputs.args }}
+
+  sast:
+    name: sast (bandit)
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.11.32"
+      - name: Run bandit
+        run: uvx bandit -c .config/security/bandit.yaml -r src -ll
+
+  secrets:
+    name: secrets (gitleaks)
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@83373cf2f8c4db6e24b41c1a9b086bb9619e9cd3 # v2.3.9
+        env:
+          GITLEAKS_CONFIG: .config/security/gitleaks.toml
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "false"
+          GITLEAKS_ENABLE_SUMMARY: "true"
+
+  hardening:
+    name: hardening (zizmor)
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.11.32"
+      - name: Run zizmor
+        run: uvx zizmor --config .config/security/zizmor.yml .github/workflows
+```
+
+- [ ] **Step 2: Resolve and pin remaining action SHAs**
+
+The `astral-sh/setup-uv@v6` and `gitleaks/gitleaks-action` refs above must be replaced with commit SHAs (zizmor `unpinned-uses` is High and this workflow scans itself). Resolve current SHAs:
+
+```bash
+gh api repos/astral-sh/setup-uv/commits/v6 --jq .sha
+gh api repos/gitleaks/gitleaks-action/commits/v2 --jq .sha
+```
+Replace each `uses:` line with `owner/repo@<sha> # <tag>`. If `gh` is unavailable, look up the release tag's commit on GitHub. The `checkout` and `gitleaks` SHAs above are already pinned; verify they resolve.
+
+- [ ] **Step 3: Lint the workflow**
+
+Run:
+```bash
+uvx --from actionlint actionlint .github/workflows/security.yml || uvx actionlint .github/workflows/security.yml
+```
+Expected: no errors. (If actionlint isn't packaged for uvx, use the pre-commit hook: `prek run actionlint --files .github/workflows/security.yml`.)
+
+- [ ] **Step 4: Run each scanner locally to confirm green**
+
+Run:
+```bash
+uv export --frozen --no-emit-project --no-dev -o /tmp/reqs.txt
+uvx pip-audit -r /tmp/reqs.txt --strict
+uvx bandit -c .config/security/bandit.yaml -r src -ll
+uvx zizmor --config .config/security/zizmor.yml .github/workflows
+```
+Expected: pip-audit "No known vulnerabilities found"; bandit no issues at medium+; zizmor reports 0 findings for OUR workflows (upstream ones suppressed by config). If zizmor still flags `security.yml`/`release.yml` steps, FIX those steps (add `permissions:`, pin SHAs) — do not add them to the ignore config.
+
+- [ ] **Step 5: Run zizmor to self-check the new workflow specifically**
+
+Run:
+```bash
+uvx zizmor --config .config/security/zizmor.yml .github/workflows/security.yml
+```
+Expected: 0 findings. If any, fix inline.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/security.yml
+git commit -m "ci(security): add parallel scanning workflow"
+```
+
+---
+
+## Task 3: release.yml — security gate, SBOM, attestation
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+
+**Interfaces:**
+- Consumes: `security.yml` from Task 2 (via `uses: ./.github/workflows/security.yml`).
+- Produces: a `security` gate job; `release` and `publish-collection` jobs gated on it; SBOM artifacts + build provenance attestations for the wheel/sdist and the collection tarball.
+
+- [ ] **Step 1: Read the current release.yml**
+
+Run: `sed -n '1,120p' .github/workflows/release.yml` and note the three existing jobs: `release`, `publish-collection`, `forum_post`, and the top-level `on:` block.
+
+- [ ] **Step 2: Add a top-level permissions block and the security gate job**
+
+Below the `on:` block (before `jobs:`), add:
+
+```yaml
+permissions:
+  contents: read
+```
+
+As the FIRST entry under `jobs:`, add:
+
+```yaml
+  security:
+    uses: ./.github/workflows/security.yml
+    permissions:
+      contents: read
+```
+
+- [ ] **Step 3: Gate the publish jobs on security**
+
+In the `release` job, add `needs: [security]` and, in the `publish-collection` job, add `needs: [security]` (immediately under the `if:` line of each). This makes both jobs wait for and require the scans.
+
+- [ ] **Step 4: Add SBOM + attestation to the `release` (PyPI) job**
+
+In the `release` job, add `attestations: write` to its `permissions:` block (it already has `id-token: write`). After the `Build dists` step and BEFORE `Publish to pypi.org`, insert:
+
+```yaml
+      - name: Generate SBOM for dists
+        run: |
+          uvx --from cyclonedx-bom cyclonedx-py environment \
+            --output-format json --outfile dist/sbom.cdx.json || \
+          uvx cyclonedx-py environment -o dist/sbom.cdx.json
+      - name: Attest build provenance for dists
+        uses: actions/attest-build-provenance@<PIN_SHA> # v2
+        with:
+          subject-path: "dist/*.tar.gz, dist/*.whl"
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@<PIN_SHA> # v4
+        with:
+          name: sbom-dists
+          path: dist/sbom.cdx.json
+```
+
+Resolve the two `<PIN_SHA>` values with:
+```bash
+gh api repos/actions/attest-build-provenance/commits/v2 --jq .sha
+gh api repos/actions/upload-artifact/commits/v4 --jq .sha
+```
+
+- [ ] **Step 5: Add SBOM + attestation to the `publish-collection` job**
+
+Change that job's `permissions:` to:
+```yaml
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+```
+After the `Build the collection` step and BEFORE `Publish the collection on Galaxy`, insert:
+
+```yaml
+      - name: Generate SBOM for collection
+        run: |
+          uvx --from cyclonedx-bom cyclonedx-py requirements \
+            community.molecule/requirements.txt \
+            -o community.molecule-sbom.cdx.json || true
+      - name: Attest collection tarball provenance
+        uses: actions/attest-build-provenance@<PIN_SHA> # v2
+        with:
+          subject-path: "./community.molecule-*.tar.gz"
+      - name: Upload collection SBOM artifact
+        uses: actions/upload-artifact@<PIN_SHA> # v4
+        with:
+          name: sbom-collection
+          path: community.molecule-sbom.cdx.json
+```
+Use the same resolved SHAs as Step 4.
+
+- [ ] **Step 6: Lint the edited workflow**
+
+Run:
+```bash
+uvx zizmor --config .config/security/zizmor.yml .github/workflows/release.yml
+prek run actionlint --files .github/workflows/release.yml || uvx actionlint .github/workflows/release.yml
+```
+Expected: actionlint clean; zizmor 0 findings for release.yml (the `@main` upstream rule doesn't apply here since release.yml uses pinned/local refs). Fix any real findings inline.
+
+- [ ] **Step 7: Verify SBOM generation works locally**
+
+Run:
+```bash
+uvx cyclonedx-py requirements community.molecule/requirements.txt -o /tmp/coll-sbom.cdx.json && python3 -c "import json;d=json.load(open('/tmp/coll-sbom.cdx.json'));print('sbom components:',len(d.get('components',[])))"
+```
+Expected: prints a component count (>=1). If the `cyclonedx-py` subcommand differs by version, adjust the command in the workflow to match and re-verify.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci(release): gate on security scans, add SBOM + provenance attestation"
+```
+
+---
+
+## Task 4: Speed — path filters for heavy jobs
+
+**Files:**
+- Modify: `.github/workflows/security.yml`
+
+**Interfaces:**
+- Consumes: the `security.yml` from Task 2.
+- Produces: `deps` and `sast` jobs that are skipped on docs-only changes; `secrets` and `hardening` always run.
+
+- [ ] **Step 1: Add a change-detection gate job**
+
+At the top of `jobs:` in `security.yml`, add:
+
+```yaml
+  changes:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: dorny/paths-filter@<PIN_SHA> # v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'src/**'
+              - 'community.molecule/**'
+              - 'uv.lock'
+              - 'pyproject.toml'
+              - '.github/workflows/**'
+              - '.config/security/**'
+```
+Resolve the SHA: `gh api repos/dorny/paths-filter/commits/v3 --jq .sha`.
+
+- [ ] **Step 2: Gate deps and sast on code changes**
+
+Add to both the `deps` and `sast` jobs:
+```yaml
+    needs: [changes]
+    if: ${{ needs.changes.outputs.code == 'true' || github.event_name != 'pull_request' }}
+```
+(On non-PR events — push, schedule, workflow_call from release — they always run.)
+
+- [ ] **Step 3: Lint and self-check**
+
+Run:
+```bash
+prek run actionlint --files .github/workflows/security.yml || uvx actionlint .github/workflows/security.yml
+uvx zizmor --config .config/security/zizmor.yml .github/workflows/security.yml
+```
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/security.yml
+git commit -m "ci(security): skip deps/sast scans on docs-only PRs"
+```
+
+---
+
+## Task 5: Documentation
+
+**Files:**
+- Create: `.config/security/README.md`
+
+**Interfaces:**
+- Consumes: nothing at runtime.
+- Produces: contributor-facing docs for the allowlist/ignore workflow.
+
+- [ ] **Step 1: Write the README**
+
+`.config/security/README.md`:
+
+```markdown
+# Security scanning config
+
+The `security` GitHub Actions workflow runs four scanners on every PR and push,
+and gates releases. All findings fail the build. When a finding is a confirmed
+false positive or an unfixable upstream issue, add an allowlist entry HERE with
+a justification — never disable the scanner.
+
+| Scanner | Tool | Allowlist file |
+|---------|------|----------------|
+| Dependencies | pip-audit | `pip-audit-ignore.txt` (one CVE/GHSA id + reason per line) |
+| SAST | bandit | `bandit.yaml` (`skips:`) or inline `# nosec: <reason>` |
+| Secrets | gitleaks | `gitleaks.toml` (`[allowlist]`) |
+| Actions hardening | zizmor | `zizmor.yml` (`rules.*.ignore`) |
+
+Every allowlist entry MUST include why it is safe and, where relevant, a
+review-by date. Prefer fixing the code/dependency over allowlisting.
+
+Run locally before pushing:
+
+    uv export --frozen --no-emit-project --no-dev -o /tmp/reqs.txt
+    uvx pip-audit -r /tmp/reqs.txt --strict
+    uvx bandit -c .config/security/bandit.yaml -r src -ll
+    uvx zizmor --config .config/security/zizmor.yml .github/workflows
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .config/security/README.md
+git commit -m "docs(security): document scanner allowlist workflow"
+```
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** dependency scanning → Task 2 `deps`; SAST → Task 2 `sast`; secrets → Task 2 `secrets`; Actions hardening → Task 2 `hardening`; SBOM + signing → Task 3 (SBOM + attest-build-provenance); fail-on-any-with-allowlist → Task 1 configs + `--strict`/`-ll`; hard release gate → Task 3 `needs: [security]`; speed (parallel) → Task 2 independent jobs; speed (path filters) → Task 4; verify locally → verification steps in Tasks 2/3.
+- **Placeholders:** `<PIN_SHA>` markers are intentional and each has an adjacent `gh api … --jq .sha` command to resolve them; not free-text TODOs.
+- **Type/name consistency:** workflow name `security`; job ids `changes`/`deps`/`sast`/`secrets`/`hardening` used consistently across Tasks 2–4; config paths identical everywhere.
+```

--- a/docs/superpowers/specs/2026-08-01-devsecops-cicd-hardening-design.md
+++ b/docs/superpowers/specs/2026-08-01-devsecops-cicd-hardening-design.md
@@ -1,0 +1,136 @@
+# DevSecOps CI/CD Hardening — Design
+
+Date: 2026-08-01
+Repo: `ansible-community/molecule` (this workspace)
+Status: Approved design → implementation
+
+## Goal
+
+Improve the existing CI/CD pipelines to meet DevSecOps best practices and
+repository policies so that:
+
+1. Published packages (the PyPI sdist/wheel and the `community.molecule`
+   Ansible collection tarball) have **no known security issues**.
+2. The pipelines run **faster** (no serial security overhead; skip heavy jobs
+   when irrelevant).
+
+## Current state (as-is)
+
+- `.github/workflows/`:
+  - `tox.yml` → calls `ansible/team-devtools/.github/workflows/tox.yml@main`
+    (8 coverage jobs + `collection` + `eco` across a Python matrix). Has
+    `concurrency` + `cancel-in-progress`.
+  - `release.yml` → builds dists via `tox -e pkg`, publishes to PyPI via
+    trusted publishing (OIDC, `id-token: write`), builds & publishes the
+    `community.molecule` collection to Galaxy, posts a forum announcement.
+  - `push.yml`, `ack.yml`, `finalize.yml`, `redirects.yml` → thin wrappers
+    around `team-devtools` reusable workflows.
+- `.pre-commit-config.yaml`: has `detect-private-key`, `actionlint`, `ruff`,
+  `mypy`, `pylint`, `codespell`, `yamllint`, `uv-lock`. Good linting baseline.
+- Package manager: `uv` (lockfile `uv.lock`). `tox -e pkg` builds dists.
+- **No security scanning exists**: no dependency CVE scan, no SAST, no secret
+  scanning gate in CI, no GitHub Actions hardening audit, no SBOM, no artifact
+  provenance/attestation.
+
+## Decisions (from brainstorming)
+
+- **Scope:** Local workflows only. Do **not** fork/vendor the `team-devtools`
+  reusable workflows. Add new local workflow(s) and edit `release.yml`.
+- **Controls:** dependency scanning, SAST, supply-chain (SBOM + signing),
+  secret + workflow hardening — all four.
+- **Speed:** caching, path filters/conditional jobs, parallelism tuning, and
+  security jobs run in parallel with existing tests.
+- **Gating:** fail on any finding, **with** an auditable, version-controlled
+  ignore/allowlist (justification required) so the pipeline is not permanently
+  red on genuinely unfixable upstream transitive CVEs.
+- **SAST tool:** Bandit only (no CodeQL / no GHAS dependency).
+- **Release gate:** hard gate — `release.yml` runs the security scans first and
+  refuses to publish to PyPI/Galaxy if any scan fails.
+
+## Architecture
+
+### 1. New workflow: `.github/workflows/security.yml`
+
+Triggers: `pull_request`, `push` (main), `schedule` (weekly full scan),
+`workflow_dispatch`, and `workflow_call` (so `release.yml` can gate on it).
+
+`concurrency` group + `cancel-in-progress` (mirrors `tox.yml`).
+
+Top-level `permissions: contents: read` (least privilege); jobs that upload
+SARIF add `security-events: write` only where needed.
+
+Independent parallel jobs (each pins actions to commit SHAs):
+
+| Job | Tool | Runs on | Behavior |
+|-----|------|---------|----------|
+| `deps` | `pip-audit` (via `uvx`) against `uv.lock` and the collection requirements | code/lock changes | Fail on any vuln; ignores read from `.config/security/pip-audit-ignore.txt` |
+| `sast` | `bandit` (via `uvx`) recursive over `src/` | code changes | Fail on any finding at/above configured severity; config `.config/security/bandit.yaml`; per-line `# nosec: <reason>` allowed |
+| `secrets` | `gitleaks` | PR: diff scan; schedule/push: full history | Fail on any leak; allowlist `.config/security/gitleaks.toml` |
+| `hardening` | `zizmor` (via `uvx`) over `.github/workflows/` | workflow changes | Fail on any finding; config `.config/security/zizmor.yml` |
+
+Path filters: docs-only changes (`docs/**`, `*.md`, `mkdocs.yml`) do not
+trigger `deps`/`sast`; `secrets`/`hardening` still run (cheap). This is the
+"skip heavy jobs" speedup.
+
+### 2. Supply-chain: SBOM + attestation in `release.yml` (edits)
+
+- Add a `security` gate: `release.yml` calls `./.github/workflows/security.yml`
+  via `workflow_call`; both `release` and `publish-collection` gain
+  `needs: [security]` so nothing publishes on a red scan.
+- In the `release` job (PyPI): after `tox -e pkg`, generate a CycloneDX SBOM for
+  the built dists and run `actions/attest-build-provenance` on the sdist+wheel
+  (uses existing `id-token: write`). Attach SBOM to the release.
+- In `publish-collection`: after `ansible-galaxy collection build`, generate a
+  CycloneDX SBOM from the collection's Python requirements and attest the
+  tarball. Attach SBOM to the release.
+
+### 3. Speed
+
+- Security jobs are short and fully parallel → negligible addition to the tox
+  critical path.
+- Path filters skip `deps`/`sast` on docs-only PRs.
+- `fail-fast` semantics: each job fails independently and early.
+- `uvx` tool runs are cached via `astral-sh/setup-uv` cache; `gitleaks`/`zizmor`
+  pinned-action installs are cached by their actions.
+- We intentionally do **not** touch the upstream 8-coverage-job tox fan-out
+  (out of scope: local-only). Path filters ensure security does not pile onto
+  it.
+
+### 4. Config surface: `.config/security/`
+
+- `pip-audit-ignore.txt` — one CVE/GHSA id per line + `# reason (expiry)`.
+- `bandit.yaml` — bandit config (severity/confidence thresholds, excludes).
+- `gitleaks.toml` — gitleaks allowlist (regexes/paths + reason).
+- `zizmor.yml` — zizmor config (ignored rules + reason).
+
+Empty/minimal to start; entries added only for verified false positives or
+genuinely unfixable upstream issues, each with a justification.
+
+## Verification (local, before finalize)
+
+Run each scanner locally via `uvx`/pinned binaries and make the repo pass:
+
+- `uvx pip-audit -r <exported reqs>` / against `uv.lock`
+- `uvx bandit -c .config/security/bandit.yaml -r src`
+- `gitleaks detect --no-banner` (or `uvx`-equivalent) on the working tree
+- `uvx zizmor .github/workflows`
+- `uvx cyclonedx-py` (or `cyclonedx-bom`) SBOM generation smoke test
+- `actionlint` on the new/edited workflows
+
+Fix real findings in code/config; record allowlist entries (with reasons) for
+any confirmed unfixable transitive CVEs so CI lands green.
+
+## Deliverables
+
+- `.github/workflows/security.yml` (new)
+- `.github/workflows/release.yml` (edited: security gate, SBOM, attestation)
+- `.config/security/{pip-audit-ignore.txt,bandit.yaml,gitleaks.toml,zizmor.yml}`
+- This design doc.
+
+## Non-goals
+
+- Forking/modifying `team-devtools` reusable workflows.
+- CodeQL / GitHub Advanced Security.
+- Changing the upstream tox coverage-job fan-out.
+- Container image scanning of Molecule's test-target images (Molecule drives
+  user-supplied images at test time; not a published artifact).


### PR DESCRIPTION
  ## What & why
  Adds security scanning and supply-chain hardening to CI/CD so published
  packages have no known security issues, and speeds up the pipeline. Local
  workflows only — the upstream `ansible/team-devtools` reusable workflows are
  not forked.

  ## Changes
  - **New `security.yml`** — parallel jobs: `deps` (pip-audit `--strict`),
    `sast` (bandit), `secrets` (MIT gitleaks CLI, pinned + SHA256-verified),
    `hardening` (zizmor). All actions SHA-pinned, least-privilege permissions.
  - **`release.yml`** — hard security gate (`needs: [security]` on both publish
    jobs); CycloneDX SBOM + `actions/attest-build-provenance` for the PyPI dists
    and the collection tarball; fixed a `forum_post` template-injection.
  - **`redirects.yml`** — pinned actions, least-privilege permissions.
  - **`.config/security/`** — scanner configs with auditable, justified
    allowlists + contributor README.
  - **Speed** — `deps`/`sast` skip on docs-only PRs; scans run in parallel.

  ## What & why
  Adds security scanning and supply-chain hardening to CI/CD so published
  packages have no known security issues, and speeds up the pipeline. Local
  workflows only — the upstream `ansible/team-devtools` reusable workflows are
  not forked.

  ## Changes
  - **New `security.yml`** — parallel jobs: `deps` (pip-audit `--strict`),
    `sast` (bandit), `secrets` (MIT gitleaks CLI, pinned + SHA256-verified),
    `hardening` (zizmor). All actions SHA-pinned, least-privilege permissions.
  - **`release.yml`** — hard security gate (`needs: [security]` on both publish
    jobs); CycloneDX SBOM + `actions/attest-build-provenance` for the PyPI dists
    and the collection tarball; fixed a `forum_post` template-injection.
  - **`redirects.yml`** — pinned actions, least-privilege permissions.
  - **`.config/security/`** — scanner configs with auditable, justified
    allowlists + contributor README.
  - **Speed** — `deps`/`sast` skip on docs-only PRs; scans run in parallel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated security checks for dependencies, source code, secrets, and GitHub Actions workflows.
  - Added release safeguards, including software bills of materials (SBOMs) and build-provenance attestations.
  - Restricted workflow permissions and pinned actions to improve release integrity.

- **Documentation**
  - Added guidance for security scanning, local verification, approved exceptions, and CI/CD hardening.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->